### PR TITLE
Introduce `node-modules` config to override node module resolution

### DIFF
--- a/packages/compiler/src/config/config-interpolation.ts
+++ b/packages/compiler/src/config/config-interpolation.ts
@@ -39,8 +39,13 @@ export function expandConfigVariables(
   const outputDir = diagnostics.pipe(
     resolveValue(expandOptions.outputDir ?? config.outputDir, commonVars),
   );
+  const nodeModules: string[] = config.nodeModules.map(nodeModuleDir => {
+    return diagnostics.pipe(
+      resolveValue(nodeModuleDir, commonVars),
+    )
+  });
 
-  const result = { ...config, outputDir };
+  const result = { ...config, outputDir, nodeModules };
   if (config.options) {
     const options: Record<string, EmitterOptions> = {};
     for (const [name, emitterOptions] of Object.entries(config.options)) {

--- a/packages/compiler/src/config/config-loader.ts
+++ b/packages/compiler/src/config/config-loader.ts
@@ -16,6 +16,7 @@ export const TypeSpecConfigFilename = "tspconfig.yaml";
 export const defaultConfig = deepFreeze({
   outputDir: "{cwd}/tsp-output",
   diagnostics: [] as Diagnostic[],
+  nodeModules: [] as string[],
 });
 
 /**
@@ -222,6 +223,7 @@ async function loadConfigFile(
     trace: typeof data.trace === "string" ? [data.trace] : data.trace,
     emit,
     options,
+    nodeModules: data["node-modules"],
     linter: data.linter,
   });
 }
@@ -245,6 +247,9 @@ export function validateConfigPathsAbsolute(config: TypeSpecConfig): readonly Di
   checkPath(config.outputDir, ["output-dir"]);
   for (const [emitterName, emitterOptions] of Object.entries(config.options ?? {})) {
     checkPath(emitterOptions["emitter-output-dir"], ["options", emitterName, "emitter-output-dir"]);
+  }
+  for (const nodeModulesDir of config.nodeModules ?? []) {
+    checkPath(nodeModulesDir, ["node-modules"]);
   }
   return diagnostics;
 }

--- a/packages/compiler/src/config/config-schema.ts
+++ b/packages/compiler/src/config/config-schema.ts
@@ -85,7 +85,11 @@ export const TypeSpecConfigJsonSchema: JSONSchemaType<TypeSpecRawConfig> = {
         oneOf: [{ type: "boolean" }, emitterOptionsSchema],
       },
     },
-
+    "node-modules": {
+      type: "array",
+      nullable: true,
+      items: { type: "string" },
+    },
     linter: {
       type: "object",
       nullable: true,

--- a/packages/compiler/src/config/config-to-options.ts
+++ b/packages/compiler/src/config/config-to-options.ts
@@ -97,6 +97,7 @@ export function resolveOptionsFromConfig(config: TypeSpecConfig, options: Config
     outputDir: expandedConfig.outputDir,
     config: config.filename,
     configFile: config,
+    nodeModules: expandedConfig.nodeModules,
     additionalImports: expandedConfig["imports"],
     warningAsError: expandedConfig.warnAsError,
     trace: expandedConfig.trace,

--- a/packages/compiler/src/config/types.ts
+++ b/packages/compiler/src/config/types.ts
@@ -68,6 +68,11 @@ export interface TypeSpecConfig {
    */
   options?: Record<string, EmitterOptions>;
 
+  /**
+   * Additional paths that should be preferred in the node module resolution (order matters).
+   */
+  nodeModules: string[];
+
   linter?: LinterConfig;
 }
 
@@ -88,6 +93,7 @@ export interface TypeSpecRawConfig {
   options?: Record<string, EmitterOptions>;
   emitters?: Record<string, boolean | EmitterOptions>;
 
+  "node-modules"?: string[];
   linter?: LinterConfig;
 }
 

--- a/packages/compiler/src/core/cli/actions/compile/args.ts
+++ b/packages/compiler/src/core/cli/actions/compile/args.ts
@@ -21,6 +21,7 @@ export interface CompileCliArgs {
   "warn-as-error"?: boolean;
   "no-emit"?: boolean;
   "ignore-deprecated"?: boolean;
+  "node-modules"?: string[];
   args?: string[];
 }
 
@@ -55,6 +56,7 @@ export async function getCompilerOptions(
         trace: args.trace,
         emit: args.emit,
         options: cliOptions.options,
+        nodeModules: args["node-modules"],
       }),
     }),
   );

--- a/packages/compiler/src/core/cli/cli.ts
+++ b/packages/compiler/src/core/cli/cli.ts
@@ -121,6 +121,11 @@ async function main() {
             default: false,
             describe: "Suppresses all `deprecated` diagnostics.",
           })
+          .option("node-modules", {
+            type: "array",
+            string: true,
+            describe: "Additional paths that should be preferred in the node module resolution.",
+          })
           .option("arg", {
             type: "array",
             alias: "args",

--- a/packages/compiler/src/core/options.ts
+++ b/packages/compiler/src/core/options.ts
@@ -43,6 +43,8 @@ export interface CompilerOptions {
    */
   ignoreDeprecated?: boolean;
 
+  nodeModules?: string[];
+
   nostdlib?: boolean;
   noEmit?: boolean;
   additionalImports?: string[];

--- a/packages/compiler/src/core/program.ts
+++ b/packages/compiler/src/core/program.ts
@@ -315,6 +315,8 @@ export async function compile(
   async function loadSources(entrypoint: string) {
     const sourceLoader = await createSourceLoader(host, {
       parseOptions: options.parseOptions,
+      nodeModules: options.nodeModules,
+      tracer,
       getCachedScript: (file) =>
         oldProgram?.sourceFiles.get(file.path) ?? host.parseCache?.get(file),
     });
@@ -634,7 +636,7 @@ export async function compile(
   ): Promise<[ModuleResolutionResult | undefined, readonly Diagnostic[]]> {
     try {
       return [
-        await resolveModule(getResolveModuleHost(), specifier, { baseDir, conditions: ["import"] }),
+        await resolveModule(getResolveModuleHost(), specifier, { baseDir, nodeModules: options.nodeModules, conditions: ["import"] }),
         [],
       ];
     } catch (e: any) {
@@ -676,7 +678,7 @@ export async function compile(
           },
         },
         "@typespec/compiler",
-        { baseDir },
+        { baseDir, nodeModules: options.nodeModules },
       );
       compilerAssert(
         resolved.type === "module",

--- a/packages/compiler/src/core/source-loader.ts
+++ b/packages/compiler/src/core/source-loader.ts
@@ -50,6 +50,7 @@ interface TypeSpecLibraryReference {
 export interface LoadSourceOptions {
   readonly parseOptions?: ParseOptions;
   readonly tracer?: Tracer;
+  readonly nodeModules?: string[];
   getCachedScript?: (file: SourceFile) => TypeSpecScriptNode | undefined;
 }
 
@@ -255,6 +256,7 @@ export async function createSourceLoader(
           return resolveTspMain(pkg) ?? pkg.main;
         },
         conditions: ["typespec"],
+        nodeModules: options?.nodeModules ?? [],
         fallbackOnMissingCondition: true,
       });
     } catch (e: any) {

--- a/packages/compiler/src/module-resolver/module-resolver.ts
+++ b/packages/compiler/src/module-resolver/module-resolver.ts
@@ -29,6 +29,11 @@ export interface ResolveModuleOptions {
   readonly conditions?: string[];
 
   /**
+   * Search these node_modules paths before the default module resolution.
+   */
+  readonly nodeModules?: string[];
+
+  /**
    * If exports is defined ignore if the none of the given condition is found and fallback to using main field resolution.
    * By default it will throw an error.
    */
@@ -127,7 +132,7 @@ export async function resolveModule(
   }
 
   // Try to resolve as a node_module package.
-  const module = await resolveAsNodeModule(specifier, absoluteStart);
+  const module = await resolveAsNodeModule(specifier, absoluteStart, options.nodeModules);
   if (module) return module;
 
   throw new ResolveModuleError(
@@ -171,10 +176,11 @@ export async function resolveModule(
   async function resolveAsNodeModule(
     importSpecifier: string,
     baseDir: string,
+    nodeModules?: string[],
   ): Promise<ResolvedModule | undefined> {
     const module = parseNodeModuleSpecifier(importSpecifier);
     if (module === null) return undefined;
-    const dirs = listDirHierarchy(baseDir);
+    const dirs = (nodeModules ?? []).concat(listDirHierarchy(baseDir));
 
     for (const dir of dirs) {
       const self = await resolveSelf(module, dir);

--- a/website/src/content/docs/docs/handbook/configuration/configuration.mdx
+++ b/website/src/content/docs/docs/handbook/configuration/configuration.mdx
@@ -36,6 +36,7 @@ model TypeSpecProjectSchema {
   imports?: string;
   emit?: string[];
   options?: Record<unknown>;
+  "node-modules"?: string[];
   linter?: LinterConfig;
 }
 
@@ -194,6 +195,7 @@ Due to this capability, emitter option names should not contain a `.` in their n
 | `imports`       | `--import`                | Additional imports to include                            |
 | `emit`          | `--emit`                  | Emitter configuration                                    |
 | `options`       | `--option` or `--options` | Emitter configuration                                    |
+| `node-modules`  | `--node-modules`          | Paths to prefer when resolving node modules              |
 | `linter`        |                           | Linter configuration                                     |
 
 ### `output-dir` - Configure the default output dir
@@ -320,6 +322,18 @@ Represent the path where the emitter should be outputing the generated files.
 Default: `{output-dir}/{emitter-name}`
 
 See [output directory configuration for mode details](#configuring-output-directory)
+
+### `node-modules` - Overriding module resolution
+
+This allows you to specify one or more paths that will be checked first when resolving node modules.
+
+Do not include the `node_modules` folder in the path.
+
+```yaml
+node-modules:
+  - '{project-root}/custom_modules'
+  - '{project-root}/another_modules'
+```
 
 ### `linter` - Setting Up Linters
 


### PR DESCRIPTION
This commit introduces a new config option where one or more paths can be provided that contain `node_modules` directories. When searching for a module, the resolver will prefer a module found in those paths over the default resolution order.

This is useful if you have a development copy of `@typespec` modules and you want to use those without changing the `import` statements in TSP files.

The option can either be provided in `tspconfig.yaml` or with the CLI flag `--node-modules`.

**THIS IS NOT INTENDED TO BE MERGED UPSTREAM.** This may be specific to our use case and is not well thought-out for general applicability.