### PR TITLE
Add GraphQL Emitter to playground website

### DIFF
--- a/packages/playground-website/package.json
+++ b/packages/playground-website/package.json
@@ -62,6 +62,7 @@
     "@typespec/json-schema": "workspace:^",
     "@typespec/openapi": "workspace:^",
     "@typespec/openapi3": "workspace:^",
+    "@typespec/graphql": "workspace:^",
     "@typespec/playground": "workspace:^",
     "@typespec/protobuf": "workspace:^",
     "@typespec/rest": "workspace:^",

--- a/packages/playground-website/src/config.ts
+++ b/packages/playground-website/src/config.ts
@@ -10,6 +10,7 @@ export const TypeSpecPlaygroundConfig = {
     "@typespec/versioning",
     "@typespec/openapi3",
     "@typespec/json-schema",
+    "@typespec/graphql",
     "@typespec/protobuf",
     "@typespec/streams",
     "@typespec/events",

--- a/packages/playground-website/tsconfig.json
+++ b/packages/playground-website/tsconfig.json
@@ -4,7 +4,8 @@
     { "path": "../compiler/tsconfig.json" },
     { "path": "../rest/tsconfig.json" },
     { "path": "../openapi/tsconfig.json" },
-    { "path": "../openapi3/tsconfig.json" }
+    { "path": "../openapi3/tsconfig.json" },
+    { "path": "../graphql/tsconfig.json" }
   ],
   "compilerOptions": {
     "outDir": "dist-dev",


### PR DESCRIPTION
This commit adds the GraphQL emitter as a selectable option in the TypeSpec playground.

![image](https://github.com/user-attachments/assets/5478850c-93f6-41d7-9811-cf725608c1b0)