### PR TITLE
Add multiple schema support

### DIFF
--- a/packages/graphql/package.json
+++ b/packages/graphql/package.json
@@ -56,6 +56,7 @@
   ],
   "peerDependencies": {
     "@typespec/compiler": "workspace:~",
+    "@typespec/http": "workspace:~",
     "@typespec/emitter-framework": "^0.5.0"
   },
   "devDependencies": {

--- a/packages/graphql/src/emitter.ts
+++ b/packages/graphql/src/emitter.ts
@@ -1,7 +1,7 @@
 import type { EmitContext, NewLine } from "@typespec/compiler";
 import { resolvePath } from "@typespec/compiler";
+import { createGraphQLEmitter } from "./graphql-emitter.js";
 import type { GraphQLEmitterOptions } from "./lib.js";
-import { createGraphQLEmitter } from "./schema-emitter.js";
 
 const defaultOptions = {
   "new-line": "lf",

--- a/packages/graphql/src/graphql-emitter.ts
+++ b/packages/graphql/src/graphql-emitter.ts
@@ -1,0 +1,68 @@
+import {
+  emitFile,
+  getNamespaceFullName,
+  interpolatePath,
+  type EmitContext,
+} from "@typespec/compiler";
+import { printSchema } from "graphql";
+import type { ResolvedGraphQLEmitterOptions } from "./emitter.js";
+import type { GraphQLEmitterOptions } from "./lib.js";
+import { listSchemas } from "./lib/schema.js";
+import { createSchemaEmitter } from "./schema-emitter.js";
+import type { GraphQLSchemaRecord } from "./types.js";
+
+export function createGraphQLEmitter(
+  context: EmitContext<GraphQLEmitterOptions>,
+  options: ResolvedGraphQLEmitterOptions,
+) {
+  const program = context.program;
+
+  return {
+    emitGraphQL,
+  };
+
+  async function emitGraphQL() {
+    if (!program.compilerOptions.noEmit) {
+      const schemaRecords = await getGraphQL();
+      // first, emit diagnostics
+      for (const schemaRecord of schemaRecords) {
+        program.reportDiagnostics(schemaRecord.diagnostics);
+      }
+      if (program.hasError()) {
+        return;
+      }
+      for (const schemaRecord of schemaRecords) {
+        const schemaName = getNamespaceFullName(schemaRecord.schema.type) || "schema";
+        const filePath = interpolatePath(options.outputFile, {
+          "schema-name": schemaName,
+        });
+        await emitFile(program, {
+          path: filePath,
+          content: printSchema(schemaRecord.graphQLSchema),
+          newLine: options.newLine,
+        });
+      }
+    }
+  }
+
+  async function getGraphQL(): Promise<GraphQLSchemaRecord[]> {
+    const schemaRecords: GraphQLSchemaRecord[] = [];
+    const schemas = listSchemas(program);
+    if (schemas.length === 0) {
+      schemas.push({ type: program.getGlobalNamespaceType() });
+    }
+    for (const schema of schemas) {
+      const schemaEmitter = createSchemaEmitter(schema, context, options);
+      const document = await schemaEmitter.emitSchema();
+      if (document === undefined) {
+        continue;
+      }
+      schemaRecords.push({
+        schema: schema,
+        graphQLSchema: document[0],
+        diagnostics: document[1],
+      });
+    }
+    return schemaRecords;
+  }
+}

--- a/packages/graphql/src/schema-emitter.ts
+++ b/packages/graphql/src/schema-emitter.ts
@@ -1,46 +1,88 @@
 import {
-  emitFile,
-  interpolatePath,
-  navigateProgram,
+  createDiagnosticCollector,
+  navigateTypesInNamespace,
+  type Diagnostic,
+  type DiagnosticCollector,
   type EmitContext,
   type Model,
-  type Namespace,
 } from "@typespec/compiler";
-import type { ResolvedGraphQLEmitterOptions } from "./emitter.js";
-import type { GraphQLEmitterOptions } from "./lib.js";
+import {
+  GraphQLBoolean,
+  GraphQLObjectType,
+  GraphQLSchema,
+  validateSchema,
+  type GraphQLSchemaConfig,
+} from "graphql";
+import { type GraphQLEmitterOptions } from "./lib.js";
+import type { Schema } from "./lib/schema.js";
 
-export function createGraphQLEmitter(
-  context: EmitContext<GraphQLEmitterOptions>,
-  options: ResolvedGraphQLEmitterOptions,
-) {
-  const program = context.program;
-  const placeholderSchema = `query { hello: String }`;
-
-  return {
-    emitGraphQL,
-  };
-
-  async function emitGraphQL() {
-    if (!program.compilerOptions.noEmit) {
-      const filePath = interpolatePath(options.outputFile, { "schema-name": "schema" });
-      navigateProgram(program, semanticNodeListener());
-      await emitFile(program, {
-        path: filePath,
-        content: placeholderSchema,
-        newLine: options.newLine,
-      });
-    }
+class GraphQLSchemaEmitter {
+  private tspSchema: Schema;
+  private context: EmitContext<GraphQLEmitterOptions>;
+  private options: GraphQLEmitterOptions;
+  private diagnostics: DiagnosticCollector;
+  constructor(
+    tspSchema: Schema,
+    context: EmitContext<GraphQLEmitterOptions>,
+    options: GraphQLEmitterOptions,
+  ) {
+    // Initialize any properties if needed, including the registry
+    this.tspSchema = tspSchema;
+    this.context = context;
+    this.options = options;
+    this.diagnostics = createDiagnosticCollector();
   }
 
-  function semanticNodeListener() {
+  async emitSchema(): Promise<[GraphQLSchema, Readonly<Diagnostic[]>] | undefined> {
+    const schemaNamespace = this.tspSchema.type;
+    // Logic to emit the GraphQL schema
+    navigateTypesInNamespace(schemaNamespace, this.semanticNodeListener());
+    // Replace this with the actual schema config that should be derived from the registry
+    // something like: registry.materializeSchemaConfig();
+    const schemaConfig: GraphQLSchemaConfig = {
+      query: new GraphQLObjectType({
+        name: "Query",
+        fields: {
+          _: {
+            type: GraphQLBoolean,
+            description:
+              "A placeholder field. If you are seeing this, it means no operations were defined that could be emitted.",
+          },
+        },
+      }),
+    };
+    const schema = new GraphQLSchema(schemaConfig);
+    // validate the schema
+    const validationErrors = validateSchema(schema);
+    validationErrors.forEach((error) => {
+      this.diagnostics.add({
+        message: error.message,
+        code: "GraphQLSchemaValidationError",
+        target: this.tspSchema.type,
+        severity: "error",
+      });
+    });
+    return [schema, this.diagnostics.diagnostics];
+  }
+
+  semanticNodeListener() {
     // TODO: Add GraphQL types to registry as the TSP nodes are visited
     return {
-      namespace: (namespace: Namespace) => {
-        {}
-      },
       model: (model: Model) => {
-        {}
+        {
+        }
       },
     };
   }
 }
+
+export function createSchemaEmitter(
+  schema: Schema,
+  context: EmitContext<GraphQLEmitterOptions>,
+  options: GraphQLEmitterOptions,
+): GraphQLSchemaEmitter {
+  // Placeholder for creating a GraphQL schema emitter
+  return new GraphQLSchemaEmitter(schema, context, options);
+}
+
+export type { GraphQLSchemaEmitter };

--- a/packages/graphql/src/visibility-usage.ts
+++ b/packages/graphql/src/visibility-usage.ts
@@ -1,0 +1,26 @@
+import type { Namespace, Program, Type } from "@typespec/compiler";
+import type { Visibility } from "@typespec/http";
+
+export interface VisibilityUsageTracker {
+  // This Visibility might change to be GraphQL specific
+  getUsage(type: Type): Set<Visibility> | undefined;
+  isUnreachable(type: Type): boolean;
+}
+
+export function resolveVisibilityUsage(
+  program: Program,
+  root: Namespace,
+  omitUnreachableTypes: boolean,
+): VisibilityUsageTracker {
+  // Track usages and return visibility tracker
+  return {
+    getUsage: (type: Type) => {
+      // Placeholder for actual implementation
+      return new Set<Visibility>();
+    },
+    isUnreachable: (type: Type) => {
+      // Placeholder for actual implementation
+      return false;
+    },
+  };
+}

--- a/packages/graphql/test/emitter.test.ts
+++ b/packages/graphql/test/emitter.test.ts
@@ -4,7 +4,12 @@ import { emitSingleSchema } from "./test-host.js";
 
 // For now, the expected output is a placeholder string.
 // In the future, this should be replaced with the actual GraphQL schema output.
-const expectedGraphQLSchema = `query { hello: String }`;
+const expectedGraphQLSchema = `type Query {
+  """
+  A placeholder field. If you are seeing this, it means no operations were defined that could be emitted.
+  """
+  _: Boolean
+}`;
 
 describe("name", () => {
   it("Emits a schema.graphql file with placeholder text", async () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -543,25 +543,28 @@ importers:
 
   packages/graphql:
     dependencies:
-      graphql:
-        specifier: ^16.9.0
-        version: 16.10.0
-    devDependencies:
       '@alloy-js/core':
         specifier: ^0.11.0
         version: 0.11.0
       '@alloy-js/typescript':
         specifier: ^0.11.0
         version: 0.11.0
-      '@types/node':
-        specifier: ~22.13.13
-        version: 22.13.13
       '@typespec/compiler':
         specifier: workspace:~
         version: link:../compiler
       '@typespec/emitter-framework':
         specifier: ^0.5.0
-        version: 0.5.0(@alloy-js/core@0.11.0)(@alloy-js/typescript@0.11.0)(@typespec/compiler@packages+compiler)(@typespec/http@1.0.0-rc.1(@typespec/compiler@packages+compiler)(@typespec/streams@0.69.0(@typespec/compiler@packages+compiler)))(@typespec/rest@0.69.0(@typespec/compiler@packages+compiler)(@typespec/http@1.0.0-rc.1(@typespec/compiler@packages+compiler)(@typespec/streams@0.69.0(@typespec/compiler@packages+compiler))))
+        version: 0.5.0(@alloy-js/core@0.11.0)(@alloy-js/typescript@0.11.0)(@typespec/compiler@packages+compiler)(@typespec/http@packages+http)(@typespec/rest@0.69.0(@typespec/compiler@packages+compiler)(@typespec/http@packages+http))
+      '@typespec/http':
+        specifier: workspace:~
+        version: link:../http
+      graphql:
+        specifier: ^16.9.0
+        version: 16.10.0
+    devDependencies:
+      '@types/node':
+        specifier: ~22.13.13
+        version: 22.13.13
       rimraf:
         specifier: ~6.0.1
         version: 6.0.1
@@ -3826,152 +3829,102 @@ packages:
   '@esbuild/aix-ppc64@0.25.1':
     resolution: {integrity: sha512-kfYGy8IdzTGy+z0vFGvExZtxkFlA4zAxgKEahG9KE1ScBjpQnFsNOX8KTU5ojNru5ed5CVoJYXFtoxaq5nFbjQ==}
     engines: {node: '>=18'}
-    cpu: [ppc64]
-    os: [aix]
 
   '@esbuild/android-arm64@0.25.1':
     resolution: {integrity: sha512-50tM0zCJW5kGqgG7fQ7IHvQOcAn9TKiVRuQ/lN0xR+T2lzEFvAi1ZcS8DiksFcEpf1t/GYOeOfCAgDHFpkiSmA==}
     engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [android]
 
   '@esbuild/android-arm@0.25.1':
     resolution: {integrity: sha512-dp+MshLYux6j/JjdqVLnMglQlFu+MuVeNrmT5nk6q07wNhCdSnB7QZj+7G8VMUGh1q+vj2Bq8kRsuyA00I/k+Q==}
     engines: {node: '>=18'}
-    cpu: [arm]
-    os: [android]
 
   '@esbuild/android-x64@0.25.1':
     resolution: {integrity: sha512-GCj6WfUtNldqUzYkN/ITtlhwQqGWu9S45vUXs7EIYf+7rCiiqH9bCloatO9VhxsL0Pji+PF4Lz2XXCES+Q8hDw==}
     engines: {node: '>=18'}
-    cpu: [x64]
-    os: [android]
 
   '@esbuild/darwin-arm64@0.25.1':
     resolution: {integrity: sha512-5hEZKPf+nQjYoSr/elb62U19/l1mZDdqidGfmFutVUjjUZrOazAtwK+Kr+3y0C/oeJfLlxo9fXb1w7L+P7E4FQ==}
     engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [darwin]
 
   '@esbuild/darwin-x64@0.25.1':
     resolution: {integrity: sha512-hxVnwL2Dqs3fM1IWq8Iezh0cX7ZGdVhbTfnOy5uURtao5OIVCEyj9xIzemDi7sRvKsuSdtCAhMKarxqtlyVyfA==}
     engines: {node: '>=18'}
-    cpu: [x64]
-    os: [darwin]
 
   '@esbuild/freebsd-arm64@0.25.1':
     resolution: {integrity: sha512-1MrCZs0fZa2g8E+FUo2ipw6jw5qqQiH+tERoS5fAfKnRx6NXH31tXBKI3VpmLijLH6yriMZsxJtaXUyFt/8Y4A==}
     engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [freebsd]
 
   '@esbuild/freebsd-x64@0.25.1':
     resolution: {integrity: sha512-0IZWLiTyz7nm0xuIs0q1Y3QWJC52R8aSXxe40VUxm6BB1RNmkODtW6LHvWRrGiICulcX7ZvyH6h5fqdLu4gkww==}
     engines: {node: '>=18'}
-    cpu: [x64]
-    os: [freebsd]
 
   '@esbuild/linux-arm64@0.25.1':
     resolution: {integrity: sha512-jaN3dHi0/DDPelk0nLcXRm1q7DNJpjXy7yWaWvbfkPvI+7XNSc/lDOnCLN7gzsyzgu6qSAmgSvP9oXAhP973uQ==}
     engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [linux]
 
   '@esbuild/linux-arm@0.25.1':
     resolution: {integrity: sha512-NdKOhS4u7JhDKw9G3cY6sWqFcnLITn6SqivVArbzIaf3cemShqfLGHYMx8Xlm/lBit3/5d7kXvriTUGa5YViuQ==}
     engines: {node: '>=18'}
-    cpu: [arm]
-    os: [linux]
 
   '@esbuild/linux-ia32@0.25.1':
     resolution: {integrity: sha512-OJykPaF4v8JidKNGz8c/q1lBO44sQNUQtq1KktJXdBLn1hPod5rE/Hko5ugKKZd+D2+o1a9MFGUEIUwO2YfgkQ==}
     engines: {node: '>=18'}
-    cpu: [ia32]
-    os: [linux]
 
   '@esbuild/linux-loong64@0.25.1':
     resolution: {integrity: sha512-nGfornQj4dzcq5Vp835oM/o21UMlXzn79KobKlcs3Wz9smwiifknLy4xDCLUU0BWp7b/houtdrgUz7nOGnfIYg==}
     engines: {node: '>=18'}
-    cpu: [loong64]
-    os: [linux]
 
   '@esbuild/linux-mips64el@0.25.1':
     resolution: {integrity: sha512-1osBbPEFYwIE5IVB/0g2X6i1qInZa1aIoj1TdL4AaAb55xIIgbg8Doq6a5BzYWgr+tEcDzYH67XVnTmUzL+nXg==}
     engines: {node: '>=18'}
-    cpu: [mips64el]
-    os: [linux]
 
   '@esbuild/linux-ppc64@0.25.1':
     resolution: {integrity: sha512-/6VBJOwUf3TdTvJZ82qF3tbLuWsscd7/1w+D9LH0W/SqUgM5/JJD0lrJ1fVIfZsqB6RFmLCe0Xz3fmZc3WtyVg==}
     engines: {node: '>=18'}
-    cpu: [ppc64]
-    os: [linux]
 
   '@esbuild/linux-riscv64@0.25.1':
     resolution: {integrity: sha512-nSut/Mx5gnilhcq2yIMLMe3Wl4FK5wx/o0QuuCLMtmJn+WeWYoEGDN1ipcN72g1WHsnIbxGXd4i/MF0gTcuAjQ==}
     engines: {node: '>=18'}
-    cpu: [riscv64]
-    os: [linux]
 
   '@esbuild/linux-s390x@0.25.1':
     resolution: {integrity: sha512-cEECeLlJNfT8kZHqLarDBQso9a27o2Zd2AQ8USAEoGtejOrCYHNtKP8XQhMDJMtthdF4GBmjR2au3x1udADQQQ==}
     engines: {node: '>=18'}
-    cpu: [s390x]
-    os: [linux]
 
   '@esbuild/linux-x64@0.25.1':
     resolution: {integrity: sha512-xbfUhu/gnvSEg+EGovRc+kjBAkrvtk38RlerAzQxvMzlB4fXpCFCeUAYzJvrnhFtdeyVCDANSjJvOvGYoeKzFA==}
     engines: {node: '>=18'}
-    cpu: [x64]
-    os: [linux]
 
   '@esbuild/netbsd-arm64@0.25.1':
     resolution: {integrity: sha512-O96poM2XGhLtpTh+s4+nP7YCCAfb4tJNRVZHfIE7dgmax+yMP2WgMd2OecBuaATHKTHsLWHQeuaxMRnCsH8+5g==}
     engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [netbsd]
 
   '@esbuild/netbsd-x64@0.25.1':
     resolution: {integrity: sha512-X53z6uXip6KFXBQ+Krbx25XHV/NCbzryM6ehOAeAil7X7oa4XIq+394PWGnwaSQ2WRA0KI6PUO6hTO5zeF5ijA==}
     engines: {node: '>=18'}
-    cpu: [x64]
-    os: [netbsd]
 
   '@esbuild/openbsd-arm64@0.25.1':
     resolution: {integrity: sha512-Na9T3szbXezdzM/Kfs3GcRQNjHzM6GzFBeU1/6IV/npKP5ORtp9zbQjvkDJ47s6BCgaAZnnnu/cY1x342+MvZg==}
     engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [openbsd]
 
   '@esbuild/openbsd-x64@0.25.1':
     resolution: {integrity: sha512-T3H78X2h1tszfRSf+txbt5aOp/e7TAz3ptVKu9Oyir3IAOFPGV6O9c2naym5TOriy1l0nNf6a4X5UXRZSGX/dw==}
     engines: {node: '>=18'}
-    cpu: [x64]
-    os: [openbsd]
 
   '@esbuild/sunos-x64@0.25.1':
     resolution: {integrity: sha512-2H3RUvcmULO7dIE5EWJH8eubZAI4xw54H1ilJnRNZdeo8dTADEZ21w6J22XBkXqGJbe0+wnNJtw3UXRoLJnFEg==}
     engines: {node: '>=18'}
-    cpu: [x64]
-    os: [sunos]
 
   '@esbuild/win32-arm64@0.25.1':
     resolution: {integrity: sha512-GE7XvrdOzrb+yVKB9KsRMq+7a2U/K5Cf/8grVFRAGJmfADr/e/ODQ134RK2/eeHqYV5eQRFxb1hY7Nr15fv1NQ==}
     engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [win32]
 
   '@esbuild/win32-ia32@0.25.1':
     resolution: {integrity: sha512-uOxSJCIcavSiT6UnBhBzE8wy3n0hOkJsBOzy7HDAuTDE++1DJMRRVCPGisULScHL+a/ZwdXPpXD3IyFKjA7K8A==}
     engines: {node: '>=18'}
-    cpu: [ia32]
-    os: [win32]
 
   '@esbuild/win32-x64@0.25.1':
     resolution: {integrity: sha512-Y1EQdcfwMSeQN/ujR5VayLOJ1BHaK+ssyk0AEzPjC+t1lITgsnccPqFjb6V+LsTp/9Iov4ysfjxLaGJ9RPtkVg==}
     engines: {node: '>=18'}
-    cpu: [x64]
-    os: [win32]
 
   '@esfx/async-canceltoken@1.0.0':
     resolution: {integrity: sha512-3Ps/4NPd7qFltmHL+CYXCjZtNXcQGV9BZmpzu8Rt3/0SZMtbQve0gtX0uJDJGvAWa6w3IB4HrKVP12VPoFONmA==}
@@ -4608,107 +4561,70 @@ packages:
   '@img/sharp-darwin-arm64@0.33.5':
     resolution: {integrity: sha512-UT4p+iz/2H4twwAoLCqfA9UH5pI6DggwKEGuaPy7nCVQ8ZsiY5PIcrRvD1DzuY3qYL07NtIQcWnBSY/heikIFQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [arm64]
-    os: [darwin]
 
   '@img/sharp-darwin-x64@0.33.5':
     resolution: {integrity: sha512-fyHac4jIc1ANYGRDxtiqelIbdWkIuQaI84Mv45KvGRRxSAa7o7d1ZKAOBaYbnepLC1WqxfpimdeWfvqqSGwR2Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [x64]
-    os: [darwin]
 
   '@img/sharp-libvips-darwin-arm64@1.0.4':
     resolution: {integrity: sha512-XblONe153h0O2zuFfTAbQYAX2JhYmDHeWikp1LM9Hul9gVPjFY427k6dFEcOL72O01QxQsWi761svJ/ev9xEDg==}
-    cpu: [arm64]
-    os: [darwin]
 
   '@img/sharp-libvips-darwin-x64@1.0.4':
     resolution: {integrity: sha512-xnGR8YuZYfJGmWPvmlunFaWJsb9T/AO2ykoP3Fz/0X5XV2aoYBPkX6xqCQvUTKKiLddarLaxpzNe+b1hjeWHAQ==}
-    cpu: [x64]
-    os: [darwin]
 
   '@img/sharp-libvips-linux-arm64@1.0.4':
     resolution: {integrity: sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA==}
-    cpu: [arm64]
-    os: [linux]
 
   '@img/sharp-libvips-linux-arm@1.0.5':
     resolution: {integrity: sha512-gvcC4ACAOPRNATg/ov8/MnbxFDJqf/pDePbBnuBDcjsI8PssmjoKMAz4LtLaVi+OnSb5FK/yIOamqDwGmXW32g==}
-    cpu: [arm]
-    os: [linux]
 
   '@img/sharp-libvips-linux-s390x@1.0.4':
     resolution: {integrity: sha512-u7Wz6ntiSSgGSGcjZ55im6uvTrOxSIS8/dgoVMoiGE9I6JAfU50yH5BoDlYA1tcuGS7g/QNtetJnxA6QEsCVTA==}
-    cpu: [s390x]
-    os: [linux]
 
   '@img/sharp-libvips-linux-x64@1.0.4':
     resolution: {integrity: sha512-MmWmQ3iPFZr0Iev+BAgVMb3ZyC4KeFc3jFxnNbEPas60e1cIfevbtuyf9nDGIzOaW9PdnDciJm+wFFaTlj5xYw==}
-    cpu: [x64]
-    os: [linux]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.0.4':
     resolution: {integrity: sha512-9Ti+BbTYDcsbp4wfYib8Ctm1ilkugkA/uscUn6UXK1ldpC1JjiXbLfFZtRlBhjPZ5o1NCLiDbg8fhUPKStHoTA==}
-    cpu: [arm64]
-    os: [linux]
 
   '@img/sharp-libvips-linuxmusl-x64@1.0.4':
     resolution: {integrity: sha512-viYN1KX9m+/hGkJtvYYp+CCLgnJXwiQB39damAO7WMdKWlIhmYTfHjwSbQeUK/20vY154mwezd9HflVFM1wVSw==}
-    cpu: [x64]
-    os: [linux]
 
   '@img/sharp-linux-arm64@0.33.5':
     resolution: {integrity: sha512-JMVv+AMRyGOHtO1RFBiJy/MBsgz0x4AWrT6QoEVVTyh1E39TrCUpTRI7mx9VksGX4awWASxqCYLCV4wBZHAYxA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [arm64]
-    os: [linux]
 
   '@img/sharp-linux-arm@0.33.5':
     resolution: {integrity: sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [arm]
-    os: [linux]
 
   '@img/sharp-linux-s390x@0.33.5':
     resolution: {integrity: sha512-y/5PCd+mP4CA/sPDKl2961b+C9d+vPAveS33s6Z3zfASk2j5upL6fXVPZi7ztePZ5CuH+1kW8JtvxgbuXHRa4Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [s390x]
-    os: [linux]
 
   '@img/sharp-linux-x64@0.33.5':
     resolution: {integrity: sha512-opC+Ok5pRNAzuvq1AG0ar+1owsu842/Ab+4qvU879ippJBHvyY5n2mxF1izXqkPYlGuP/M556uh53jRLJmzTWA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [x64]
-    os: [linux]
 
   '@img/sharp-linuxmusl-arm64@0.33.5':
     resolution: {integrity: sha512-XrHMZwGQGvJg2V/oRSUfSAfjfPxO+4DkiRh6p2AFjLQztWUuY/o8Mq0eMQVIY7HJ1CDQUJlxGGZRw1a5bqmd1g==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [arm64]
-    os: [linux]
 
   '@img/sharp-linuxmusl-x64@0.33.5':
     resolution: {integrity: sha512-WT+d/cgqKkkKySYmqoZ8y3pxx7lx9vVejxW/W4DOFMYVSkErR+w7mf2u8m/y4+xHe7yY9DAXQMWQhpnMuFfScw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [x64]
-    os: [linux]
 
   '@img/sharp-wasm32@0.33.5':
     resolution: {integrity: sha512-ykUW4LVGaMcU9lu9thv85CbRMAwfeadCJHRsg2GmeRa/cJxsVY9Rbd57JcMxBkKHag5U/x7TSBpScF4U8ElVzg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [wasm32]
 
   '@img/sharp-win32-ia32@0.33.5':
     resolution: {integrity: sha512-T36PblLaTwuVJ/zw/LaH0PdZkRz5rd3SmMHX8GSmR7vtNSP5Z6bQkExdSK7xGWyxLw4sUknBuugTelgw2faBbQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [ia32]
-    os: [win32]
 
   '@img/sharp-win32-x64@0.33.5':
     resolution: {integrity: sha512-MpY/o8/8kj+EcnxwvrP4aTJSWw/aZ7JIGR4aBeZkZw5B7/Jn+tY9/VNwtcoGmdT7GfggGIU4kygOMSbYnOrAbg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [x64]
-    os: [win32]
 
   '@inquirer/checkbox@4.1.4':
     resolution: {integrity: sha512-d30576EZdApjAMceijXA5jDzRQHT/MygbC+J8I7EqA6f/FRpYxlRtRJbHF8gHeWYeSdOuTEJqonn7QLB1ELezA==}
@@ -5112,31 +5028,21 @@ packages:
 
   '@pagefind/darwin-arm64@1.3.0':
     resolution: {integrity: sha512-365BEGl6ChOsauRjyVpBjXybflXAOvoMROw3TucAROHIcdBvXk9/2AmEvGFU0r75+vdQI4LJdJdpH4Y6Yqaj4A==}
-    cpu: [arm64]
-    os: [darwin]
 
   '@pagefind/darwin-x64@1.3.0':
     resolution: {integrity: sha512-zlGHA23uuXmS8z3XxEGmbHpWDxXfPZ47QS06tGUq0HDcZjXjXHeLG+cboOy828QIV5FXsm9MjfkP5e4ZNbOkow==}
-    cpu: [x64]
-    os: [darwin]
 
   '@pagefind/default-ui@1.3.0':
     resolution: {integrity: sha512-CGKT9ccd3+oRK6STXGgfH+m0DbOKayX6QGlq38TfE1ZfUcPc5+ulTuzDbZUnMo+bubsEOIypm4Pl2iEyzZ1cNg==}
 
   '@pagefind/linux-arm64@1.3.0':
     resolution: {integrity: sha512-8lsxNAiBRUk72JvetSBXs4WRpYrQrVJXjlRRnOL6UCdBN9Nlsz0t7hWstRk36+JqHpGWOKYiuHLzGYqYAqoOnQ==}
-    cpu: [arm64]
-    os: [linux]
 
   '@pagefind/linux-x64@1.3.0':
     resolution: {integrity: sha512-hAvqdPJv7A20Ucb6FQGE6jhjqy+vZ6pf+s2tFMNtMBG+fzcdc91uTw7aP/1Vo5plD0dAOHwdxfkyw0ugal4kcQ==}
-    cpu: [x64]
-    os: [linux]
 
   '@pagefind/windows-x64@1.3.0':
     resolution: {integrity: sha512-BR1bIRWOMqkf8IoU576YDhij1Wd/Zf2kX/kCI0b2qzCKC8wcc2GQJaaRMCpzvCCrmliO4vtJ6RITp/AnoYUUmQ==}
-    cpu: [x64]
-    os: [win32]
 
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
@@ -5387,98 +5293,60 @@ packages:
 
   '@rollup/rollup-android-arm-eabi@4.36.0':
     resolution: {integrity: sha512-jgrXjjcEwN6XpZXL0HUeOVGfjXhPyxAbbhD0BlXUB+abTOpbPiN5Wb3kOT7yb+uEtATNYF5x5gIfwutmuBA26w==}
-    cpu: [arm]
-    os: [android]
 
   '@rollup/rollup-android-arm64@4.36.0':
     resolution: {integrity: sha512-NyfuLvdPdNUfUNeYKUwPwKsE5SXa2J6bCt2LdB/N+AxShnkpiczi3tcLJrm5mA+eqpy0HmaIY9F6XCa32N5yzg==}
-    cpu: [arm64]
-    os: [android]
 
   '@rollup/rollup-darwin-arm64@4.36.0':
     resolution: {integrity: sha512-JQ1Jk5G4bGrD4pWJQzWsD8I1n1mgPXq33+/vP4sk8j/z/C2siRuxZtaUA7yMTf71TCZTZl/4e1bfzwUmFb3+rw==}
-    cpu: [arm64]
-    os: [darwin]
 
   '@rollup/rollup-darwin-x64@4.36.0':
     resolution: {integrity: sha512-6c6wMZa1lrtiRsbDziCmjE53YbTkxMYhhnWnSW8R/yqsM7a6mSJ3uAVT0t8Y/DGt7gxUWYuFM4bwWk9XCJrFKA==}
-    cpu: [x64]
-    os: [darwin]
 
   '@rollup/rollup-freebsd-arm64@4.36.0':
     resolution: {integrity: sha512-KXVsijKeJXOl8QzXTsA+sHVDsFOmMCdBRgFmBb+mfEb/7geR7+C8ypAml4fquUt14ZyVXaw2o1FWhqAfOvA4sg==}
-    cpu: [arm64]
-    os: [freebsd]
 
   '@rollup/rollup-freebsd-x64@4.36.0':
     resolution: {integrity: sha512-dVeWq1ebbvByI+ndz4IJcD4a09RJgRYmLccwlQ8bPd4olz3Y213uf1iwvc7ZaxNn2ab7bjc08PrtBgMu6nb4pQ==}
-    cpu: [x64]
-    os: [freebsd]
 
   '@rollup/rollup-linux-arm-gnueabihf@4.36.0':
     resolution: {integrity: sha512-bvXVU42mOVcF4le6XSjscdXjqx8okv4n5vmwgzcmtvFdifQ5U4dXFYaCB87namDRKlUL9ybVtLQ9ztnawaSzvg==}
-    cpu: [arm]
-    os: [linux]
 
   '@rollup/rollup-linux-arm-musleabihf@4.36.0':
     resolution: {integrity: sha512-JFIQrDJYrxOnyDQGYkqnNBtjDwTgbasdbUiQvcU8JmGDfValfH1lNpng+4FWlhaVIR4KPkeddYjsVVbmJYvDcg==}
-    cpu: [arm]
-    os: [linux]
 
   '@rollup/rollup-linux-arm64-gnu@4.36.0':
     resolution: {integrity: sha512-KqjYVh3oM1bj//5X7k79PSCZ6CvaVzb7Qs7VMWS+SlWB5M8p3FqufLP9VNp4CazJ0CsPDLwVD9r3vX7Ci4J56A==}
-    cpu: [arm64]
-    os: [linux]
 
   '@rollup/rollup-linux-arm64-musl@4.36.0':
     resolution: {integrity: sha512-QiGnhScND+mAAtfHqeT+cB1S9yFnNQ/EwCg5yE3MzoaZZnIV0RV9O5alJAoJKX/sBONVKeZdMfO8QSaWEygMhw==}
-    cpu: [arm64]
-    os: [linux]
 
   '@rollup/rollup-linux-loongarch64-gnu@4.36.0':
     resolution: {integrity: sha512-1ZPyEDWF8phd4FQtTzMh8FQwqzvIjLsl6/84gzUxnMNFBtExBtpL51H67mV9xipuxl1AEAerRBgBwFNpkw8+Lg==}
-    cpu: [loong64]
-    os: [linux]
 
   '@rollup/rollup-linux-powerpc64le-gnu@4.36.0':
     resolution: {integrity: sha512-VMPMEIUpPFKpPI9GZMhJrtu8rxnp6mJR3ZzQPykq4xc2GmdHj3Q4cA+7avMyegXy4n1v+Qynr9fR88BmyO74tg==}
-    cpu: [ppc64]
-    os: [linux]
 
   '@rollup/rollup-linux-riscv64-gnu@4.36.0':
     resolution: {integrity: sha512-ttE6ayb/kHwNRJGYLpuAvB7SMtOeQnVXEIpMtAvx3kepFQeowVED0n1K9nAdraHUPJ5hydEMxBpIR7o4nrm8uA==}
-    cpu: [riscv64]
-    os: [linux]
 
   '@rollup/rollup-linux-s390x-gnu@4.36.0':
     resolution: {integrity: sha512-4a5gf2jpS0AIe7uBjxDeUMNcFmaRTbNv7NxI5xOCs4lhzsVyGR/0qBXduPnoWf6dGC365saTiwag8hP1imTgag==}
-    cpu: [s390x]
-    os: [linux]
 
   '@rollup/rollup-linux-x64-gnu@4.36.0':
     resolution: {integrity: sha512-5KtoW8UWmwFKQ96aQL3LlRXX16IMwyzMq/jSSVIIyAANiE1doaQsx/KRyhAvpHlPjPiSU/AYX/8m+lQ9VToxFQ==}
-    cpu: [x64]
-    os: [linux]
 
   '@rollup/rollup-linux-x64-musl@4.36.0':
     resolution: {integrity: sha512-sycrYZPrv2ag4OCvaN5js+f01eoZ2U+RmT5as8vhxiFz+kxwlHrsxOwKPSA8WyS+Wc6Epid9QeI/IkQ9NkgYyQ==}
-    cpu: [x64]
-    os: [linux]
 
   '@rollup/rollup-win32-arm64-msvc@4.36.0':
     resolution: {integrity: sha512-qbqt4N7tokFwwSVlWDsjfoHgviS3n/vZ8LK0h1uLG9TYIRuUTJC88E1xb3LM2iqZ/WTqNQjYrtmtGmrmmawB6A==}
-    cpu: [arm64]
-    os: [win32]
 
   '@rollup/rollup-win32-ia32-msvc@4.36.0':
     resolution: {integrity: sha512-t+RY0JuRamIocMuQcfwYSOkmdX9dtkr1PbhKW42AMvaDQa+jOdpUYysroTF/nuPpAaQMWp7ye+ndlmmthieJrQ==}
-    cpu: [ia32]
-    os: [win32]
 
   '@rollup/rollup-win32-x64-msvc@4.36.0':
     resolution: {integrity: sha512-aRXd7tRZkWLqGbChgcMMDEHjOKudo1kChb1Jt1IfR8cY/KIpgNviLeJy5FUb9IpSuQj8dU2fAYNMPW/hLKOSTw==}
-    cpu: [x64]
-    os: [win32]
 
   '@rtsao/scc@1.1.0':
     resolution: {integrity: sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==}
@@ -6162,28 +6030,12 @@ packages:
       '@typespec/http': ^1.0.0-rc.0
       '@typespec/rest': ^0.68.0
 
-  '@typespec/http@1.0.0-rc.1':
-    resolution: {integrity: sha512-USAxsTeRF1i4g39KeHOh7/x1RzW4lpSpWQqlz/xuHAxEPVsu23BRq9AJrN/nTpgYlpGvOTbJnadWXOs20/TmBA==}
-    engines: {node: '>=20.0.0'}
-    peerDependencies:
-      '@typespec/compiler': ^1.0.0-rc.1
-      '@typespec/streams': ^0.69.0
-    peerDependenciesMeta:
-      '@typespec/streams':
-        optional: true
-
   '@typespec/rest@0.69.0':
     resolution: {integrity: sha512-rbYG0XG6UYapJ6yG9Ytk5djkuaJ3QHG0WEQ01KpdNl4XEfpelH7wLStShP85nxrP4hmNZ6Slqm1Zng2kcyjkww==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
       '@typespec/compiler': ^1.0.0-rc.1
       '@typespec/http': ^1.0.0-rc.1
-
-  '@typespec/streams@0.69.0':
-    resolution: {integrity: sha512-4GIXjWYUI38MEbq1hWfBEwvrze18sAsgWn7OQKFSTg+SvE6VDVP1J6Hfr4Ps+wNmn3x9tySEyX1NrwBlAZSJDQ==}
-    engines: {node: '>=20.0.0'}
-    peerDependencies:
-      '@typespec/compiler': ^1.0.0-rc.1
 
   '@typespec/ts-http-runtime@0.2.1':
     resolution: {integrity: sha512-3zI/d10N4D0L0MQVNTLp9PhhY49Wtg9iYZcb+rWxA4Ii9eJigpamCXjGaH7SkrhQ4+5w++ad7TP64tQzUvRDQA==}
@@ -6309,48 +6161,30 @@ packages:
 
   '@vscode/vsce-sign-alpine-arm64@2.0.2':
     resolution: {integrity: sha512-E80YvqhtZCLUv3YAf9+tIbbqoinWLCO/B3j03yQPbjT3ZIHCliKZlsy1peNc4XNZ5uIb87Jn0HWx/ZbPXviuAQ==}
-    cpu: [arm64]
-    os: [alpine]
 
   '@vscode/vsce-sign-alpine-x64@2.0.2':
     resolution: {integrity: sha512-n1WC15MSMvTaeJ5KjWCzo0nzjydwxLyoHiMJHu1Ov0VWTZiddasmOQHekA47tFRycnt4FsQrlkSCTdgHppn6bw==}
-    cpu: [x64]
-    os: [alpine]
 
   '@vscode/vsce-sign-darwin-arm64@2.0.2':
     resolution: {integrity: sha512-rz8F4pMcxPj8fjKAJIfkUT8ycG9CjIp888VY/6pq6cuI2qEzQ0+b5p3xb74CJnBbSC0p2eRVoe+WgNCAxCLtzQ==}
-    cpu: [arm64]
-    os: [darwin]
 
   '@vscode/vsce-sign-darwin-x64@2.0.2':
     resolution: {integrity: sha512-MCjPrQ5MY/QVoZ6n0D92jcRb7eYvxAujG/AH2yM6lI0BspvJQxp0o9s5oiAM9r32r9tkLpiy5s2icsbwefAQIw==}
-    cpu: [x64]
-    os: [darwin]
 
   '@vscode/vsce-sign-linux-arm64@2.0.2':
     resolution: {integrity: sha512-Ybeu7cA6+/koxszsORXX0OJk9N0GgfHq70Wqi4vv2iJCZvBrOWwcIrxKjvFtwyDgdeQzgPheH5nhLVl5eQy7WA==}
-    cpu: [arm64]
-    os: [linux]
 
   '@vscode/vsce-sign-linux-arm@2.0.2':
     resolution: {integrity: sha512-Fkb5jpbfhZKVw3xwR6t7WYfwKZktVGNXdg1m08uEx1anO0oUPUkoQRsNm4QniL3hmfw0ijg00YA6TrxCRkPVOQ==}
-    cpu: [arm]
-    os: [linux]
 
   '@vscode/vsce-sign-linux-x64@2.0.2':
     resolution: {integrity: sha512-NsPPFVtLaTlVJKOiTnO8Cl78LZNWy0Q8iAg+LlBiCDEgC12Gt4WXOSs2pmcIjDYzj2kY4NwdeN1mBTaujYZaPg==}
-    cpu: [x64]
-    os: [linux]
 
   '@vscode/vsce-sign-win32-arm64@2.0.2':
     resolution: {integrity: sha512-wPs848ymZ3Ny+Y1Qlyi7mcT6VSigG89FWQnp2qRYCyMhdJxOpA4lDwxzlpL8fG6xC8GjQjGDkwbkWUcCobvksQ==}
-    cpu: [arm64]
-    os: [win32]
 
   '@vscode/vsce-sign-win32-x64@2.0.2':
     resolution: {integrity: sha512-pAiRN6qSAhDM5SVOIxgx+2xnoVUePHbRNC7OD2aOR3WltTKxxF25OfpK8h8UQ7A0BuRkSgREbB59DBlFk4iAeg==}
-    cpu: [x64]
-    os: [win32]
 
   '@vscode/vsce-sign@2.0.5':
     resolution: {integrity: sha512-GfYWrsT/vypTMDMgWDm75iDmAOMe7F71sZECJ+Ws6/xyIfmB3ELVnVN+LwMFAvmXY+e6eWhR2EzNGF/zAhWY3Q==}
@@ -8565,12 +8399,10 @@ packages:
   fsevents@2.3.2:
     resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
-    os: [darwin]
 
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
-    os: [darwin]
 
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
@@ -17895,29 +17727,18 @@ snapshots:
       '@typescript-eslint/types': 8.28.0
       eslint-visitor-keys: 4.2.0
 
-  '@typespec/emitter-framework@0.5.0(@alloy-js/core@0.11.0)(@alloy-js/typescript@0.11.0)(@typespec/compiler@packages+compiler)(@typespec/http@1.0.0-rc.1(@typespec/compiler@packages+compiler)(@typespec/streams@0.69.0(@typespec/compiler@packages+compiler)))(@typespec/rest@0.69.0(@typespec/compiler@packages+compiler)(@typespec/http@1.0.0-rc.1(@typespec/compiler@packages+compiler)(@typespec/streams@0.69.0(@typespec/compiler@packages+compiler))))':
+  '@typespec/emitter-framework@0.5.0(@alloy-js/core@0.11.0)(@alloy-js/typescript@0.11.0)(@typespec/compiler@packages+compiler)(@typespec/http@packages+http)(@typespec/rest@0.69.0(@typespec/compiler@packages+compiler)(@typespec/http@packages+http))':
     dependencies:
       '@alloy-js/core': 0.11.0
       '@alloy-js/typescript': 0.11.0
       '@typespec/compiler': link:packages/compiler
-      '@typespec/http': 1.0.0-rc.1(@typespec/compiler@packages+compiler)(@typespec/streams@0.69.0(@typespec/compiler@packages+compiler))
-      '@typespec/rest': 0.69.0(@typespec/compiler@packages+compiler)(@typespec/http@1.0.0-rc.1(@typespec/compiler@packages+compiler)(@typespec/streams@0.69.0(@typespec/compiler@packages+compiler)))
+      '@typespec/http': link:packages/http
+      '@typespec/rest': 0.69.0(@typespec/compiler@packages+compiler)(@typespec/http@packages+http)
 
-  '@typespec/http@1.0.0-rc.1(@typespec/compiler@packages+compiler)(@typespec/streams@0.69.0(@typespec/compiler@packages+compiler))':
+  '@typespec/rest@0.69.0(@typespec/compiler@packages+compiler)(@typespec/http@packages+http)':
     dependencies:
       '@typespec/compiler': link:packages/compiler
-    optionalDependencies:
-      '@typespec/streams': 0.69.0(@typespec/compiler@packages+compiler)
-
-  '@typespec/rest@0.69.0(@typespec/compiler@packages+compiler)(@typespec/http@1.0.0-rc.1(@typespec/compiler@packages+compiler)(@typespec/streams@0.69.0(@typespec/compiler@packages+compiler)))':
-    dependencies:
-      '@typespec/compiler': link:packages/compiler
-      '@typespec/http': 1.0.0-rc.1(@typespec/compiler@packages+compiler)(@typespec/streams@0.69.0(@typespec/compiler@packages+compiler))
-
-  '@typespec/streams@0.69.0(@typespec/compiler@packages+compiler)':
-    dependencies:
-      '@typespec/compiler': link:packages/compiler
-    optional: true
+      '@typespec/http': link:packages/http
 
   '@typespec/ts-http-runtime@0.2.1':
     dependencies:
@@ -17954,7 +17775,7 @@ snapshots:
       std-env: 3.8.1
       test-exclude: 7.0.1
       tinyrainbow: 2.0.0
-      vitest: 3.0.9(@types/debug@4.1.12)(@types/node@22.13.13)(@vitest/ui@3.0.9)(happy-dom@17.4.4)(jsdom@25.0.1)(tsx@4.19.3)(yaml@2.7.0)
+      vitest: 3.0.9(@types/debug@4.1.12)(@types/node@22.13.13)(@vitest/ui@3.0.9)(happy-dom@17.4.4)(jsdom@25.0.1)(tsx@4.19.3)(yaml@2.7.1)
     transitivePeerDependencies:
       - supports-color
 


### PR DESCRIPTION
This commit does the following:

1. Setup multiple schema support in this commit
2. We use `navigateTypesInNamespace` per schema to navigate the types in the schema. We are not yet using `UsageFlags`, but that will be initialized at this point
3. It distributes some responsibilities in the emitter where the graphql-emitter is responsible for calling each schema-emitter for each schema

TODO:
- Add a way to test the multiple schemas. The current test setup only checks a single schema
- Add the registry