### PR TITLE
Add `@schema` decorator to main.tsp

### DIFF
--- a/packages/graphql/main.tsp
+++ b/packages/graphql/main.tsp
@@ -1,16 +1,19 @@
-namespace MyLibrary;
+import "@typespec/graphql";
+using GraphQL;
 
-model Book {
-  id: string;
-  title: string;
-  publicationDate: string;
-  author: Author;
+@schema
+namespace MyLibrary {
+  model Book {
+    id: string;
+    title: string;
+    publicationDate: string;
+    author: Author;
+  }
+
+  model Author {
+    id: string;
+    name: string;
+    bio?: string;
+    books: Book[];
+  }
 }
-
-model Author {
-  id: string;
-  name: string;
-  bio?: string;
-  books: Book[];
-}
-

--- a/packages/graphql/main.tsp
+++ b/packages/graphql/main.tsp
@@ -1,7 +1,7 @@
 import "@typespec/graphql";
 using GraphQL;
 
-@schema
+@schema(#{name: "library-schema"})
 namespace MyLibrary {
   model Book {
     id: string;

--- a/packages/graphql/src/graphql-emitter.ts
+++ b/packages/graphql/src/graphql-emitter.ts
@@ -32,7 +32,7 @@ export function createGraphQLEmitter(
         return;
       }
       for (const schemaRecord of schemaRecords) {
-        const schemaName = getNamespaceFullName(schemaRecord.schema.type) || "schema";
+        const schemaName = schemaRecord.schema.name || "schema";
         const filePath = interpolatePath(options.outputFile, {
           "schema-name": schemaName,
         });


### PR DESCRIPTION
# Summary

This PR:
* Adds the `@schema` decorator to our example TSP definition in `main.tsp`. Note that we add the import `"@typespec/graphql"` and also specify `using GraphQL`. 
* Sets a name custom name for the GraphQL schema (the emitted schema is called `library-schema.graphql`)
* Fixes a bug with custom schema naming