### PR TITLE
Add basic TSP Model registration and materialization 

### DIFF
--- a/packages/graphql/src/graphql-emitter.ts
+++ b/packages/graphql/src/graphql-emitter.ts
@@ -1,9 +1,4 @@
-import {
-  emitFile,
-  getNamespaceFullName,
-  interpolatePath,
-  type EmitContext,
-} from "@typespec/compiler";
+import { emitFile, interpolatePath, type EmitContext } from "@typespec/compiler";
 import { printSchema } from "graphql";
 import type { ResolvedGraphQLEmitterOptions } from "./emitter.js";
 import type { GraphQLEmitterOptions } from "./lib.js";

--- a/packages/graphql/src/lib/scalars.ts
+++ b/packages/graphql/src/lib/scalars.ts
@@ -1,0 +1,31 @@
+import {
+  GraphQLBoolean,
+  GraphQLString,
+  GraphQLInt,
+  GraphQLFloat,
+  type GraphQLInputType,
+  type GraphQLOutputType,
+} from "graphql";
+
+/**
+ * Map TypeSpec scalar types to GraphQL scalar types
+ */
+export function mapScalarToGraphQL(scalarName: string): GraphQLInputType | GraphQLOutputType {
+  switch (scalarName) {
+    case "string":
+      return GraphQLString;
+    case "int32":
+    case "integer":
+      return GraphQLInt;
+    case "int64":
+      // GraphQL doesn't have int64, use string representation
+      return GraphQLString;
+    case "float32":
+    case "float64":
+      return GraphQLFloat;
+    case "boolean":
+      return GraphQLBoolean;
+    default:
+      return GraphQLString;
+  }
+} 

--- a/packages/graphql/src/registry.ts
+++ b/packages/graphql/src/registry.ts
@@ -49,21 +49,18 @@ export class GraphQLTypeRegistry {
   addEnum(tspEnum: Enum): void {
     const enumName = tspEnum.name;
     if (this.TSPTypeContextRegistry.has(enumName)) {
-      // Optionally, log a warning or update if new information is more complete.
       return;
     }
 
     this.TSPTypeContextRegistry.set(enumName, {
       tspType: tspEnum,
       name: enumName,
-      // TODO: Populate usageFlags based on TSP context and other decorator context.
     });
   }
 
   addModel(tspModel: Model): void {
     const modelName = tspModel.name;
     if (this.TSPTypeContextRegistry.has(modelName)) {
-      // Optionally, log a warning or update if new information is more complete.
       return;
     }
 
@@ -110,9 +107,8 @@ export class GraphQLTypeRegistry {
 
     // Process each property of the model
     for (const [propertyName, property] of tspModel.properties) {
-      // For now, we'll handle only simple scalar types and references to other models
-      // TODO: Add proper type resolution based on the property type
-      let fieldType: GraphQLOutputType = GraphQLString; // Default to string for now
+      // TODO: Add proper type resolution based on the property type, default to string for now
+      let fieldType: GraphQLOutputType = GraphQLString;
 
       // If the property type is a reference to another type, try to materialize it
       if (property.type.kind === "Model") {

--- a/packages/graphql/src/registry.ts
+++ b/packages/graphql/src/registry.ts
@@ -173,7 +173,6 @@ export class GraphQLTypeRegistry {
         },
       });
     }
-
     return {
       query: queryType,
       types: allMaterializedGqlTypes.length > 0 ? allMaterializedGqlTypes : null,

--- a/packages/graphql/src/registry.ts
+++ b/packages/graphql/src/registry.ts
@@ -3,7 +3,9 @@ import {
   GraphQLBoolean,
   GraphQLEnumType,
   GraphQLObjectType,
+  GraphQLString,
   type GraphQLNamedType,
+  type GraphQLOutputType,
   type GraphQLSchemaConfig,
 } from "graphql";
 
@@ -15,32 +17,30 @@ interface TSPTypeContext {
   usageFlags?: Set<UsageFlags>;
   // TODO: Add any other TSP-specific metadata here.
 }
+
 /**
- * GraphQLTypeRegistry manages the registration and materialization of TypeSpec (TSP) 
+ * GraphQLTypeRegistry manages the registration and materialization of TypeSpec (TSP)
  * types into their corresponding GraphQL type definitions.
  *
  * The registry operates in a two-stage process:
  * 1. Registration: TSP types (like Enums, Models, etc.) are first registered
  *    along with relevant metadata (e.g., name, usage flags). This stores an
  *    intermediate representation (`TSPTypeContext`) without immediately creating
- *    GraphQL types. This stage is typically performed while traversing the TSP AST. 
+ *    GraphQL types. This stage is typically performed while traversing the TSP AST.
  *    Register type by calling the appropriate method (e.g., `addEnum`).
- * 
+ *
  * 2. Materialization: When a GraphQL type is needed (e.g., to build the final
  *    schema or resolve a field type), the registry can materialize the TSP type
- *    into its GraphQL counterpart (e.g., `GraphQLEnumType`, `GraphQLObjectType`). 
+ *    into its GraphQL counterpart (e.g., `GraphQLEnumType`, `GraphQLObjectType`).
  *    Materialize types by calling the appropriate method (e.g., `materializeEnum`).
  *
  * This approach helps in:
  *  - Decoupling TSP AST traversal from GraphQL object instantiation.
  *  - Caching materialized GraphQL types to avoid redundant work and ensure object identity.
- *  - Handling forward references and circular dependencies, as types can be
- *    registered first and materialized later when all dependencies are known or
- *    by using thunks for fields/arguments.
+ *  - Handling forward references and circular dependencies through thunks
  */
 export class GraphQLTypeRegistry {
   // Stores intermediate TSP type information, keyed by TSP type name.
-  // TODO: make this more of a seen set
   private TSPTypeContextRegistry: Map<string, TSPTypeContext> = new Map();
 
   // Stores materialized GraphQL types, keyed by their GraphQL name.
@@ -56,6 +56,20 @@ export class GraphQLTypeRegistry {
     this.TSPTypeContextRegistry.set(enumName, {
       tspType: tspEnum,
       name: enumName,
+      // TODO: Populate usageFlags based on TSP context and other decorator context.
+    });
+  }
+
+  addModel(tspModel: Model): void {
+    const modelName = tspModel.name;
+    if (this.TSPTypeContextRegistry.has(modelName)) {
+      // Optionally, log a warning or update if new information is more complete.
+      return;
+    }
+
+    this.TSPTypeContextRegistry.set(modelName, {
+      tspType: tspModel,
+      name: modelName,
       // TODO: Populate usageFlags based on TSP context and other decorator context.
     });
   }
@@ -79,7 +93,7 @@ export class GraphQLTypeRegistry {
       name: context.name,
       values: Object.fromEntries(
         Array.from(tspEnum.members.values()).map((member) => [
-          member.name, 
+          member.name,
           {
             value: member.value ?? member.name,
           },
@@ -89,6 +103,59 @@ export class GraphQLTypeRegistry {
 
     this.materializedGraphQLTypes.set(enumName, gqlEnum);
     return gqlEnum;
+  }
+
+  private computeModelFields(tspModel: Model): Record<string, { type: GraphQLOutputType }> {
+    const fields: Record<string, { type: GraphQLOutputType }> = {};
+
+    // Process each property of the model
+    for (const [propertyName, property] of tspModel.properties) {
+      // For now, we'll handle only simple scalar types and references to other models
+      // TODO: Add proper type resolution based on the property type
+      let fieldType: GraphQLOutputType = GraphQLString; // Default to string for now
+
+      // If the property type is a reference to another type, try to materialize it
+      if (property.type.kind === "Model") {
+        const referencedType = this.materializeModel(property.type.name);
+        if (referencedType) {
+          fieldType = referencedType;
+        }
+      } else if (property.type.kind === "Enum") {
+        const referencedType = this.materializeEnum(property.type.name);
+        if (referencedType) {
+          fieldType = referencedType;
+        }
+      }
+
+      fields[propertyName] = { type: fieldType };
+    }
+
+    return fields;
+  }
+
+  // Materializes a TSP Model into a GraphQLObjectType.
+  materializeModel(modelName: string): GraphQLObjectType | undefined {
+    // Check if the GraphQL type is already materialized.
+    if (this.materializedGraphQLTypes.has(modelName)) {
+      return this.materializedGraphQLTypes.get(modelName) as GraphQLObjectType;
+    }
+
+    const context = this.TSPTypeContextRegistry.get(modelName);
+    if (!context || context.tspType.kind !== "Model") {
+      // TODO: Handle error or warning for missing context.
+      return undefined;
+    }
+
+    const tspModel = context.tspType as Model;
+
+    // Create the GraphQL object type with a thunk for fields to handle forward references
+    const gqlObjectType = new GraphQLObjectType({
+      name: context.name,
+      fields: () => this.computeModelFields(tspModel),
+    });
+
+    this.materializedGraphQLTypes.set(modelName, gqlObjectType);
+    return gqlObjectType;
   }
 
   materializeSchemaConfig(): GraphQLSchemaConfig {

--- a/packages/graphql/src/registry.ts
+++ b/packages/graphql/src/registry.ts
@@ -1,172 +1,368 @@
-import { UsageFlags, type Enum, type Model } from "@typespec/compiler";
+import {
+  isArrayModelType,
+  UsageFlags,
+  type Enum,
+  type Model,
+  type ModelProperty,
+  type Program,
+  type UsageTracker,
+} from "@typespec/compiler";
 import {
   GraphQLBoolean,
-  GraphQLEnumType,
   GraphQLObjectType,
   GraphQLString,
-  type GraphQLFieldConfigMap,
+  type GraphQLEnumType,
+  type GraphQLInputObjectType,
+  type GraphQLInputType,
   type GraphQLNamedType,
   type GraphQLOutputType,
   type GraphQLSchemaConfig,
 } from "graphql";
+import { mapScalarToGraphQL } from "./lib/scalars.js";
+import { EnumTypeMap, InputTypeMap, ObjectTypeMap, type TSPContext } from "./type-maps.js";
 
-// The TSPTypeContext interface represents the intermediate TSP type information before materialization.
-// It stores the raw TSP type and any extracted metadata relevant for GraphQL generation.
-interface TSPTypeContext {
-  tspType: Enum | Model; // Extend with other TSP types like Operation, Interface, TSP Union, etc.
-  name: string;
-  usageFlags?: Set<UsageFlags>;
-  // TODO: Add any other TSP-specific metadata here.
+/**
+ * Model type name tracking for usage flags
+ */
+interface ModelTypeNames {
+  [UsageFlags.Input]?: string;
+  [UsageFlags.Output]?: string;
+  [UsageFlags.None]?: string;
+}
+
+/**
+ * Registry for managing model type names with usage flags
+ */
+class ModelTypeRegistry {
+  private typeNames = new Map<string, ModelTypeNames>();
+
+  /**
+   * Register a type name with a usage flag
+   */
+  registerTypeName(modelName: string, usageFlag: UsageFlags): string {
+    if (!this.typeNames.has(modelName)) {
+      this.typeNames.set(modelName, {});
+    }
+
+    const typeNames = this.typeNames.get(modelName)!;
+
+    let graphqlTypeName: string;
+    if (usageFlag === UsageFlags.Input) {
+      graphqlTypeName = `${modelName}Input`;
+    } else {
+      graphqlTypeName = modelName;
+    }
+
+    typeNames[usageFlag] = graphqlTypeName;
+    return graphqlTypeName;
+  }
+
+  /**
+   * Get all GraphQL type names for a model
+   */
+  getModelTypeNames(modelName: string): ModelTypeNames {
+    return this.typeNames.get(modelName) || {};
+  }
+
+  /**
+   * Reset the registry
+   */
+  reset(): void {
+    this.typeNames.clear();
+  }
 }
 
 /**
  * GraphQLTypeRegistry manages the registration and materialization of TypeSpec (TSP)
  * types into their corresponding GraphQL type definitions.
  *
- * The registry operates in a two-stage process:
- * 1. Registration: TSP types (like Enums, Models, etc.) are first registered
- *    along with relevant metadata (e.g., name, usage flags). This stores an
- *    intermediate representation (`TSPTypeContext`) without immediately creating
- *    GraphQL types. This stage is typically performed while traversing the TSP AST.
- *    Register type by calling the appropriate method (e.g., `addEnum`).
- *
- * 2. Materialization: When a GraphQL type is needed (e.g., to build the final
- *    schema or resolve a field type), the registry can materialize the TSP type
- *    into its GraphQL counterpart (e.g., `GraphQLEnumType`, `GraphQLObjectType`).
- *    Materialize types by calling the appropriate method (e.g., `materializeEnum`).
- *
- * This approach helps in:
- *  - Decoupling TSP AST traversal from GraphQL object instantiation.
- *  - Caching materialized GraphQL types to avoid redundant work and ensure object identity.
- *  - Handling forward references and circular dependencies through per-property lazy evaluation.
+ * This registry uses a sophisticated type mapping system with specialized maps for
+ * different GraphQL types, thunk-based field handling, and proper usage context tracking.
  */
 export class GraphQLTypeRegistry {
-  // Stores intermediate TSP type information, keyed by TSP type name.
-  private TSPTypeContextRegistry: Map<string, TSPTypeContext> = new Map();
+  // Type name registry
+  private modelTypeNames = new ModelTypeRegistry();
 
-  // Stores materialized GraphQL types, keyed by their GraphQL name.
-  private materializedGraphQLTypes: Map<string, GraphQLNamedType> = new Map();
+  // Type maps for different GraphQL types
+  private objectTypes: ObjectTypeMap;
+  private inputTypes: InputTypeMap;
+  private enumTypes: EnumTypeMap;
 
+  // Usage tracker for determining input vs output usage
+  private usageTracker?: UsageTracker;
+
+  // Program instance for TypeSpec utilities
+  private program: Program;
+
+  constructor(program: Program) {
+    this.program = program;
+    // Initialize type maps with necessary dependencies
+    this.objectTypes = new ObjectTypeMap();
+    this.inputTypes = new InputTypeMap();
+    this.enumTypes = new EnumTypeMap();
+  }
+
+  /**
+   * Set the usage tracker for determining input vs output usage
+   */
+  setUsageTracker(usageTracker: UsageTracker): void {
+    this.usageTracker = usageTracker;
+  }
+
+  /**
+   * Add a model to the registry
+   */
+  addModel(model: Model): void {
+    const modelName = model.name;
+    if (!modelName) return;
+
+    // Always register for output usage (GraphQL object type)
+    const outputTypeName = this.modelTypeNames.registerTypeName(modelName, UsageFlags.Output);
+    const outputContext: TSPContext<Model> = {
+      type: model,
+      usageFlag: UsageFlags.Output,
+      name: outputTypeName,
+    };
+    this.objectTypes.register(outputContext);
+
+    // Only register for input usage if the model is actually used as input
+    if (this.usageTracker?.isUsedAs(model, UsageFlags.Input)) {
+      const inputTypeName = this.modelTypeNames.registerTypeName(modelName, UsageFlags.Input);
+      const inputContext: TSPContext<Model> = {
+        type: model,
+        usageFlag: UsageFlags.Input,
+        name: inputTypeName,
+      };
+      this.inputTypes.register(inputContext);
+    }
+  }
+
+  /**
+   * Materialize a model for all its registered usage contexts
+   */
+  materializeModelWithAllUsages(modelName: string): {
+    outputType?: GraphQLObjectType;
+    inputType?: GraphQLInputObjectType;
+  } {
+    const result: {
+      outputType?: GraphQLObjectType;
+      inputType?: GraphQLInputObjectType;
+    } = {};
+
+    // Get the type names for this model
+    const typeNames = this.getModelTypeNames(modelName);
+
+    // Materialize output type if registered
+    const outputTypeName = typeNames[UsageFlags.Output];
+    if (outputTypeName) {
+      result.outputType = this.materializeModel(outputTypeName);
+    }
+
+    // Materialize input type if registered
+    const inputTypeName = typeNames[UsageFlags.Input];
+    if (inputTypeName) {
+      result.inputType = this.materializeInputModel(inputTypeName);
+    }
+
+    return result;
+  }
+
+  /**
+   * Add an enum to the registry
+   */
   addEnum(tspEnum: Enum): void {
-    const enumName = tspEnum.name;
-    if (this.TSPTypeContextRegistry.has(enumName)) {
-      return;
-    }
+    const context: TSPContext<Enum> = {
+      type: tspEnum,
+      usageFlag: UsageFlags.Output, // Enums are typically output types
+      name: tspEnum.name,
+    };
 
-    this.TSPTypeContextRegistry.set(enumName, {
-      tspType: tspEnum,
-      name: enumName,
-    });
+    this.enumTypes.register(context);
   }
 
-  addModel(tspModel: Model): void {
-    const modelName = tspModel.name;
-    if (this.TSPTypeContextRegistry.has(modelName)) {
-      return;
-    }
-
-    this.TSPTypeContextRegistry.set(modelName, {
-      tspType: tspModel,
-      name: modelName,
-      // TODO: Populate usageFlags based on TSP context and other decorator context.
-    });
+  /**
+   * Get all GraphQL type names for a model
+   */
+  getModelTypeNames(modelName: string): ModelTypeNames {
+    return this.modelTypeNames.getModelTypeNames(modelName);
   }
 
-  // Materializes a TSP Enum into a GraphQLEnumType.
-  materializeEnum(enumName: string): GraphQLEnumType | undefined {
-    // Check if the GraphQL type is already materialized.
-    if (this.materializedGraphQLTypes.has(enumName)) {
-      return this.materializedGraphQLTypes.get(enumName) as GraphQLEnumType;
+  /**
+   * Add a model property using TypeSpec ModelProperty
+   */
+  addModelProperty(parentModelName: string, property: ModelProperty): void {
+    const propertyName = property.name;
+
+    // Determine if the property is optional
+    const isOptional = property.optional;
+
+    // Determine if the property is a list/array using TypeSpec's built-in utility
+    const isList = property.type.kind === "Model" && isArrayModelType(this.program, property.type);
+
+    // Get all GraphQL type names for the model
+    const typeNames = this.getModelTypeNames(parentModelName);
+
+    // Add to output type map with output-specific thunk
+    const outputTypeName = typeNames[UsageFlags.Output];
+    if (outputTypeName) {
+      const outputTypeThunk = () => {
+        return this.resolvePropertyType(property, UsageFlags.Output);
+      };
+
+      this.objectTypes.registerField(
+        outputTypeName,
+        propertyName,
+        outputTypeThunk,
+        isOptional,
+        isList,
+      );
     }
 
-    const context = this.TSPTypeContextRegistry.get(enumName);
-    if (!context || context.tspType.kind !== "Enum") {
-      // TODO: Handle error or warning for missing context.
-      return undefined;
+    // Add to input type map with input-specific thunk
+    const inputTypeName = typeNames[UsageFlags.Input];
+    if (inputTypeName) {
+      const inputTypeThunk = () => {
+        return this.resolvePropertyType(property, UsageFlags.Input);
+      };
+
+      this.inputTypes.registerField(
+        inputTypeName,
+        propertyName,
+        inputTypeThunk,
+        isOptional,
+        isList,
+      );
     }
-
-    const tspEnum = context.tspType as Enum;
-
-    const gqlEnum = new GraphQLEnumType({
-      name: context.name,
-      values: Object.fromEntries(
-        Array.from(tspEnum.members.values()).map((member) => [
-          member.name,
-          {
-            value: member.value ?? member.name,
-          },
-        ]),
-      ),
-    });
-
-    this.materializedGraphQLTypes.set(enumName, gqlEnum);
-    return gqlEnum;
   }
 
-  private computeModelFields(tspModel: Model): GraphQLFieldConfigMap<any, any> {
-    const registry = this;
+  /**
+   * Resolve the GraphQL type for a model property with usage context
+   */
+  private resolvePropertyType(
+    property: ModelProperty,
+    usageFlag: UsageFlags,
+  ): GraphQLInputType | GraphQLOutputType {
+    const propertyType = property.type;
 
-    const fields: GraphQLFieldConfigMap<any, any> = {};
+    switch (propertyType.kind) {
+      case "Scalar":
+        // Map TypeSpec scalars to GraphQL scalars
+        return mapScalarToGraphQL(propertyType.name);
 
-    // Process each property of the model
-    for (const [propertyName, property] of tspModel.properties) {
-      const fieldConfig: any = {};
+      case "Model":
+        // Check if this is an array type - resolve to element type directly (non-recursive)
+        if (isArrayModelType(this.program, propertyType)) {
+          const elementType = propertyType.indexer!.value;
+          return this.resolveElementType(elementType, usageFlag);
+        }
 
-      // Define a getter for the type property to enable lazy evaluation per field
-      Object.defineProperty(fieldConfig, "type", {
-        get: function () {
-          // TODO: Add proper type resolution based on the property type, default to string for now
-          let fieldType: GraphQLOutputType = GraphQLString;
-
-          // If the property type is a reference to another type, try to materialize it
-          if (property.type.kind === "Model") {
-            const referencedType = registry.materializeModel(property.type.name);
-            if (referencedType) {
-              fieldType = referencedType;
+        // For regular models, reference the registered type
+        if (propertyType.name) {
+          if (usageFlag === UsageFlags.Input) {
+            const referencedInputType = this.materializeInputModel(propertyType.name);
+            if (referencedInputType) {
+              return referencedInputType;
             }
-          } else if (property.type.kind === "Enum") {
-            const referencedType = registry.materializeEnum(property.type.name);
-            if (referencedType) {
-              fieldType = referencedType;
+          } else {
+            const referencedOutputType = this.materializeModel(propertyType.name);
+            if (referencedOutputType) {
+              return referencedOutputType;
             }
           }
+        }
+        // Fallback to string if model not found
+        return GraphQLString;
 
-          return fieldType;
-        },
-      });
-      fields[propertyName] = fieldConfig;
+      case "Enum":
+        // Reference to an enum (enums work for both input and output)
+        if (propertyType.name) {
+          const referencedEnum = this.materializeEnum(propertyType.name);
+          if (referencedEnum) {
+            return referencedEnum;
+          }
+        }
+        // Fallback to string if enum not found
+        return GraphQLString;
+
+      default:
+        // Default to GraphQL String for unknown types
+        return GraphQLString;
     }
-
-    return fields;
   }
 
-  // Materializes a TSP Model into a GraphQLObjectType.
+  /**
+   * Resolve array element type directly
+   */
+  private resolveElementType(
+    elementType: any,
+    usageFlag: UsageFlags,
+  ): GraphQLInputType | GraphQLOutputType {
+    switch (elementType.kind) {
+      case "Scalar":
+        return mapScalarToGraphQL(elementType.name);
+
+      case "Model":
+        if (elementType.name) {
+          if (usageFlag === UsageFlags.Input) {
+            const referencedInputType = this.materializeInputModel(elementType.name);
+            if (referencedInputType) {
+              return referencedInputType;
+            }
+          } else {
+            const referencedOutputType = this.materializeModel(elementType.name);
+            if (referencedOutputType) {
+              return referencedOutputType;
+            }
+          }
+        }
+        return GraphQLString;
+
+      case "Enum":
+        if (elementType.name) {
+          const referencedEnum = this.materializeEnum(elementType.name);
+          if (referencedEnum) {
+            return referencedEnum;
+          }
+        }
+        return GraphQLString;
+
+      default:
+        return GraphQLString;
+    }
+  }
+
+  /**
+   * Materialize a TSP Enum into a GraphQLEnumType
+   */
+  materializeEnum(enumName: string): GraphQLEnumType | undefined {
+    return this.enumTypes.get(enumName);
+  }
+
+  /**
+   * Materialize a TSP Model into a GraphQLObjectType
+   */
   materializeModel(modelName: string): GraphQLObjectType | undefined {
-    // Check if the GraphQL type is already materialized.
-    if (this.materializedGraphQLTypes.has(modelName)) {
-      return this.materializedGraphQLTypes.get(modelName) as GraphQLObjectType;
-    }
-
-    const context = this.TSPTypeContextRegistry.get(modelName);
-    if (!context || context.tspType.kind !== "Model") {
-      // TODO: Handle error or warning for missing context.
-      return undefined;
-    }
-
-    const tspModel = context.tspType as Model;
-
-    const gqlObjectType = new GraphQLObjectType({
-      name: context.name,
-      fields: this.computeModelFields(tspModel),
-    });
-
-    this.materializedGraphQLTypes.set(modelName, gqlObjectType);
-    return gqlObjectType;
+    return this.objectTypes.get(modelName);
   }
 
+  /**
+   * Materialize a TSP Model into a GraphQLInputObjectType
+   */
+  materializeInputModel(modelName: string): GraphQLInputObjectType | undefined {
+    return this.inputTypes.get(modelName);
+  }
+
+  /**
+   * Generate the GraphQL schema configuration
+   */
   materializeSchemaConfig(): GraphQLSchemaConfig {
-    const allMaterializedGqlTypes = Array.from(this.materializedGraphQLTypes.values());
-    let queryType = this.materializedGraphQLTypes.get("Query") as GraphQLObjectType | undefined;
+    const allMaterializedGqlTypes: GraphQLNamedType[] = [
+      ...this.objectTypes.getAllMaterialized(),
+      ...this.inputTypes.getAllMaterialized(),
+      ...this.enumTypes.getAllMaterialized(),
+    ];
+
+    let queryType = this.objectTypes.get("Query");
 
     if (!queryType) {
       queryType = new GraphQLObjectType({
@@ -185,5 +381,15 @@ export class GraphQLTypeRegistry {
       query: queryType,
       types: allMaterializedGqlTypes.length > 0 ? allMaterializedGqlTypes : null,
     };
+  }
+
+  /**
+   * Reset all registries to their initial state
+   */
+  reset(): void {
+    this.modelTypeNames.reset();
+    this.objectTypes.reset();
+    this.inputTypes.reset();
+    this.enumTypes.reset();
   }
 }

--- a/packages/graphql/src/schema-emitter.ts
+++ b/packages/graphql/src/schema-emitter.ts
@@ -1,11 +1,13 @@
 import {
   createDiagnosticCollector,
+  ListenerFlow,
   navigateTypesInNamespace,
   type Diagnostic,
   type DiagnosticCollector,
   type EmitContext,
   type Enum,
   type Model,
+  type Namespace,
 } from "@typespec/compiler";
 import { GraphQLSchema, validateSchema } from "graphql";
 import { type GraphQLEmitterOptions } from "./lib.js";
@@ -52,18 +54,22 @@ class GraphQLSchemaEmitter {
 
   semanticNodeListener() {
     return {
+      namespace: (namespace: Namespace) => {
+        if (namespace.name === "TypeSpec" || namespace.name === "Reflection") {
+          return ListenerFlow.NoRecursion;
+        }
+        return;
+      },
       enum: (node: Enum) => {
         this.registry.addEnum(node);
       },
       model: (node: Model) => {
-        // Register the model in the registry
         this.registry.addModel(node);
       },
       exitEnum: (node: Enum) => {
         this.registry.materializeEnum(node.name);
       },
       exitModel: (node: Model) => {
-        // Materialize the model after all its properties have been processed
         this.registry.materializeModel(node.name);
       },
     };

--- a/packages/graphql/src/schema-emitter.ts
+++ b/packages/graphql/src/schema-emitter.ts
@@ -11,7 +11,6 @@ import { GraphQLSchema, validateSchema } from "graphql";
 import { type GraphQLEmitterOptions } from "./lib.js";
 import type { Schema } from "./lib/schema.js";
 import { GraphQLTypeRegistry } from "./registry.js";
-import { exit } from "node:process";
 
 class GraphQLSchemaEmitter {
   private tspSchema: Schema;
@@ -52,19 +51,20 @@ class GraphQLSchemaEmitter {
   }
 
   semanticNodeListener() {
-    // TODO: Add GraphQL types to registry as the TSP nodes are visited
     return {
       enum: (node: Enum) => {
         this.registry.addEnum(node);
       },
       model: (node: Model) => {
-        // Add logic to handle the model node
+        // Register the model in the registry
+        this.registry.addModel(node);
       },
       exitEnum: (node: Enum) => {
         this.registry.materializeEnum(node.name);
       },
       exitModel: (node: Model) => {
-        // Add logic to handle the exit of the model node
+        // Materialize the model after all its properties have been processed
+        this.registry.materializeModel(node.name);
       },
     };
   }

--- a/packages/graphql/src/type-maps.ts
+++ b/packages/graphql/src/type-maps.ts
@@ -1,0 +1,392 @@
+import { UsageFlags, type Enum, type Model } from "@typespec/compiler";
+import {
+  GraphQLEnumType,
+  GraphQLInputObjectType,
+  GraphQLInterfaceType,
+  GraphQLList,
+  GraphQLNonNull,
+  GraphQLObjectType,
+  type GraphQLEnumValueConfig,
+  type GraphQLFieldConfigMap,
+  type GraphQLInputFieldConfigMap,
+  type GraphQLInputType,
+  type GraphQLOutputType,
+  type GraphQLFieldConfigArgumentMap,
+} from "graphql";
+
+/**
+ * TypeSpec context for type mapping
+ * @template T - The TypeSpec type
+ */
+export interface TSPContext<T = any> {
+  type: T;                    // The TypeSpec type
+  usageFlag: UsageFlags;      // How the type is being used
+  name?: string;              // Optional name override
+  metadata?: Record<string, any>; // Optional additional metadata
+}
+
+/**
+ * Thunk types for lazy evaluation of GraphQL types and arguments
+ */
+export type ThunkGraphQLType = () => GraphQLInputType | GraphQLOutputType;
+export type ThunkGraphQLFieldConfigArgumentMap = () => GraphQLFieldConfigArgumentMap;
+
+/**
+ * Configuration for thunk-based field definitions
+ */
+export interface ThunkFieldConfig {
+  type: ThunkGraphQLType;
+  isOptional: boolean;
+  isList: boolean;
+  args?: ThunkGraphQLFieldConfigArgumentMap;
+}
+
+/**
+ * Model field map to store thunk field configurations
+ */
+export class ModelFieldMap {
+  private fieldMap = new Map<string, ThunkFieldConfig>();
+  
+  /**
+   * Add a field with thunk configuration
+   */
+  addField(
+    fieldName: string, 
+    type: ThunkGraphQLType,
+    isOptional: boolean, 
+    isList: boolean,
+    args?: ThunkGraphQLFieldConfigArgumentMap
+  ): void {
+    this.fieldMap.set(fieldName, {
+      type,
+      isOptional,
+      isList,
+      args
+    });
+  }
+  
+  /**
+   * Get all field thunk configurations
+   */
+  getFieldThunks(): Map<string, ThunkFieldConfig> {
+    return this.fieldMap;
+  }
+}
+
+/**
+ * Base TypeMap for all GraphQL type mappings
+ * @template T - The TypeSpec type
+ * @template G - The GraphQL type
+ */
+export abstract class TypeMap<T, G> {
+  // Map of materialized GraphQL types
+  protected materializedMap = new Map<string, G>();
+  
+  // Map of registration contexts
+  protected registrationMap = new Map<string, TSPContext<T>>();
+  
+  /**
+   * Register a TypeSpec type with context for later materialization
+   * @param context - The TypeSpec context
+   * @returns The name used for registration
+   */
+  register(context: TSPContext<T>): string {
+    const name = this.getNameFromContext(context);
+    
+    // Check for conflicts with existing registrations
+    const existing = this.registrationMap.get(name);
+    if (existing && existing.usageFlag !== context.usageFlag) {
+      throw new Error(
+        `Type conflict for "${name}": attempting to register as ${UsageFlags[context.usageFlag]} but already registered as ${UsageFlags[existing.usageFlag]}`
+      );
+    }
+    
+    this.registrationMap.set(name, context);
+    return name;
+  }
+  
+  /**
+   * Get the materialized GraphQL type
+   * @param name - The type name
+   * @returns The materialized GraphQL type or undefined
+   */
+  get(name: string): G | undefined {
+    // Return already materialized type if available
+    if (this.materializedMap.has(name)) {
+      return this.materializedMap.get(name);
+    }
+    
+    // Attempt to materialize if registered
+    const context = this.registrationMap.get(name);
+    if (context) {
+      const materializedType = this.materialize(context);
+      if (materializedType) {
+        this.materializedMap.set(name, materializedType);
+        return materializedType;
+      }
+    }
+    
+    return undefined;
+  }
+  
+  /**
+   * Check if a type is registered
+   */
+  isRegistered(name: string): boolean {
+    return this.registrationMap.has(name);
+  }
+  
+  /**
+   * Get all materialized types
+   */
+  getAllMaterialized(): G[] {
+    return Array.from(this.materializedMap.values());
+  }
+  
+  /**
+   * Reset the type map
+   */
+  reset(): void {
+    this.materializedMap.clear();
+    this.registrationMap.clear();
+  }
+  
+  /**
+   * Get a name from a context
+   */
+  protected abstract getNameFromContext(context: TSPContext<T>): string;
+  
+  /**
+   * Materialize a type from a context
+   */
+  protected abstract materialize(context: TSPContext<T>): G | undefined;
+}
+
+/**
+ * TypeMap for GraphQL Object types (output types)
+ */
+export class ObjectTypeMap extends TypeMap<Model, GraphQLObjectType> {
+  // Maps for fields by model name
+  private modelFieldMaps = new Map<string, ModelFieldMap>();
+  
+  // For handling interfaces
+  private interfacesMap = new Map<string, GraphQLInterfaceType[]>();
+  
+  /**
+   * Get a name from a context
+   */
+  protected override getNameFromContext(context: TSPContext<Model>): string {
+    return context.name || context.type.name || '';
+  }
+  
+  /**
+   * Register a field for a model
+   */
+  registerField(
+    modelName: string,
+    fieldName: string,
+    type: ThunkGraphQLType,
+    isOptional: boolean,
+    isList: boolean,
+    args?: ThunkGraphQLFieldConfigArgumentMap
+  ): void {
+    if (!this.modelFieldMaps.has(modelName)) {
+      this.modelFieldMaps.set(modelName, new ModelFieldMap());
+    }
+    
+    this.modelFieldMaps.get(modelName)!.addField(
+      fieldName,
+      type,
+      isOptional,
+      isList,
+      args
+    );
+  }
+  
+  /**
+   * Add an interface to a model
+   */
+  addInterface(modelName: string, interfaceType: GraphQLInterfaceType): void {
+    if (!this.interfacesMap.has(modelName)) {
+      this.interfacesMap.set(modelName, []);
+    }
+    this.interfacesMap.get(modelName)!.push(interfaceType);
+  }
+  
+  /**
+   * Get interfaces for a model
+   */
+  getInterfaces(modelName: string): GraphQLInterfaceType[] {
+    return this.interfacesMap.get(modelName) || [];
+  }
+  
+  /**
+   * Materialize a GraphQL object type
+   */
+  protected override materialize(context: TSPContext<Model>): GraphQLObjectType | undefined {
+    const modelName = this.getNameFromContext(context);
+    
+    return new GraphQLObjectType({
+      name: modelName,
+      fields: () => this.materializeFields(modelName),
+      interfaces: () => this.getInterfaces(modelName)
+    });
+  }
+  
+  /**
+   * Materialize fields for a model
+   */
+  private materializeFields(modelName: string): GraphQLFieldConfigMap<any, any> {
+    const fieldMap = this.modelFieldMaps.get(modelName);
+    if (!fieldMap) {
+      return {};
+    }
+    
+    const result: GraphQLFieldConfigMap<any, any> = {};
+    const fieldThunks = fieldMap.getFieldThunks();
+    
+    fieldThunks.forEach((config, fieldName) => {
+      let fieldType = config.type() as GraphQLOutputType;
+      
+      if (fieldType instanceof GraphQLInputObjectType) {
+        throw new Error(
+          `Model "${modelName}" has a field "${fieldName}" that is an input type. It should be an output type.`
+        );
+      }
+      
+      if (config.isList) {
+        fieldType = new GraphQLNonNull(new GraphQLList(fieldType));
+      }
+      
+      result[fieldName] = {
+        type: fieldType,
+        args: config.args ? config.args() : undefined
+      };
+    });
+    
+    return result;
+  }
+}
+
+/**
+ * TypeMap for GraphQL Input types
+ */
+export class InputTypeMap extends TypeMap<Model, GraphQLInputObjectType> {
+  // Maps for fields by model name
+  private modelFieldMaps = new Map<string, ModelFieldMap>();
+  
+  /**
+   * Get a name from a context
+   */
+  protected override getNameFromContext(context: TSPContext<Model>): string {
+    return context.name || `${context.type.name || ''}Input`;
+  }
+  
+  /**
+   * Register a field for an input model
+   */
+  registerField(
+    modelName: string,
+    fieldName: string,
+    type: ThunkGraphQLType,
+    isOptional: boolean,
+    isList: boolean
+  ): void {
+    if (!this.modelFieldMaps.has(modelName)) {
+      this.modelFieldMaps.set(modelName, new ModelFieldMap());
+    }
+    
+    this.modelFieldMaps.get(modelName)!.addField(
+      fieldName,
+      type,
+      isOptional,
+      isList
+    );
+  }
+  
+  /**
+   * Materialize a GraphQL input type
+   */
+  protected override materialize(context: TSPContext<Model>): GraphQLInputObjectType | undefined {
+    const modelName = this.getNameFromContext(context);
+    
+    return new GraphQLInputObjectType({
+      name: modelName,
+      fields: () => this.materializeFields(modelName)
+    });
+  }
+  
+  /**
+   * Materialize fields for an input model
+   */
+  private materializeFields(modelName: string): GraphQLInputFieldConfigMap {
+    const fieldMap = this.modelFieldMaps.get(modelName);
+    if (!fieldMap) {
+      return {};
+    }
+    
+    const result: GraphQLInputFieldConfigMap = {};
+    const fieldThunks = fieldMap.getFieldThunks();
+    
+    fieldThunks.forEach((config, fieldName) => {
+      let fieldType = config.type() as GraphQLInputType;
+      
+      if (fieldType instanceof GraphQLObjectType) {
+        throw new Error(
+          `Input model "${modelName}" has a field "${fieldName}" that is an output type. It should be an input type.`
+        );
+      }
+      
+      if (config.isList) {
+        fieldType = new GraphQLNonNull(new GraphQLList(fieldType));
+      }
+      
+      result[fieldName] = {
+        type: fieldType
+      };
+    });
+    
+    return result;
+  }
+}
+
+/**
+ * TypeMap for GraphQL Enum types
+ */
+export class EnumTypeMap extends TypeMap<Enum, GraphQLEnumType> {
+  
+  /**
+   * Get a name from a context
+   */
+  protected override getNameFromContext(context: TSPContext<Enum>): string {
+    return context.name || context.type.name || '';
+  }
+  
+  /**
+   * Sanitize enum member names for GraphQL compatibility
+   */
+  private sanitizeEnumMemberName(name: string): string {
+    // Basic sanitization - replace invalid characters and ensure it starts with letter/underscore
+    return name.replace(/[^A-Za-z0-9_]/g, '_').replace(/^[^A-Za-z_]/, '_$&');
+  }
+  
+  /**
+   * Materialize a GraphQL enum type
+   */
+  protected override materialize(context: TSPContext<Enum>): GraphQLEnumType | undefined {
+    const enumType = context.type;
+    const name = this.getNameFromContext(context);
+    
+    return new GraphQLEnumType({
+      name,
+      values: Array.from(enumType.members.values()).reduce<{
+        [key: string]: GraphQLEnumValueConfig;
+      }>((acc, member) => {
+        acc[this.sanitizeEnumMemberName(member.name)] = {
+          value: member.value ?? member.name,
+        };
+        return acc;
+      }, {})
+    });
+  }
+} 

--- a/packages/graphql/test/emitter.test.ts
+++ b/packages/graphql/test/emitter.test.ts
@@ -2,9 +2,23 @@ import { strictEqual } from "node:assert";
 import { describe, it } from "vitest";
 import { emitSingleSchema } from "./test-host.js";
 
-// For now, the expected output is a placeholder string.
-// In the future, this should be replaced with the actual GraphQL schema output.
-const expectedGraphQLSchema = `type Query {
+// For now, the expected output contains a placeholder string and model property types as String for scalar types that are not yet supported by the emitter.
+// In the future, this should be replaced with the correct GraphQL schema output.
+const expectedGraphQLSchema = `type Author {
+  name: String
+  book: Book
+  coauthor: Author
+}
+
+type Book {
+  name: String
+  page_count: String
+  published: String
+  price: String
+  author: Author
+}
+
+type Query {
   """
   A placeholder field. If you are seeing this, it means no operations were defined that could be emitted.
   """
@@ -21,10 +35,12 @@ describe("name", () => {
           page_count: int32;
           published: boolean;
           price: float64;
+          author: Author;
         }
         model Author {
           name: string;
-          books: Book[];
+          book: Book;
+          coauthor: Author;
         }
         op getBooks(): Book[];
         op getAuthors(): Author[];

--- a/packages/graphql/test/emitter.test.ts
+++ b/packages/graphql/test/emitter.test.ts
@@ -12,9 +12,9 @@ const expectedGraphQLSchema = `type Author {
 
 type Book {
   name: String
-  page_count: String
-  published: String
-  price: String
+  page_count: Int
+  published: Boolean
+  price: Float
   author: Author
 }
 

--- a/packages/graphql/test/interface.test.ts
+++ b/packages/graphql/test/interface.test.ts
@@ -14,7 +14,9 @@ describe("@Interface", () => {
       TestModel: Model;
     }>(`
       @Interface
-      @test model TestModel {}
+      @test model TestModel {
+        name: string;
+      }
     `);
     expectDiagnosticEmpty(diagnostics);
 
@@ -29,10 +31,14 @@ describe("@compose", () => {
       AnInterface: Interface;
     }>(`
       @Interface
-      @test model AnInterface {}
+      @test model AnInterface {
+        prop: string;
+      }
 
       @compose(AnInterface)
-      @test model TestModel {}
+      @test model TestModel {
+        prop: string;
+      }
     `);
     expectDiagnosticEmpty(diagnostics);
 
@@ -50,12 +56,18 @@ describe("@compose", () => {
         SecondInterface: Interface;
       }>(`
       @Interface
-      @test model FirstInterface {}
+      @test model FirstInterface {
+        prop: string;
+      }
       @Interface
-      @test model SecondInterface {}
+      @test model SecondInterface {
+        prop: string;
+      }
 
       @compose(FirstInterface, SecondInterface)
-      @test model TestModel {}
+      @test model TestModel {
+        prop: string;
+      }
     `);
     expectDiagnosticEmpty(diagnostics);
 
@@ -87,7 +99,9 @@ describe("@compose", () => {
       }
 
       @compose(AnInterface)
-      model TestModel extends AnInterface {}
+      model TestModel extends AnInterface {
+        another_prop: string;
+      }
     `);
     expectDiagnosticEmpty(diagnostics);
   });
@@ -99,7 +113,9 @@ describe("@compose", () => {
       }
 
       @compose(AnInterface)
-      model TestModel is AnInterface {}
+      model TestModel is AnInterface {
+        another_prop: string;
+      }
     `);
     expectDiagnosticEmpty(diagnostics);
   });
@@ -158,11 +174,15 @@ describe("@compose", () => {
       AnotherInterface: Interface;
     }>(`
       @Interface
-      @test model AnotherInterface {}
+      @test model AnotherInterface {
+        prop: string;
+      }
 
       @compose(AnotherInterface)
       @Interface
-      @test model AnInterface {}
+      @test model AnInterface {
+        prop: string;
+      }
     `);
     expectDiagnosticEmpty(diagnostics);
 

--- a/packages/graphql/test/main.tsp
+++ b/packages/graphql/test/main.tsp
@@ -16,16 +16,16 @@ namespace MyLibrary {
     id: string;
     name: string;
     bio?: string;
-    book: Book;
-    friend: Author;
-    publisher: Publisher;
+    books: Book[];
+    friends: Author[];
+    publishers: Publisher[];
   }
 
   model Publisher {
     id: string;
     name: string;
-    book: Book;
-    author: Author;
+    books: Book[];
+    authors: Author[];
   }
 
   enum Genre {

--- a/packages/graphql/test/main.tsp
+++ b/packages/graphql/test/main.tsp
@@ -1,13 +1,15 @@
 import "@typespec/graphql";
 using GraphQL;
 
-@schema(#{name: "library-schema"})
+@schema(#{ name: "library-schema" })
 namespace MyLibrary {
   model Book {
     id: string;
     title: string;
     publicationDate: string;
     author: Author;
+    prequel: Book;
+    genre: Genre;
   }
 
   model Author {
@@ -16,12 +18,20 @@ namespace MyLibrary {
     bio?: string;
     books: Book[];
     friend: Author;
+    publisher: Publisher;
   }
-  
+
+  model Publisher {
+    id: string;
+    name: string;
+    book: Book;
+    author: Author;
+  }
+
   enum Genre {
     Fiction,
     NonFiction,
     Mystery,
-    Fantasy
+    Fantasy,
   }
 }

--- a/packages/graphql/test/main.tsp
+++ b/packages/graphql/test/main.tsp
@@ -16,7 +16,7 @@ namespace MyLibrary {
     id: string;
     name: string;
     bio?: string;
-    books: Book[];
+    book: Book;
     friend: Author;
     publisher: Publisher;
   }

--- a/packages/graphql/test/operation-fields.test.ts
+++ b/packages/graphql/test/operation-fields.test.ts
@@ -13,7 +13,9 @@ describe("@operationFields", () => {
       @test op testOperation(): void;
 
       @operationFields(testOperation)
-      @test model TestModel {}
+      @test model TestModel {
+        name: string;
+      }
     `);
     expectDiagnosticEmpty(diagnostics);
 
@@ -30,7 +32,9 @@ describe("@operationFields", () => {
       }
 
       @operationFields(TestInterface)
-      @test model TestModel {}
+      @test model TestModel {
+        prop: string;
+      }
     `);
     expectDiagnosticEmpty(diagnostics);
 
@@ -53,7 +57,9 @@ describe("@operationFields", () => {
       @test op testOperation3(): void;
 
       @operationFields(TestInterface, testOperation3)
-      @test model TestModel {}
+      @test model TestModel {
+        prop: string;
+      }
     `);
     expectDiagnosticEmpty(diagnostics);
 
@@ -72,7 +78,9 @@ describe("@operationFields", () => {
       }
 
       @operationFields(TestInterface, TestInterface.testOperation)
-      @test model TestModel {}
+      @test model TestModel {
+        prop: string;
+      }
     `);
     expectDiagnostics(diagnostics, {
       code: "@typespec/graphql/operation-field-duplicate",
@@ -179,7 +187,9 @@ describe("@operationFields", () => {
         }
   
         @operationFields(testOperation, TestInterface.testOperation)
-        model TestModel {}
+        model TestModel {
+          prop: string;
+        }
       `);
       expectDiagnosticEmpty(diagnostics);
     });

--- a/packages/graphql/test/test-host.ts
+++ b/packages/graphql/test/test-host.ts
@@ -107,3 +107,17 @@ export async function emitSingleSchema(
   ok(schemaRecord.graphQLOutput, "Expected to have found graphql output");
   return schemaRecord.graphQLOutput;
 }
+
+/**
+ * Test usage tracking by creating a simple schema with output-only models
+ */
+export async function emitSchemaForUsageTest(code: string): Promise<string> {
+  const testCode = `
+@schema
+namespace TestUsage {
+  ${code}
+}
+  `;
+  
+  return await emitSingleSchema(testCode, {});
+}

--- a/packages/graphql/test/usage-tracking.test.ts
+++ b/packages/graphql/test/usage-tracking.test.ts
@@ -1,0 +1,55 @@
+import { strictEqual } from "node:assert";
+import { describe, it } from "vitest";
+import { emitSchemaForUsageTest } from "./test-host.js";
+
+describe("Usage Tracking", () => {
+  it("Only generates input types for models used as inputs", async () => {
+    const typeSpecCode = `
+      // Model used only in query return types (output-only usage)
+      model User {
+        id: string;
+        name: string;
+        email: string;
+      }
+      
+      // Model used in both mutation parameters (input) and return types (output)
+      model Product {
+        id: string;
+        title: string;
+        price: float32;
+      }
+      
+      // Query that returns User (creates output usage only)
+      op getUser(id: string): User;
+      
+      // Mutation that takes Product as input and returns it (creates both input and output usage)
+      op createProduct(productData: Product): Product;
+    `;
+    
+    const generatedSchema = await emitSchemaForUsageTest(typeSpecCode);
+    
+    // User should have GraphQL output type but NO input type (only used in query returns)
+    strictEqual(generatedSchema.includes("type User"), true, "User output type should be generated");
+    strictEqual(generatedSchema.includes("input UserInput"), false, "User input type should NOT be generated");
+    
+    // Product should have BOTH GraphQL output type AND input type (used in mutations and returns)
+    strictEqual(generatedSchema.includes("type Product"), true, "Product output type should be generated");
+    strictEqual(generatedSchema.includes("input ProductInput"), true, "Product input type should be generated");
+  });
+  
+  it("Handles models with no operations (output-only by default)", async () => {
+    const typeSpecCode = `
+      // Model defined but not referenced by any operations
+      model OrphanedModel {
+        id: string;
+        metadata: string;
+      }
+    `;
+    
+    const generatedSchema = await emitSchemaForUsageTest(typeSpecCode);
+    
+    // Orphaned models should get output type by default, but no input type
+    strictEqual(generatedSchema.includes("type OrphanedModel"), true, "Orphaned model should get output type");
+    strictEqual(generatedSchema.includes("input OrphanedModelInput"), false, "Orphaned model should NOT get input type");
+  });
+}); 


### PR DESCRIPTION
# Summary
This PR:
* Adds basic functionality for registering TSP Models and materializing GraphQL Types
* Adds lazy loading for model properties to handle circular dependencies and forward references
* Uses `String` as the default type for Scalars for now
* Updates models in existing tests to include at least one property

## Coming Soon
* Make use of `UsageFlags` to generate `GraphQLInputType`s and `GraphQLOutputType`s
* Properly apply TSP directives to models