### PR TITLE
Add TSP Model -> GraphQLObject type translation

### DIFF
--- a/packages/graphql/src/lib/scalars.ts
+++ b/packages/graphql/src/lib/scalars.ts
@@ -1,0 +1,52 @@
+import type { Scalar } from "@typespec/compiler";
+import { $ } from "@typespec/compiler/typekit";
+import {
+  GraphQLBoolean,
+  GraphQLFloat,
+  GraphQLInt,
+  GraphQLString,
+  type GraphQLScalarType,
+} from "graphql";
+
+/**
+ * Map TypeSpec scalar types to GraphQL Built-in types
+ */
+export function mapScalarToGraphQL(
+  scalar: Scalar,
+  typekit: ReturnType<typeof $>,
+): GraphQLScalarType {
+  // Check for string type
+  if (typekit.scalar.isString(scalar)) {
+    return GraphQLString;
+  }
+
+  // Check for integer types
+  if (
+    typekit.scalar.isInt8(scalar) ||
+    typekit.scalar.isInt16(scalar) ||
+    typekit.scalar.isInt32(scalar) ||
+    typekit.scalar.isSafeint(scalar) ||
+    typekit.scalar.isUint8(scalar) ||
+    typekit.scalar.isUint16(scalar) ||
+    typekit.scalar.isUint32(scalar)
+  ) {
+    return GraphQLInt;
+  }
+
+  // Check for float types
+  if (
+    typekit.scalar.isFloat32(scalar) ||
+    typekit.scalar.isFloat64(scalar) ||
+    typekit.scalar.isFloat(scalar)
+  ) {
+    return GraphQLFloat;
+  }
+
+  // Check for boolean type
+  if (typekit.scalar.isBoolean(scalar)) {
+    return GraphQLBoolean;
+  }
+
+  // Default to string for unknown scalar types
+  return GraphQLString;
+}

--- a/packages/graphql/src/registry.ts
+++ b/packages/graphql/src/registry.ts
@@ -70,6 +70,13 @@ export class GraphQLTypeRegistry {
   }
 
   /**
+   * Reset the global name registry 
+   */
+  static resetGlobalRegistry(): void {
+    GraphQLTypeRegistry.#globalNameRegistry.clear();
+  }
+
+  /**
    * Get GraphQL type names for a model based on usage flags
    * Returns a mapping of usage flags to their corresponding GraphQL type names
    */
@@ -95,8 +102,17 @@ export class GraphQLTypeRegistry {
       graphqlName: model.name,
       metadata: {},
     };
+
+    // Check if the model name already exists in the global registry
+    const graphqlName = model_context.graphqlName as TypeKey;
+    if (GraphQLTypeRegistry.#globalNameRegistry.has(graphqlName)) {
+      throw new Error(
+        `GraphQL type name '${graphqlName}' is already registered. Type names must be unique across the entire schema.`,
+      );
+    }
+
     this.#objectTypes.register(model_context);
-    GraphQLTypeRegistry.#globalNameRegistry.add(model_context.graphqlName as TypeKey);
+    GraphQLTypeRegistry.#globalNameRegistry.add(graphqlName);
 
     // TODO: Register input types for models
   }

--- a/packages/graphql/src/type-maps.ts
+++ b/packages/graphql/src/type-maps.ts
@@ -1,5 +1,16 @@
-import { UsageFlags, type Type } from "@typespec/compiler";
-import type { GraphQLType } from "graphql";
+import { UsageFlags, type Model, type Type } from "@typespec/compiler";
+import {
+  GraphQLInputObjectType,
+  GraphQLInterfaceType,
+  GraphQLList,
+  GraphQLNonNull,
+  GraphQLObjectType,
+  type GraphQLFieldConfigArgumentMap,
+  type GraphQLFieldConfigMap,
+  type GraphQLInputType,
+  type GraphQLOutputType,
+  type GraphQLType,
+} from "graphql";
 
 /**
  * TypeSpec context for type mapping
@@ -13,9 +24,57 @@ export interface TSPContext<T extends Type> {
 }
 
 /**
+ * Thunk types for lazy evaluation of GraphQL types and arguments
+ */
+export type ThunkGraphQLType = () => GraphQLInputType | GraphQLOutputType;
+export type ThunkGraphQLFieldConfigArgumentMap = () => GraphQLFieldConfigArgumentMap;
+
+/**
+ * Configuration for thunk-based field definitions
+ */
+export interface ThunkFieldConfig {
+  type: ThunkGraphQLType;
+  isOptional: boolean;
+  isList: boolean;
+  args?: ThunkGraphQLFieldConfigArgumentMap;
+}
+
+/**
+ * Model field map to store thunk field configurations
+ */
+export class ModelFieldMap {
+  #fieldMap = new Map<string, ThunkFieldConfig>();
+
+  /**
+   * Add a field with thunk configuration
+   */
+  addField(
+    fieldName: string,
+    type: ThunkGraphQLType,
+    isOptional: boolean,
+    isList: boolean,
+    args?: ThunkGraphQLFieldConfigArgumentMap,
+  ): void {
+    this.#fieldMap.set(fieldName, {
+      type,
+      isOptional,
+      isList,
+      args,
+    });
+  }
+
+  /**
+   * Get all field thunk configurations
+   */
+  getFieldThunks(): Map<string, ThunkFieldConfig> {
+    return this.#fieldMap;
+  }
+}
+
+/**
  * Nominal type for keys in the TypeMap
  */
-type TypeKey = string & { __typeKey: any };
+export type TypeKey = string & { __typeKey: any };
 
 /**
  * Base TypeMap for all GraphQL type mappings
@@ -23,7 +82,6 @@ type TypeKey = string & { __typeKey: any };
  * @template G - The GraphQL type constrained to GraphQL's GraphQLType
  */
 export abstract class TypeMap<T extends Type, G extends GraphQLType> {
-
   // Map of materialized GraphQL types
   protected materializedMap = new Map<TypeKey, G>();
 
@@ -100,4 +158,144 @@ export abstract class TypeMap<T extends Type, G extends GraphQLType> {
    * Materialize a type from a context
    */
   protected abstract materialize(context: TSPContext<T>): G;
+}
+
+/**
+ * TypeMap for GraphQL Object types (output types)
+ */
+export class ObjectTypeMap extends TypeMap<Model, GraphQLObjectType> {
+  // Maps for fields by model name
+  #modelFieldMaps = new Map<string, ModelFieldMap>();
+
+  // For handling interfaces
+  #interfacesMap = new Map<string, GraphQLInterfaceType[]>();
+
+  /**
+   * Get a name from a context
+   */
+  protected override getNameFromContext(context: TSPContext<Model>): TypeKey {
+    return (context.graphqlName as TypeKey) || (context.type.name as TypeKey) || ("" as TypeKey);
+  }
+
+  /**
+   * Register a field for a model
+   */
+  registerField(
+    modelName: string,
+    fieldName: string,
+    type: ThunkGraphQLType,
+    isOptional: boolean,
+    isList: boolean,
+    args?: ThunkGraphQLFieldConfigArgumentMap,
+  ): void {
+    if (!this.#modelFieldMaps.has(modelName)) {
+      this.#modelFieldMaps.set(modelName, new ModelFieldMap());
+    }
+
+    this.#modelFieldMaps.get(modelName)!.addField(fieldName, type, isOptional, isList, args);
+  }
+
+  /**
+   * Add an interface to a model
+   */
+  addInterface(modelName: string, interfaceType: GraphQLInterfaceType): void {
+    if (!this.#interfacesMap.has(modelName)) {
+      this.#interfacesMap.set(modelName, []);
+    }
+    this.#interfacesMap.get(modelName)!.push(interfaceType);
+  }
+
+  /**
+   * Get interfaces for a model
+   */
+  getInterfaces(modelName: string): GraphQLInterfaceType[] {
+    return this.#interfacesMap.get(modelName) || [];
+  }
+
+  /**
+   * Check if a model has any fields
+   */
+  hasFields(modelName: string): boolean {
+    const fieldMap = this.#modelFieldMaps.get(modelName);
+    return fieldMap ? fieldMap.getFieldThunks().size > 0 : false;
+  }
+
+  /**
+   * Get the materialized GraphQL type, but only if it has fields
+   * @param name - The type name as a TypeKey
+   * @returns The materialized GraphQL type or undefined
+   */
+  override get(name: TypeKey): GraphQLObjectType | undefined {
+    // Return already materialized type if available
+    if (this.materializedMap.has(name)) {
+      return this.materializedMap.get(name);
+    }
+
+    // Check if the model has fields before attempting to materialize
+    // GraphQL requires object types to have at least one field
+    if (!this.hasFields(name)) {
+      return undefined;
+    }
+
+    // Attempt to materialize if registered
+    const context = this.registrationMap.get(name);
+    if (context) {
+      const materializedType = this.materialize(context);
+      this.materializedMap.set(name, materializedType);
+      return materializedType;
+    }
+
+    return undefined;
+  }
+
+  /**
+   * Materialize a GraphQL object type
+   */
+  protected override materialize(context: TSPContext<Model>): GraphQLObjectType {
+    const modelName = this.getNameFromContext(context);
+
+    return new GraphQLObjectType({
+      name: modelName,
+      fields: () => this.#materializeFields(modelName),
+      interfaces: () => this.getInterfaces(modelName),
+    });
+  }
+
+  /**
+   * Materialize fields for a model
+   */
+  #materializeFields(modelName: string): GraphQLFieldConfigMap<any, any> {
+    const fieldMap = this.#modelFieldMaps.get(modelName);
+    if (!fieldMap) {
+      return {};
+    }
+
+    const result: GraphQLFieldConfigMap<any, any> = {};
+    const fieldThunks = fieldMap.getFieldThunks();
+
+    fieldThunks.forEach((config, fieldName) => {
+      let fieldType = config.type() as GraphQLOutputType;
+
+      if (fieldType instanceof GraphQLInputObjectType) {
+        throw new Error(
+          `Model "${modelName}" has a field "${fieldName}" that is an input type. It should be an output type.`,
+        );
+      }
+
+      if (!config.isOptional) {
+        fieldType = new GraphQLNonNull(fieldType);
+      }
+
+      if (config.isList) {
+        fieldType = new GraphQLNonNull(new GraphQLList(fieldType));
+      }
+
+      result[fieldName] = {
+        type: fieldType,
+        args: config.args ? config.args() : undefined,
+      };
+    });
+
+    return result;
+  }
 }

--- a/packages/graphql/test/emitter.test.ts
+++ b/packages/graphql/test/emitter.test.ts
@@ -4,7 +4,19 @@ import { emitSingleSchema } from "./test-host.js";
 
 // For now, the expected output is a placeholder string.
 // In the future, this should be replaced with the actual GraphQL schema output.
-const expectedGraphQLSchema = `type Query {
+const expectedGraphQLSchema = `type Book {
+  name: String!
+  page_count: Int!
+  published: Boolean!
+  price: Float!
+}
+
+type Author {
+  name: String!
+  books: [Book!]!
+}
+
+type Query {
   """
   A placeholder field. If you are seeing this, it means no operations were defined that could be emitted.
   """

--- a/packages/graphql/test/main.tsp
+++ b/packages/graphql/test/main.tsp
@@ -8,6 +8,7 @@ namespace MyLibrary {
     title: string;
     publicationDate: string;
     author: Author;
+    price: float32;
   }
 
   model Author {
@@ -16,6 +17,7 @@ namespace MyLibrary {
     bio?: string;
     books: Book[];
     friend: Author;
+    age: int32;
   }
   
   enum Genre {

--- a/packages/graphql/test/schema.test.ts
+++ b/packages/graphql/test/schema.test.ts
@@ -2,6 +2,7 @@ import type { Namespace } from "@typespec/compiler";
 import { expectDiagnosticEmpty } from "@typespec/compiler/testing";
 import { describe, expect, it } from "vitest";
 import { getSchema } from "../src/lib/schema.js";
+import { GraphQLTypeRegistry } from "../src/registry.js";
 import { compileAndDiagnose } from "./test-host.js";
 
 describe("@schema", () => {
@@ -33,5 +34,66 @@ describe("@schema", () => {
 
     expect(schema?.type).toBe(TestNamespace);
     expect(schema?.name).toBe("MySchema");
+  });
+});
+
+describe("GraphQLTypeRegistry - Collision Detection", () => {
+  // Mock a basic TypeSpec Model for testing
+  function createMockModel(name: string): any {
+    return {
+      kind: "Model",
+      name,
+      properties: new Map(),
+      baseModel: undefined,
+      derivedModels: [],
+      decorators: [],
+      namespace: undefined,
+      node: undefined,
+      indexer: undefined,
+      sourceModel: undefined,
+    };
+  }
+
+  // Mock a basic TypeSpec Program for testing
+  function createMockProgram(): any {
+    return {
+      checker: {
+        getStdType: (name: string) => ({ kind: "Scalar", name }),
+      },
+    };
+  }
+
+  it("should prevent registering models with duplicate names", () => {
+    // Reset global registry before test
+    GraphQLTypeRegistry.resetGlobalRegistry();
+    
+    const program = createMockProgram();
+    const registry = new GraphQLTypeRegistry(program);
+
+    const model1 = createMockModel("User");
+    const model2 = createMockModel("User"); // Same name
+
+    // First registration should succeed
+    expect(() => registry.addModel(model1)).not.toThrow();
+
+    // Second registration with same name should fail
+    expect(() => registry.addModel(model2)).toThrow(
+      "GraphQL type name 'User' is already registered. Type names must be unique across the entire schema.",
+    );
+  });
+
+  it("should allow registering models with different names", () => {
+    // Reset global registry before test  
+    GraphQLTypeRegistry.resetGlobalRegistry();
+    
+    const program = createMockProgram();
+    const registry = new GraphQLTypeRegistry(program); // Fresh registry instance
+
+    const user = createMockModel("User");
+    const book = createMockModel("Book");
+
+    // Both registrations should succeed
+    expect(() => registry.addModel(user)).not.toThrow();
+    expect(() => registry.addModel(book)).not.toThrow();
   });
 });


### PR DESCRIPTION
# Summary

This PR adds:
* Basic handling for emitting `GraphQLObjectTypes` from TSP `Models` using the `TypeMap` abstract class
* Mapping function TSP -> GraphQL built-in scalars
* Tests to check for name collisions
* Updates to use [JavaScript's `#private` properties](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes/Private_properties)

## Coming Soon in a Followup PR Near You
* TSP `Model`s -> `GraphQLInputType`s