### PR TITLE
Add GraphQLTSPDenormalizer to GraphQL Emitter

### DIFF
--- a/packages/graphql/src/denormalization.ts
+++ b/packages/graphql/src/denormalization.ts
@@ -1,4 +1,4 @@
-import type { Model, ModelProperty, Namespace } from "@typespec/compiler";
+import type { Model, ModelProperty, Namespace, Type } from "@typespec/compiler";
 import { UsageFlags, resolveUsages, type EmitContext, type UsageTracker } from "@typespec/compiler";
 import { $ } from "@typespec/compiler/typekit";
 
@@ -15,9 +15,9 @@ import { $ } from "@typespec/compiler/typekit";
 export class GraphQLTSPDenormalizer {
   private usageTracker: UsageTracker;
   private namespace: Namespace;
-  private context: EmitContext<any>;
+  private context: EmitContext<Record<string, never>>;
 
-  constructor(namespace: Namespace, context: EmitContext<any>) {
+  constructor(namespace: Namespace, context: EmitContext<Record<string, never>>) {
     this.namespace = namespace;
     this.context = context;
     this.usageTracker = resolveUsages(namespace);
@@ -44,11 +44,11 @@ export class GraphQLTSPDenormalizer {
       throw new Error(`Model name collision: ${inputName} already exists in namespace.`);
     }
     // Recursively transform nested model types to their input variants
-    const getInputType = (type: any): any => {
+    const getInputType = (type: Type): Type => {
       if (type.kind === "Model" && this.usageTracker.isUsedAs(type, UsageFlags.Input)) {
         const nestedInputName = type.name + "Input";
         if (this.namespace.models.has(nestedInputName)) {
-          return this.namespace.models.get(nestedInputName);
+          return this.namespace.models.get(nestedInputName)!;
         }
         
         // Create placeholder model first to prevent recursive creation
@@ -105,7 +105,7 @@ export class GraphQLTSPDenormalizer {
   private createInputModelVariant(
     outputModel: Model,
     typekit: ReturnType<typeof $>,
-    getInputType: (type: any) => any,
+    getInputType: (type: Type) => Type,
   ): Model {
     const inputProperties: Record<string, ModelProperty> = {};
     for (const [name, prop] of outputModel.properties) {

--- a/packages/graphql/src/denormalization.ts
+++ b/packages/graphql/src/denormalization.ts
@@ -1,0 +1,136 @@
+import type { Model, ModelProperty, Namespace } from "@typespec/compiler";
+import { UsageFlags, type EmitContext, type UsageTracker } from "@typespec/compiler";
+import { $ } from "@typespec/compiler/typekit";
+
+/**
+ * Provides utilities to denormalize TypeSpec (TSP) model types for GraphQL emitters.
+ *
+ * This class analyzes model usage and creates GraphQL-compliant input model variants
+ * (e.g., FooInput) for models used as input types. It mutates the provided namespace
+ * in-place, recursively denormalizing nested model properties as needed.
+ *
+ * Name collisions will throw a JavaScript Error (consider using TypeSpec diagnostics in the future).
+ * Optionally, a debug flag will print a mapping of original models to their denormalized variants.
+ *
+ * Example usage:
+ * ```typescript
+ * const usageTracker = resolveUsages(namespace);
+ * GraphQLDenormalizer.denormalize(namespace, usageTracker, context, true); // debug output enabled
+ * ```
+ */
+export class GraphQLDenormalizer {
+  /**
+   * Denormalizes TSP model types for GraphQL input usage.
+   *
+   * - Mutates the provided namespace in-place.
+   * - Recursively creates input model variants (e.g., FooInput) for models used as input types.
+   * - Throws a JavaScript Error for name collisions (TODO: use TypeSpec diagnostics).
+   * - Optionally logs a debug mapping of original models to their denormalized variants.
+   *
+   * @param namespace The TypeSpec namespace to mutate.
+   * @param usageTracker UsageTracker for determining input usage.
+   * @param context The TypeSpec emit context.
+   * @param debug If true, logs a mapping of original to denormalized models.
+   */
+  static denormalize(
+    namespace: Namespace,
+    usageTracker: UsageTracker,
+    context: EmitContext<any>,
+    debug: boolean = false,
+  ): void {
+    if (debug) {
+      // eslint-disable-next-line no-console
+      console.log(`[GraphQLDenormalizer] Starting denormalization for namespace: ${namespace.name}`);
+    }
+    for (const [_, model] of namespace.models) {
+      this.expandInputOutputTypes(model, usageTracker, context, namespace, debug);
+      // ...other steps will be called here in the future...
+    }
+  }
+
+  /**
+   * Expands input/output types by creating GraphQL-compliant input model variants (e.g., FooInput)
+   * for models used as input types. Mutates the namespace in-place.
+   * Throws on name collisions. Debug output prints mapping from TSP Model to TSP Model variants.
+   */
+  public static expandInputOutputTypes(
+    model: Model,
+    usageTracker: UsageTracker,
+    context: EmitContext<any>,
+    namespace: Namespace,
+    debug: boolean
+  ) {
+    const typekit = $(context.program);
+    // Only process if this model is used as input
+    if (!usageTracker.isUsedAs(model, UsageFlags.Input)) return;
+    const inputName = model.name + "Input";
+    if (namespace.models.has(inputName)) {
+      throw new Error(`Model name collision: ${inputName} already exists in namespace.`);
+    }
+    // Helper to recursively denormalize nested model properties
+    function getInputType(type: any): any {
+      if (type.kind === "Model" && usageTracker.isUsedAs(type, UsageFlags.Input)) {
+        const nestedInputName = type.name + "Input";
+        if (namespace.models.has(nestedInputName)) {
+          return namespace.models.get(nestedInputName);
+        }
+        const inputModel = GraphQLDenormalizer.createInputModelVariant(type, typekit, getInputType);
+        if (namespace.models.has(nestedInputName)) {
+          throw new Error(`Model name collision: ${nestedInputName} already exists in namespace.`);
+        }
+        namespace.models.set(nestedInputName, inputModel);
+        if (debug) {
+          // eslint-disable-next-line no-console
+          console.log(`[GraphQLDenormalizer] Created input model: ${type.name} -> ${nestedInputName}`);
+        }
+        return inputModel;
+      }
+      return type;
+    }
+    const inputModel = GraphQLDenormalizer.createInputModelVariant(model, typekit, getInputType);
+    namespace.models.set(inputName, inputModel);
+    if (debug) {
+      // eslint-disable-next-line no-console
+      console.log(`[GraphQLDenormalizer] Created input model: ${model.name} -> ${inputName}`);
+    }
+  }
+
+  /**
+   * Creates an input model variant from an output model.
+   * Recursively transforms nested model types to their input variants using getInputType.
+   */
+  public static createInputModelVariant(
+    outputModel: Model,
+    typekit: ReturnType<typeof $>,
+    getInputType: (type: any) => any,
+  ): Model {
+    const inputProperties: Record<string, ModelProperty> = {};
+    for (const [name, prop] of outputModel.properties) {
+      inputProperties[name] = typekit.modelProperty.create({
+        name: prop.name,
+        type: getInputType(prop.type),
+        optional: prop.optional,
+      });
+    }
+    const inputModel = typekit.model.create({
+      name: outputModel.name + "Input",
+      properties: inputProperties,
+    });
+    for (const [_, prop] of inputModel.properties) {
+      (prop as any).model = inputModel;
+    }
+    return inputModel;
+  }
+
+  // --- Stubs for future denormalization steps ---
+  public static resolveDecorators(model: Model, context: EmitContext<any>, debug: boolean) {}
+  public static renameIdentifiers(model: Model, context: EmitContext<any>, debug: boolean) {}
+  public static transformBasicTypes(model: Model, context: EmitContext<any>, debug: boolean) {}
+  public static transformIntrinsicTypes(model: Model, context: EmitContext<any>, debug: boolean) {}
+  public static transformRecordTypes(model: Model, context: EmitContext<any>, debug: boolean) {}
+  public static deanonymizeUnions(model: Model, context: EmitContext<any>, debug: boolean) {}
+  public static materializeRootOperationTypes(model: Model, context: EmitContext<any>, debug: boolean) {}
+  public static resolveSubschemaSelection(model: Model, context: EmitContext<any>, debug: boolean) {}
+  public static makeFieldsOptionalByDefault(model: Model, context: EmitContext<any>, debug: boolean) {}
+  public static removeNullFromUnions(model: Model, context: EmitContext<any>, debug: boolean) {}
+}

--- a/packages/graphql/src/denormalization.ts
+++ b/packages/graphql/src/denormalization.ts
@@ -4,12 +4,6 @@ import { $ } from "@typespec/compiler/typekit";
 
 /**
  * Provides utilities to denormalize TypeSpec (TSP) model types for GraphQL emitters.
- *
- * This class analyzes model usage and creates GraphQL-compliant input model variants
- * (e.g., FooInput) for models used as input types. It mutates the provided namespace
- * in-place, recursively denormalizing nested model properties as needed.
- *
- * Name collisions will throw a JavaScript Error (consider using TypeSpec diagnostics in the future).
  * Optionally, a debug flag will print a mapping of original models to their denormalized variants.
  *
  * Example usage:
@@ -22,11 +16,6 @@ export class GraphQLDenormalizer {
   /**
    * Denormalizes TSP model types for GraphQL input usage.
    *
-   * - Mutates the provided namespace in-place.
-   * - Recursively creates input model variants (e.g., FooInput) for models used as input types.
-   * - Throws a JavaScript Error for name collisions (TODO: use TypeSpec diagnostics).
-   * - Optionally logs a debug mapping of original models to their denormalized variants.
-   *
    * @param namespace The TypeSpec namespace to mutate.
    * @param usageTracker UsageTracker for determining input usage.
    * @param context The TypeSpec emit context.
@@ -38,19 +27,16 @@ export class GraphQLDenormalizer {
     context: EmitContext<any>,
     debug: boolean = false,
   ): void {
-    if (debug) {
-      // eslint-disable-next-line no-console
-      console.log(`[GraphQLDenormalizer] Starting denormalization for namespace: ${namespace.name}`);
-    }
     for (const [_, model] of namespace.models) {
       this.expandInputOutputTypes(model, usageTracker, context, namespace, debug);
-      // ...other steps will be called here in the future...
+    // TODO: Call methods for additional denormalization steps such as resolving decorators, de-anonymizing unions, etc.
+
     }
   }
 
   /**
    * Expands input/output types by creating GraphQL-compliant input model variants (e.g., FooInput)
-   * for models used as input types. Mutates the namespace in-place.
+   * for models used as input types. Mutates the TypeSpec namespace in-place.
    * Throws on name collisions. Debug output prints mapping from TSP Model to TSP Model variants.
    */
   public static expandInputOutputTypes(
@@ -122,15 +108,5 @@ export class GraphQLDenormalizer {
     return inputModel;
   }
 
-  // --- Stubs for future denormalization steps ---
-  public static resolveDecorators(model: Model, context: EmitContext<any>, debug: boolean) {}
-  public static renameIdentifiers(model: Model, context: EmitContext<any>, debug: boolean) {}
-  public static transformBasicTypes(model: Model, context: EmitContext<any>, debug: boolean) {}
-  public static transformIntrinsicTypes(model: Model, context: EmitContext<any>, debug: boolean) {}
-  public static transformRecordTypes(model: Model, context: EmitContext<any>, debug: boolean) {}
-  public static deanonymizeUnions(model: Model, context: EmitContext<any>, debug: boolean) {}
-  public static materializeRootOperationTypes(model: Model, context: EmitContext<any>, debug: boolean) {}
-  public static resolveSubschemaSelection(model: Model, context: EmitContext<any>, debug: boolean) {}
-  public static makeFieldsOptionalByDefault(model: Model, context: EmitContext<any>, debug: boolean) {}
-  public static removeNullFromUnions(model: Model, context: EmitContext<any>, debug: boolean) {}
+  // TODO: Add methods for additional denormalization steps such as resolving decorators, de-anonymizing unions, etc.
 }

--- a/packages/graphql/test/denormalization.test.ts
+++ b/packages/graphql/test/denormalization.test.ts
@@ -1,0 +1,364 @@
+import type { Model, Namespace } from "@typespec/compiler";
+import { UsageFlags } from "@typespec/compiler";
+import { expectDiagnosticEmpty } from "@typespec/compiler/testing";
+import { describe, expect, it } from "vitest";
+import { GraphQLDenormalizer } from "../src/denormalization.js";
+import { compileAndDiagnose } from "./test-host.js";
+
+describe("GraphQLDenormalizer", () => {
+  describe("expandInputOutputTypes", () => {
+    it("should create input model variant for models used as input", async () => {
+      const [program, { TestNamespace }, diagnostics] = await compileAndDiagnose<{
+        TestNamespace: Namespace;
+      }>(`
+        @test namespace TestNamespace {
+          model User {
+            name: string;
+            age: int32;
+          }
+        }
+      `);
+      expectDiagnosticEmpty(diagnostics);
+      
+      // Create a mock usage tracker that marks User as used for input
+      const mockUsageTracker = {
+        isUsedAs: (model: Model, flag: UsageFlags) => {
+          if (model.name === "User" && flag === UsageFlags.Input) {
+            return true;
+          }
+          return false;
+        }
+      };
+      
+      const userModel = TestNamespace.models.get("User")!;
+      expect(userModel).toBeDefined();
+      expect(TestNamespace.models.has("UserInput")).toBe(false);
+      
+      // Run denormalization
+      GraphQLDenormalizer.expandInputOutputTypes(
+        userModel,
+        mockUsageTracker as any,
+        { program } as any,
+        TestNamespace,
+        false // no debug output
+      );
+      
+      // Check that UserInput was created
+      expect(TestNamespace.models.has("UserInput")).toBe(true);
+      const userInputModel = TestNamespace.models.get("UserInput")!;
+      expect(userInputModel.name).toBe("UserInput");
+      expect(userInputModel.properties.size).toBe(2);
+      expect(userInputModel.properties.has("name")).toBe(true);
+      expect(userInputModel.properties.has("age")).toBe(true);
+    });
+
+    it("should skip models not used as input", async () => {
+      const [program, { TestNamespace }, diagnostics] = await compileAndDiagnose<{
+        TestNamespace: Namespace;
+      }>(`
+        @test namespace TestNamespace {
+          model User {
+            name: string;
+            age: int32;
+          }
+        }
+      `);
+      expectDiagnosticEmpty(diagnostics);
+      
+      // Create a mock usage tracker that does NOT mark User as used for input
+      const mockUsageTracker = {
+        isUsedAs: (model: Model, flag: UsageFlags) => {
+          return false; // User is not used as input
+        }
+      };
+      
+      const userModel = TestNamespace.models.get("User")!;
+      expect(userModel).toBeDefined();
+      expect(TestNamespace.models.has("UserInput")).toBe(false);
+      
+      // Run denormalization
+      GraphQLDenormalizer.expandInputOutputTypes(
+        userModel,
+        mockUsageTracker as any,
+        { program } as any,
+        TestNamespace,
+        false
+      );
+      
+      // Check that UserInput was NOT created
+      expect(TestNamespace.models.has("UserInput")).toBe(false);
+    });
+
+    it("should handle recursive denormalization of nested models", async () => {
+      const [program, { TestNamespace }, diagnostics] = await compileAndDiagnose<{
+        TestNamespace: Namespace;
+      }>(`
+        @test namespace TestNamespace {
+          model Address {
+            street: string;
+            city: string;
+          }
+          
+          model User {
+            name: string;
+            address: Address;
+          }
+        }
+      `);
+      expectDiagnosticEmpty(diagnostics);
+      
+      // Create a mock usage tracker that marks both User and Address as used for input
+      const mockUsageTracker = {
+        isUsedAs: (model: Model, flag: UsageFlags) => {
+          if (flag === UsageFlags.Input && (model.name === "User" || model.name === "Address")) {
+            return true;
+          }
+          return false;
+        }
+      };
+      
+      const userModel = TestNamespace.models.get("User")!;
+      const addressModel = TestNamespace.models.get("Address")!;
+      expect(userModel).toBeDefined();
+      expect(addressModel).toBeDefined();
+      expect(TestNamespace.models.has("UserInput")).toBe(false);
+      expect(TestNamespace.models.has("AddressInput")).toBe(false);
+      
+      // Run denormalization on User (should recursively handle Address)
+      GraphQLDenormalizer.expandInputOutputTypes(
+        userModel,
+        mockUsageTracker as any,
+        { program } as any,
+        TestNamespace,
+        false
+      );
+      
+      // Check that both UserInput and AddressInput were created
+      expect(TestNamespace.models.has("UserInput")).toBe(true);
+      expect(TestNamespace.models.has("AddressInput")).toBe(true);
+      
+      const userInputModel = TestNamespace.models.get("UserInput")!;
+      const addressInputModel = TestNamespace.models.get("AddressInput")!;
+      
+      // Verify UserInput has correct properties
+      expect(userInputModel.name).toBe("UserInput");
+      expect(userInputModel.properties.size).toBe(2);
+      expect(userInputModel.properties.has("name")).toBe(true);
+      expect(userInputModel.properties.has("address")).toBe(true);
+      
+      // Verify AddressInput has correct properties
+      expect(addressInputModel.name).toBe("AddressInput");
+      expect(addressInputModel.properties.size).toBe(2);
+      expect(addressInputModel.properties.has("street")).toBe(true);
+      expect(addressInputModel.properties.has("city")).toBe(true);
+    });
+
+    it("should throw error on name collision", async () => {
+      const [program, { TestNamespace }, diagnostics] = await compileAndDiagnose<{
+        TestNamespace: Namespace;
+      }>(`
+        @test namespace TestNamespace {
+          model User {
+            name: string;
+          }
+          
+          model UserInput {
+            name: string;
+          }
+        }
+      `);
+      expectDiagnosticEmpty(diagnostics);
+      
+      // Create a mock usage tracker that marks User as used for input
+      const mockUsageTracker = {
+        isUsedAs: (model: Model, flag: UsageFlags) => {
+          if (model.name === "User" && flag === UsageFlags.Input) {
+            return true;
+          }
+          return false;
+        }
+      };
+      
+      const userModel = TestNamespace.models.get("User")!;
+      expect(userModel).toBeDefined();
+      expect(TestNamespace.models.has("UserInput")).toBe(true); // Already exists
+      
+      // Run denormalization - should throw error due to name collision
+      expect(() => {
+        GraphQLDenormalizer.expandInputOutputTypes(
+          userModel,
+          mockUsageTracker as any,
+          { program } as any,
+          TestNamespace,
+          false
+        );
+      }).toThrow("Model name collision: UserInput already exists in namespace.");
+    });
+
+    it("should handle models with optional properties", async () => {
+      const [program, { TestNamespace }, diagnostics] = await compileAndDiagnose<{
+        TestNamespace: Namespace;
+      }>(`
+        @test namespace TestNamespace {
+          model User {
+            name: string;
+            email?: string;
+            age?: int32;
+          }
+        }
+      `);
+      expectDiagnosticEmpty(diagnostics);
+      
+      // Create a mock usage tracker that marks User as used for input
+      const mockUsageTracker = {
+        isUsedAs: (model: Model, flag: UsageFlags) => {
+          if (model.name === "User" && flag === UsageFlags.Input) {
+            return true;
+          }
+          return false;
+        }
+      };
+      
+      const userModel = TestNamespace.models.get("User")!;
+      expect(userModel).toBeDefined();
+      
+      // Run denormalization
+      GraphQLDenormalizer.expandInputOutputTypes(
+        userModel,
+        mockUsageTracker as any,
+        { program } as any,
+        TestNamespace,
+        false
+      );
+      
+      // Check that UserInput was created with correct optional properties
+      expect(TestNamespace.models.has("UserInput")).toBe(true);
+      const userInputModel = TestNamespace.models.get("UserInput")!;
+      
+      expect(userInputModel.name).toBe("UserInput");
+      expect(userInputModel.properties.size).toBe(3);
+      
+      const nameProperty = userInputModel.properties.get("name")!;
+      const emailProperty = userInputModel.properties.get("email")!;
+      const ageProperty = userInputModel.properties.get("age")!;
+      
+      expect(nameProperty.optional).toBe(false);
+      expect(emailProperty.optional).toBe(true);
+      expect(ageProperty.optional).toBe(true);
+    });
+  });
+
+  describe("denormalize", () => {
+    it("should denormalize all models in namespace that are used as input", async () => {
+      const [program, { TestNamespace }, diagnostics] = await compileAndDiagnose<{
+        TestNamespace: Namespace;
+      }>(`
+        @test namespace TestNamespace {
+          model User {
+            name: string;
+            age: int32;
+          }
+          
+          model Book {
+            title: string;
+            author: string;
+          }
+          
+          model ReadOnlyModel {
+            id: string;
+          }
+        }
+      `);
+      expectDiagnosticEmpty(diagnostics);
+      
+      // Create a mock usage tracker
+      const mockUsageTracker = {
+        isUsedAs: (model: Model, flag: UsageFlags) => {
+          if (flag === UsageFlags.Input && (model.name === "User" || model.name === "Book")) {
+            return true;
+          }
+          return false;
+        }
+      };
+      
+      expect(TestNamespace.models.has("UserInput")).toBe(false);
+      expect(TestNamespace.models.has("BookInput")).toBe(false);
+      expect(TestNamespace.models.has("ReadOnlyModelInput")).toBe(false);
+      
+      // Run denormalization
+      GraphQLDenormalizer.denormalize(
+        TestNamespace,
+        mockUsageTracker as any,
+        { program } as any,
+        false // no debug output
+      );
+      
+      // Check that input models were created for User and Book, but not ReadOnlyModel
+      expect(TestNamespace.models.has("UserInput")).toBe(true);
+      expect(TestNamespace.models.has("BookInput")).toBe(true);
+      expect(TestNamespace.models.has("ReadOnlyModelInput")).toBe(false);
+      
+      const userInputModel = TestNamespace.models.get("UserInput")!;
+      const bookInputModel = TestNamespace.models.get("BookInput")!;
+      
+      expect(userInputModel.name).toBe("UserInput");
+      expect(userInputModel.properties.size).toBe(2);
+      
+      expect(bookInputModel.name).toBe("BookInput");
+      expect(bookInputModel.properties.size).toBe(2);
+    });
+  });
+
+  describe("createInputModelVariant", () => {
+    it("should create input model variant with correct properties", async () => {
+      const [program, { TestNamespace }, diagnostics] = await compileAndDiagnose<{
+        TestNamespace: Namespace;
+      }>(`
+        @test namespace TestNamespace {
+          model User {
+            name: string;
+            age: int32;
+            active: boolean;
+          }
+        }
+      `);
+      expectDiagnosticEmpty(diagnostics);
+      
+      const userModel = TestNamespace.models.get("User")!;
+      expect(userModel).toBeDefined();
+      
+      // Mock typekit
+      const mockTypekit = {
+        modelProperty: {
+          create: (props: any) => ({
+            name: props.name,
+            type: props.type,
+            optional: props.optional,
+          }),
+        },
+        model: {
+          create: (props: any) => ({
+            name: props.name,
+            properties: new Map(Object.entries(props.properties)),
+          }),
+        },
+      };
+      
+      // Mock getInputType function
+      const getInputType = (type: any) => type;
+      
+      // Create input model variant
+      const inputModel = GraphQLDenormalizer.createInputModelVariant(
+        userModel,
+        mockTypekit as any,
+        getInputType
+      );
+      
+      expect(inputModel.name).toBe("UserInput");
+      expect(inputModel.properties.size).toBe(3);
+      expect(inputModel.properties.has("name")).toBe(true);
+      expect(inputModel.properties.has("age")).toBe(true);
+      expect(inputModel.properties.has("active")).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
# Overview
This PR adds a new `GraphQLTSPDenormalizer` class that is responsible for handling the denormalization of a TSP namespace for GraphQL purposes. The `GraphQLTSPDenormalizer` is essentially a preprocessing step that transforms the TypeSpec types into a more GraphQL friendly shape.

The resulting TypeSpec denormalized for GraphQL can then be used as input for multiple different emitters that are related to GraphQL for example:
- GraphQL Schema Emitter: Which would emit a GraphQL schema based on the denormalized TSP
- Python Emitter: Which could emit Python server code based on the denormalized TSP

This unified denormalization approach allows us to reuse transformation logic and ensure consistency across emitters working in the same domain (in our case GraphQL).

This PR focuses on only the first denormalization step, creating input specific types for models used as inputs to operations. 

# Example
### TypeSpec Input
```TSP
        namespace TestNamespace {
          model Address {
            street: string;
            city: string;
          }
          
          model User {
            name: string;
            homeAddress: Address;
            workAddress: Address;
          }
          
          op CreateUser(user: User): User;
        }
```

### TypeSpec Output
```TSP
        namespace TestNamespace {
          model Address {
            street: string;
            city: string;
          }

          model AddressInput {
            street: string;
            city: string;
          }
          
          model User {
            name: string;
            homeAddress: Address;
            workAddress: Address;
          }

          model UserInput {
            name: string;
            homeAddress: AddressInput;
            workAddress: AddressInput;
          }
          
          op CreateUser(user: UserInput): User;
        }
```

# Following Work
The following GraphQL normalization steps will be addressed subsequently: 
* Resolve [model property error handling](https://github.com/microsoft/typespec/issues/7596) and related GraphQL decorators
* Rename identifiers to comply with GraphQL naming rules
* Transform basic types into scalars
* Transform intrinsic types
* Transform record types
* De-anonymize unions
* Materialize implicit Query/Mutation/Subscription types
* Resolve sub-schema selection (duplicate types into every schema/namespace that uses them)
* Remove null types from unions
