### PR TITLE
Add Atom

### DIFF
--- a/packages/emitter-framework/CHANGELOG.md
+++ b/packages/emitter-framework/CHANGELOG.md
@@ -17,7 +17,6 @@
 
 - [#7650](https://github.com/microsoft/typespec/pull/7650) Adds subpath export for csharp emitter-framework components
 
-
 ## 0.8.0
 
 ### Features
@@ -32,7 +31,6 @@
 
 - [#7369](https://github.com/microsoft/typespec/pull/7369) Render discriminated unions correctly
 
-
 ## 0.7.1
 
 ### Bump dependencies
@@ -43,13 +41,11 @@
 
 - [#7321](https://github.com/microsoft/typespec/pull/7321) Use wasm version of tree sitter for snippet extractor
 
-
 ## 0.7.0
 
 ### Bump dependencies
 
 - [#7186](https://github.com/microsoft/typespec/pull/7186) Upgrade to alloy 15
-
 
 ## 0.6.0
 
@@ -57,7 +53,7 @@
 
 - [#7017](https://github.com/microsoft/typespec/pull/7017) [TypeScript] Add various function-related components - FunctionType, FunctionExpression, ArrowFunction, and InterfaceMethod.
 - [#6972](https://github.com/microsoft/typespec/pull/6972) Add support for rendering a Value Expression
-- [#7018](https://github.com/microsoft/typespec/pull/7018) Adds the `TspContextProvider` and `useTsp()` hook for providing and accessing TypeSpec context and the Typekit APIs (e.g. `# Changelog - @typespec/emitter-framework). Adds a new `Output` component that accepts a TypeSpec `Program` and automatically wraps children components with the `TspContextProvider`.
+- [#7018](https://github.com/microsoft/typespec/pull/7018) Adds the `TspContextProvider` and `useTsp()` hook for providing and accessing TypeSpec context and the Typekit APIs (e.g. `# Changelog - @typespec/emitter-framework). Adds a new `Output`component that accepts a TypeSpec`Program`and automatically wraps children components with the`TspContextProvider`.
 
 ### Bump dependencies
 
@@ -67,20 +63,17 @@
 
 - [#6951](https://github.com/microsoft/typespec/pull/6951) InterfaceMember should use Alloy
 
-
 ## 0.5.0
 
 ### Features
 
 - [#6875](https://github.com/microsoft/typespec/pull/6875) Upgrade to alloy 0.10.0
 
-
 ## 0.4.0
 
 ### Bump dependencies
 
 - [#6595](https://github.com/microsoft/typespec/pull/6595) Upgrade dependencies
-
 
 ## 0.3.0
 
@@ -93,12 +86,8 @@
 - [#6178](https://github.com/microsoft/typespec/pull/6178) Improvements on the TestHarness
 - [#6460](https://github.com/microsoft/typespec/pull/6460) Update dependency structure for EmitterFramework, HttpClient and JS Emitter
 
-
-
-
 ## 0.2.0
 
 ### Features
 
 - [#5996](https://github.com/microsoft/typespec/pull/5996) Adding Emitter Framework and Http Client packages
-

--- a/packages/emitter-framework/src/python/components/atom/atom.test.tsx
+++ b/packages/emitter-framework/src/python/components/atom/atom.test.tsx
@@ -1,11 +1,10 @@
 import { Output } from "@alloy-js/core";
 import { SourceFile } from "@alloy-js/python";
-import { Numeric, type EnumValue, type Model, type Namespace, type NullType, type NullValue, type NumericValue, type Program, type Value } from "@typespec/compiler";
+import { type Model, type Namespace, type Program, type Value } from "@typespec/compiler";
 import { $ } from "@typespec/compiler/typekit";
 import { assert, beforeAll, describe, expect, it } from "vitest";
 import { Atom } from "../../index.js";
 import { getProgram } from "../../test-host.js";
-import { dedent } from "@alloy-js/core/testing";
 
 let program: Program;
 beforeAll(async () => {
@@ -14,13 +13,7 @@ beforeAll(async () => {
 
 describe("NullValue", () => {
   it("null value", async () => {
-    const value = {
-      entityKind: "Value",
-      valueKind: "NullValue",
-      value: null,
-      type: $(program).intrinsic.null,
-      scalar: undefined,
-    } as NullValue;
+    const value = { entityKind: "Value", valueKind: "NullValue", value: null } as Value;
 
     await testValueExpression(value, `None`);
   });
@@ -116,7 +109,10 @@ describe("ScalarValue", () => {
     const dateRange = (namespace as Namespace).models.get("DateRange");
     const minDate = dateRange?.properties.get("minDate")?.defaultValue;
     assert.exists(minDate, "unable to find minDate property");
-    await testValueExpression(minDate, `"datetime.datetime(2024, 2, 15, 18, 36, 3, tzinfo=datetime.timezone.utc)"`);
+    await testValueExpression(
+      minDate,
+      `"datetime.datetime(2024, 2, 15, 18, 36, 3, tzinfo=datetime.timezone.utc)"`,
+    );
   });
 
   it("Unsupported scalar constructor", async () => {
@@ -179,42 +175,42 @@ describe("ObjectValue", () => {
   });
 });
 
-describe("EnumValue", () => {
-  it("different EnumValue types", async () => {
-    // Can be replaced with with TypeKit once #6976 is implemented
-    const program = await getProgram(`
-        namespace DemoService;
-        enum Color {
-          Red,
-          Green: 3,
-          Blue
-        }
-      `);
-    const [namespace] = program.resolveTypeReference("DemoService");
-    const colors = (namespace as Namespace).enums.get("Color");
-    assert.exists(colors, "unable to find Color enum");
+// describe("EnumValue", () => {
+//   it("different EnumValue types", async () => {
+//     // Can be replaced with with TypeKit once #6976 is implemented
+//     const program = await getProgram(`
+//         namespace DemoService;
+//         enum Color {
+//           Red,
+//           Green: 3,
+//           Blue
+//         }
+//       `);
+//     const [namespace] = program.resolveTypeReference("DemoService");
+//     const colors = (namespace as Namespace).enums.get("Color");
+//     assert.exists(colors, "unable to find Color enum");
 
-    const red = colors?.members.get("Red");
-    assert.exists(red, "unable to find Red enum member");
-    await testValueExpression(
-      {
-        valueKind: "EnumValue",
-        value: red,
-      } as EnumValue,
-      `"Red"`,
-    );
+//     const red = colors?.members.get("Red");
+//     assert.exists(red, "unable to find Red enum member");
+//     await testValueExpression(
+//       {
+//         valueKind: "EnumValue",
+//         value: red,
+//       } as EnumValue,
+//       `"Red"`,
+//     );
 
-    const green = colors?.members.get("Green");
-    assert.exists(green, "unable to find Green enum member");
-    await testValueExpression(
-      {
-        valueKind: "EnumValue",
-        value: green,
-      } as EnumValue,
-      `3`,
-    );
-  });
-});
+//     const green = colors?.members.get("Green");
+//     assert.exists(green, "unable to find Green enum member");
+//     await testValueExpression(
+//       {
+//         valueKind: "EnumValue",
+//         value: green,
+//       } as EnumValue,
+//       `3`,
+//     );
+//   });
+// });
 
 /**
  * Helper that renders a value expression and checks the output against the expected value.

--- a/packages/emitter-framework/src/python/components/atom/atom.test.tsx
+++ b/packages/emitter-framework/src/python/components/atom/atom.test.tsx
@@ -1,20 +1,219 @@
 import { Output } from "@alloy-js/core";
 import { SourceFile } from "@alloy-js/python";
-import type { Program, Value } from "@typespec/compiler";
+import { Numeric, type EnumValue, type Model, type Namespace, type NullType, type NullValue, type NumericValue, type Program, type Value } from "@typespec/compiler";
 import { $ } from "@typespec/compiler/typekit";
-import { beforeAll, expect, it } from "vitest";
+import { assert, beforeAll, describe, expect, it } from "vitest";
 import { Atom } from "../../index.js";
 import { getProgram } from "../../test-host.js";
+import { dedent } from "@alloy-js/core/testing";
 
 let program: Program;
 beforeAll(async () => {
   program = await getProgram("");
 });
 
-it("renders strings", async () => {
-  const value = $(program).value.createString("test");
+describe("NullValue", () => {
+  it("null value", async () => {
+    const value = {
+      entityKind: "Value",
+      valueKind: "NullValue",
+      value: null,
+      type: $(program).intrinsic.null,
+      scalar: undefined,
+    } as NullValue;
 
-  await testValueExpression(value, `"test"`);
+    await testValueExpression(value, `None`);
+  });
+});
+
+describe("StringValue", () => {
+  it("normal string", async () => {
+    const value = $(program).value.createString("test");
+
+    await testValueExpression(value, `"test"`);
+  });
+
+  it("empty string", async () => {
+    const value = $(program).value.createString("");
+
+    await testValueExpression(value, `""`);
+  });
+});
+
+describe("BooleanValue", () => {
+  it("True", async () => {
+    const value = $(program).value.createBoolean(true);
+
+    await testValueExpression(value, `True`);
+  });
+
+  it("False", async () => {
+    const value = $(program).value.createBoolean(false);
+
+    await testValueExpression(value, `False`);
+  });
+});
+
+describe("NumericValue", () => {
+  it("integers", async () => {
+    const value = $(program).value.createNumeric(42);
+
+    await testValueExpression(value, `42`);
+  });
+
+  it("decimals", async () => {
+    const value = $(program).value.createNumeric(42.5);
+
+    await testValueExpression(value, `42.5`);
+  });
+});
+
+describe("ArrayValue", () => {
+  it("empty", async () => {
+    // Can be replaced with with TypeKit once #6976 is implemented
+    const value = {
+      entityKind: "Value",
+      valueKind: "ArrayValue",
+      values: [],
+    } as unknown as Value;
+    await testValueExpression(value, `[]`);
+  });
+
+  it("with mixed values", async () => {
+    // Can be replaced with with TypeKit once #6976 is implemented
+    const value = {
+      entityKind: "Value",
+      valueKind: "ArrayValue",
+      values: [
+        $(program).value.createString("some_text"),
+        $(program).value.createNumeric(42),
+        $(program).value.createBoolean(true),
+        {
+          entityKind: "Value",
+          valueKind: "ArrayValue",
+          values: [
+            $(program).value.createNumeric(1),
+            $(program).value.createNumeric(2),
+            $(program).value.createNumeric(3),
+          ],
+        } as Value,
+      ],
+    } as Value;
+    await testValueExpression(value, `["some_text", 42, True, [1, 2, 3]]`);
+  });
+});
+
+describe("ScalarValue", () => {
+  it("utcDateTime.fromISO correctly supplied", async () => {
+    const program = await getProgram(`
+        namespace DemoService;
+        model DateRange {
+          @encode("rfc7231")
+          minDate: utcDateTime = utcDateTime.fromISO("2024-02-15T18:36:03Z");
+        }
+      `);
+    const [namespace] = program.resolveTypeReference("DemoService");
+    const dateRange = (namespace as Namespace).models.get("DateRange");
+    const minDate = dateRange?.properties.get("minDate")?.defaultValue;
+    assert.exists(minDate, "unable to find minDate property");
+    await testValueExpression(minDate, `"datetime.datetime(2024, 2, 15, 18, 36, 3, tzinfo=datetime.timezone.utc)"`);
+  });
+
+  it("Unsupported scalar constructor", async () => {
+    const program = await getProgram(`
+        namespace DemoService;
+
+        scalar ipv4 extends string {
+          init fromInt(value: uint32);
+        }
+
+        @example (#{ip: ipv4.fromInt(2130706433)})
+        model IpAddress {
+          ip: ipv4;
+        }
+      `);
+    const [namespace] = program.resolveTypeReference("DemoService");
+    const model = (namespace as Namespace).models.get("IpAddress");
+    assert.exists(model, "unable to find IpAddress model");
+
+    const value = getExampleValue(model);
+    await expect(testValueExpression(value, ``)).rejects.toThrow(
+      /Unsupported scalar constructor fromInt/,
+    );
+  });
+});
+
+describe("ObjectValue", () => {
+  it("empty object", async () => {
+    // Can be replaced with with TypeKit once #6976 is implemented
+    const program = await getProgram(`
+        namespace DemoService;
+        @example(#{})
+        model ObjectValue {};
+      `);
+    const [namespace] = program.resolveTypeReference("DemoService");
+    const model = (namespace as Namespace).models.get("ObjectValue");
+    assert.exists(model, "unable to find ObjectValue model");
+
+    const value = getExampleValue(model);
+    await testValueExpression(value, `{}`);
+  });
+
+  it("object with properties", async () => {
+    // Can be replaced with with TypeKit once #6976 is implemented
+    const program = await getProgram(`
+        namespace DemoService;
+        @example(#{aNumber: 5, aString: "foo", aBoolean: true})
+        model ObjectValue {
+          aNumber: int32;
+          aString: string;
+          aBoolean: boolean;
+        };
+      `);
+    const [namespace] = program.resolveTypeReference("DemoService");
+    const model = (namespace as Namespace).models.get("ObjectValue");
+    assert.exists(model, "unable to find ObjectValue model");
+
+    const value = getExampleValue(model);
+    await testValueExpression(value, `{"aNumber": 5, "aString": "foo", "aBoolean": True}`);
+  });
+});
+
+describe("EnumValue", () => {
+  it("different EnumValue types", async () => {
+    // Can be replaced with with TypeKit once #6976 is implemented
+    const program = await getProgram(`
+        namespace DemoService;
+        enum Color {
+          Red,
+          Green: 3,
+          Blue
+        }
+      `);
+    const [namespace] = program.resolveTypeReference("DemoService");
+    const colors = (namespace as Namespace).enums.get("Color");
+    assert.exists(colors, "unable to find Color enum");
+
+    const red = colors?.members.get("Red");
+    assert.exists(red, "unable to find Red enum member");
+    await testValueExpression(
+      {
+        valueKind: "EnumValue",
+        value: red,
+      } as EnumValue,
+      `"Red"`,
+    );
+
+    const green = colors?.members.get("Green");
+    assert.exists(green, "unable to find Green enum member");
+    await testValueExpression(
+      {
+        valueKind: "EnumValue",
+        value: green,
+      } as EnumValue,
+      `3`,
+    );
+  });
 });
 
 /**
@@ -28,4 +227,13 @@ async function testValueExpression(value: Value, expected: string) {
       </SourceFile>
     </Output>,
   ).toRenderTo(`${expected}`);
+}
+
+/**
+ * Extracts the value marked with the @example decorator from a model.
+ */
+function getExampleValue(model: Model): Value {
+  const decorator = model?.decorators.find((d) => d.definition?.name === "@example");
+  assert.exists(decorator?.args[0]?.value, "unable to find example decorator");
+  return decorator.args[0].value as Value;
 }

--- a/packages/emitter-framework/src/python/components/atom/atom.tsx
+++ b/packages/emitter-framework/src/python/components/atom/atom.tsx
@@ -1,14 +1,64 @@
 import { type Children } from "@alloy-js/core";
+import { Property } from "@alloy-js/csharp";
 import * as py from "@alloy-js/python";
-import { type Value } from "@typespec/compiler";
+import { compilerAssert, type Value } from "@typespec/compiler";
 
+/**
+ * Properties for the {@link Atom} component.
+ */
 interface AtomProps {
+  /**
+   * The TypeSpec value to be converted to a Python expression.
+   */
   value: Value;
 }
 
+/**
+ * Generates a Python atom from a TypeSpec value.
+ * @param props properties for the atom
+ * @returns {@link Children} representing the Python value expression
+ */
 export function Atom(props: Readonly<AtomProps>): Children {
   switch (props.value.valueKind) {
     case "StringValue":
+    case "BooleanValue":
+    case "NullValue":
       return <py.Atom jsValue={props.value.value} />;
+    case "NumericValue":
+      return <py.Atom jsValue={props.value.value.asNumber()} />;
+    case "ArrayValue":
+      return <py.Atom jsValue={props.value.values.map((v) => <Atom value={v} />)} />;
+    case "ScalarValue":
+      compilerAssert(
+        props.value.value.name === "fromISO",
+        `Unsupported scalar constructor ${props.value.value.name}`,
+        props.value,
+      );
+      return handleISOStringValue(props.value);
+    case "ObjectValue":
+      const jsProperties: Record<string, Children> = {};
+      for (const [key, value] of props.value.properties) {
+        jsProperties[key] = Atom({ value: value.value });
+      }
+      return <py.Atom jsValue={jsProperties} />;
+    case "EnumValue":
+      return <py.Atom jsValue={props.value.value.value ?? props.value.value.name} />;
+    }
   }
-}
+
+  /**
+   * Handles the conversion of ISO date strings to Python datetime objects.
+   * @param value the TypeSpec value containing the ISO string
+   * @returns {@link Children} representing the Python datetime expression
+   */
+  function handleISOStringValue(value: Value & { valueKind: "ScalarValue" }): Children {
+    const arg0 = value.value.args[0];
+    if (arg0.valueKind !== "StringValue") {
+      throw new Error("Expected arg0 to be a StringValue");
+    }
+    const isoString = arg0.value;
+    const date = new Date(isoString);
+    // Convert datetime to a module
+    const pyDatetime = `datetime.datetime(${date.getUTCFullYear()}, ${date.getUTCMonth() + 1}, ${date.getUTCDate()}, ${date.getUTCHours()}, ${date.getUTCMinutes()}, ${date.getUTCSeconds()}, tzinfo=datetime.timezone.utc)`;
+    return <py.Atom jsValue={pyDatetime} />;
+  }

--- a/packages/emitter-framework/src/python/components/atom/atom.tsx
+++ b/packages/emitter-framework/src/python/components/atom/atom.tsx
@@ -1,5 +1,4 @@
 import { type Children } from "@alloy-js/core";
-import { Property } from "@alloy-js/csharp";
 import * as py from "@alloy-js/python";
 import { compilerAssert, type Value } from "@typespec/compiler";
 
@@ -27,7 +26,13 @@ export function Atom(props: Readonly<AtomProps>): Children {
     case "NumericValue":
       return <py.Atom jsValue={props.value.value.asNumber()} />;
     case "ArrayValue":
-      return <py.Atom jsValue={props.value.values.map((v) => <Atom value={v} />)} />;
+      return (
+        <py.Atom
+          jsValue={props.value.values.map((v) => (
+            <Atom value={v} />
+          ))}
+        />
+      );
     case "ScalarValue":
       compilerAssert(
         props.value.value.name === "fromISO",
@@ -41,24 +46,25 @@ export function Atom(props: Readonly<AtomProps>): Children {
         jsProperties[key] = Atom({ value: value.value });
       }
       return <py.Atom jsValue={jsProperties} />;
-    case "EnumValue":
-      return <py.Atom jsValue={props.value.value.value ?? props.value.value.name} />;
-    }
+    // case "EnumValue":
+    //   return <py.Atom jsValue={props.value.value.value ?? props.value.value.name} />;
+    // TODO: Handle EnumValue in a separate PR
   }
+}
 
-  /**
-   * Handles the conversion of ISO date strings to Python datetime objects.
-   * @param value the TypeSpec value containing the ISO string
-   * @returns {@link Children} representing the Python datetime expression
-   */
-  function handleISOStringValue(value: Value & { valueKind: "ScalarValue" }): Children {
-    const arg0 = value.value.args[0];
-    if (arg0.valueKind !== "StringValue") {
-      throw new Error("Expected arg0 to be a StringValue");
-    }
-    const isoString = arg0.value;
-    const date = new Date(isoString);
-    // Convert datetime to a module
-    const pyDatetime = `datetime.datetime(${date.getUTCFullYear()}, ${date.getUTCMonth() + 1}, ${date.getUTCDate()}, ${date.getUTCHours()}, ${date.getUTCMinutes()}, ${date.getUTCSeconds()}, tzinfo=datetime.timezone.utc)`;
-    return <py.Atom jsValue={pyDatetime} />;
+/**
+ * Handles the conversion of ISO date strings to Python datetime objects.
+ * @param value the TypeSpec value containing the ISO string
+ * @returns {@link Children} representing the Python datetime expression
+ */
+function handleISOStringValue(value: Value & { valueKind: "ScalarValue" }): Children {
+  const arg0 = value.value.args[0];
+  if (arg0.valueKind !== "StringValue") {
+    throw new Error("Expected arg0 to be a StringValue");
   }
+  const isoString = arg0.value;
+  const date = new Date(isoString);
+  // Convert datetime to a module
+  const pyDatetime = `datetime.datetime(${date.getUTCFullYear()}, ${date.getUTCMonth() + 1}, ${date.getUTCDate()}, ${date.getUTCHours()}, ${date.getUTCMinutes()}, ${date.getUTCSeconds()}, tzinfo=datetime.timezone.utc)`;
+  return <py.Atom jsValue={pyDatetime} />;
+}


### PR DESCRIPTION
Add the Python Atom, supporting the TypeSpec types: `StringValue`, `BooleanValue`, `NullValue`, `NumericValue`, `ArrayValue`, `ScalarValue`, `ObjectValue`.

`EnumValue` will be handled separately.