### PR TITLE
Unify test utils

### DIFF
--- a/packages/emitter-framework/src/python/components/array-expression/array-expression.test.tsx
+++ b/packages/emitter-framework/src/python/components/array-expression/array-expression.test.tsx
@@ -15,9 +15,7 @@ describe("map array expression to Python list", () => {
   it.each([["string[]", "list[str]"]])("%s => %s", async (tspType, pythonType) => {
     const type = await compileModelPropertyType(tspType, runner);
 
-    expect(
-      getOutput(runner.program, [<TypeExpression type={type} />])
-    ).toRenderTo(d`
+    expect(getOutput(runner.program, [<TypeExpression type={type} />])).toRenderTo(d`
       ${pythonType}
     `);
   });

--- a/packages/emitter-framework/src/python/components/array-expression/array-expression.test.tsx
+++ b/packages/emitter-framework/src/python/components/array-expression/array-expression.test.tsx
@@ -1,11 +1,8 @@
-import { render, type Children } from "@alloy-js/core";
 import { d } from "@alloy-js/core/testing";
-import { SourceFile } from "@alloy-js/python";
 import type { BasicTestRunner } from "@typespec/compiler/testing";
-import { beforeEach, describe, it } from "vitest";
-import { Output } from "../../../../src/core/components/output.jsx";
+import { beforeEach, describe, expect, it } from "vitest";
 import { createEmitterFrameworkTestRunner } from "../../test-host.js";
-import { assertFileContents, compileModelPropertyType, getExternals } from "../../test-utils.js";
+import { compileModelPropertyType, getOutput } from "../../test-utils.js";
 import { TypeExpression } from "../type-expression/type-expression.jsx";
 
 let runner: BasicTestRunner;
@@ -14,28 +11,14 @@ beforeEach(async () => {
   runner = await createEmitterFrameworkTestRunner();
 });
 
-function Wrapper(props: { children: Children }) {
-  return (
-    <Output program={runner.program} externals={getExternals()}>
-      <SourceFile path="test.py">{props.children}</SourceFile>
-    </Output>
-  );
-}
-
 describe("map array expression to Python list", () => {
   it.each([["string[]", "list[str]"]])("%s => %s", async (tspType, pythonType) => {
     const type = await compileModelPropertyType(tspType, runner);
-    const res = render(
-      <Wrapper>
-        <TypeExpression type={type} />
-      </Wrapper>,
-    );
 
-    assertFileContents(
-      res,
-      d`
-          ${pythonType}
-        `,
-    );
+    expect(
+      getOutput(runner.program, [<TypeExpression type={type} />])
+    ).toRenderTo(d`
+      ${pythonType}
+    `);
   });
 });

--- a/packages/emitter-framework/src/python/components/function-declaration/function-declaration.test.tsx
+++ b/packages/emitter-framework/src/python/components/function-declaration/function-declaration.test.tsx
@@ -16,8 +16,7 @@ describe("Typescript Function Declaration", () => {
         const [namespace] = program.resolveTypeReference("DemoService");
         const operation = Array.from((namespace as Namespace).operations.values())[0];
 
-        expect(getOutput(program, [<FunctionDeclaration type={operation} />])
-        ).toRenderTo(`
+        expect(getOutput(program, [<FunctionDeclaration type={operation} />])).toRenderTo(`
           def get_name(id: str) -> str:
             pass
           

--- a/packages/emitter-framework/src/python/components/function-declaration/function-declaration.test.tsx
+++ b/packages/emitter-framework/src/python/components/function-declaration/function-declaration.test.tsx
@@ -1,9 +1,9 @@
-import { SourceFile } from "@alloy-js/typescript";
 import type { Namespace } from "@typespec/compiler";
 import { describe, expect, it } from "vitest";
-import { Output } from "../../../../src/core/components/output.jsx";
 import { getProgram } from "../../test-host.js";
+import { getOutput } from "../../test-utils.js";
 import { FunctionDeclaration } from "./function-declaration.jsx";
+
 describe("Typescript Function Declaration", () => {
   describe("Function bound to Typespec Types", () => {
     describe("Bound to Operation", () => {
@@ -16,12 +16,7 @@ describe("Typescript Function Declaration", () => {
         const [namespace] = program.resolveTypeReference("DemoService");
         const operation = Array.from((namespace as Namespace).operations.values())[0];
 
-        expect(
-          <Output program={program}>
-            <SourceFile path="test.ts">
-              <FunctionDeclaration type={operation} />
-            </SourceFile>
-          </Output>,
+        expect(getOutput(program, [<FunctionDeclaration type={operation} />])
         ).toRenderTo(`
           def get_name(id: str) -> str:
             pass

--- a/packages/emitter-framework/src/python/components/record-expression/record-expression.test.tsx
+++ b/packages/emitter-framework/src/python/components/record-expression/record-expression.test.tsx
@@ -1,11 +1,8 @@
-import { render, type Children } from "@alloy-js/core";
 import { d } from "@alloy-js/core/testing";
-import { SourceFile } from "@alloy-js/python";
 import type { BasicTestRunner } from "@typespec/compiler/testing";
-import { beforeEach, describe, it } from "vitest";
-import { Output } from "../../../../src/core/components/output.jsx";
+import { beforeEach, describe, expect, it } from "vitest";
 import { createEmitterFrameworkTestRunner } from "../../test-host.js";
-import { assertFileContents, compileModelPropertyType, getExternals } from "../../test-utils.js";
+import { compileModelPropertyType, getOutput } from "../../test-utils.js";
 import { TypeExpression } from "../type-expression/type-expression.jsx";
 
 let runner: BasicTestRunner;
@@ -14,28 +11,15 @@ beforeEach(async () => {
   runner = await createEmitterFrameworkTestRunner();
 });
 
-function Wrapper(props: { children: Children }) {
-  return (
-    <Output program={runner.program} externals={getExternals()}>
-      <SourceFile path="test.py">{props.children}</SourceFile>
-    </Output>
-  );
-}
-
 describe("map Record to Python dict", () => {
   it.each([["Record<boolean>", "dict[str, bool]"]])("%s => %s", async (tspType, pythonType) => {
     const type = await compileModelPropertyType(tspType, runner);
-    const res = render(
-      <Wrapper>
-        <TypeExpression type={type} />
-      </Wrapper>,
-    );
 
-    assertFileContents(
-      res,
-      d`
-          ${pythonType}
-        `,
-    );
+    expect(
+      getOutput(runner.program, [<TypeExpression type={type} />])
+    ).toRenderTo(d`
+      ${pythonType}
+    `);
   });
 });
+

--- a/packages/emitter-framework/src/python/components/record-expression/record-expression.test.tsx
+++ b/packages/emitter-framework/src/python/components/record-expression/record-expression.test.tsx
@@ -15,11 +15,8 @@ describe("map Record to Python dict", () => {
   it.each([["Record<boolean>", "dict[str, bool]"]])("%s => %s", async (tspType, pythonType) => {
     const type = await compileModelPropertyType(tspType, runner);
 
-    expect(
-      getOutput(runner.program, [<TypeExpression type={type} />])
-    ).toRenderTo(d`
+    expect(getOutput(runner.program, [<TypeExpression type={type} />])).toRenderTo(d`
       ${pythonType}
     `);
   });
 });
-

--- a/packages/emitter-framework/src/python/components/type-alias-declaration/type-alias-declaration.test.tsx
+++ b/packages/emitter-framework/src/python/components/type-alias-declaration/type-alias-declaration.test.tsx
@@ -1,9 +1,7 @@
-import { SourceFile } from "@alloy-js/python";
 import type { Namespace } from "@typespec/compiler";
 import { describe, expect, it } from "vitest";
-import { Output } from "../../../../src/core/components/output.jsx";
 import { getProgram } from "../../test-host.js";
-import { getExternals } from "../../test-utils.js";
+import { getOutput } from "../../test-utils.js";
 import { TypeAliasDeclaration } from "./type-alias-declaration.jsx";
 
 describe("Python Declaration equivalency to Type Alias", () => {
@@ -18,16 +16,11 @@ describe("Python Declaration equivalency to Type Alias", () => {
         const [namespace] = program.resolveTypeReference("DemoService");
         const scalar = Array.from((namespace as Namespace).scalars.values())[0];
 
-        expect(
-          <Output program={program} externals={getExternals()}>
-            <SourceFile path="test.py">
-              <TypeAliasDeclaration type={scalar} />
-            </SourceFile>
-          </Output>,
+        expect(getOutput(program, [<TypeAliasDeclaration type={scalar} />])
         ).toRenderTo(`
           from datetime import datetime
 
-          MyDate: datetime`);
+          my_date: datetime`);
       });
 
       it("creates a type alias declaration with JSDoc", async () => {
@@ -42,17 +35,12 @@ describe("Python Declaration equivalency to Type Alias", () => {
         const [namespace] = program.resolveTypeReference("DemoService");
         const scalar = Array.from((namespace as Namespace).scalars.values())[0];
 
-        expect(
-          <Output program={program} externals={getExternals()}>
-            <SourceFile path="test.py">
-              <TypeAliasDeclaration type={scalar} />
-            </SourceFile>
-          </Output>,
+        expect(getOutput(program, [<TypeAliasDeclaration type={scalar} />])
         ).toRenderTo(`
           from datetime import datetime
 
           # Type to represent a date
-          MyDate: datetime`);
+          my_date: datetime`);
       });
 
       it("can override JSDoc", async () => {
@@ -67,17 +55,12 @@ describe("Python Declaration equivalency to Type Alias", () => {
         const [namespace] = program.resolveTypeReference("DemoService");
         const scalar = Array.from((namespace as Namespace).scalars.values())[0];
 
-        expect(
-          <Output program={program} externals={getExternals()}>
-            <SourceFile path="test.py">
-              <TypeAliasDeclaration doc={"Overridden Doc"} type={scalar} />
-            </SourceFile>
-          </Output>,
+        expect(getOutput(program, [<TypeAliasDeclaration doc={"Overridden Doc"} type={scalar} />])
         ).toRenderTo(`
           from datetime import datetime
 
           # Overridden Doc
-          MyDate: datetime`);
+          my_date: datetime`);
       });
 
       it("creates a type alias declaration for a utcDateTime with unixTimeStamp encoding", async () => {
@@ -90,16 +73,11 @@ describe("Python Declaration equivalency to Type Alias", () => {
         const [namespace] = program.resolveTypeReference("DemoService");
         const scalar = Array.from((namespace as Namespace).scalars.values())[0];
 
-        expect(
-          <Output program={program} externals={getExternals()}>
-            <SourceFile path="test.py">
-              <TypeAliasDeclaration type={scalar} />
-            </SourceFile>
-          </Output>,
+        expect(getOutput(program, [<TypeAliasDeclaration type={scalar} />])
         ).toRenderTo(`
           from datetime import datetime
 
-          MyDate: datetime`);
+          my_date: datetime`);
       });
 
       it("creates a type alias declaration for a utcDateTime with rfc7231 encoding", async () => {
@@ -112,16 +90,11 @@ describe("Python Declaration equivalency to Type Alias", () => {
         const [namespace] = program.resolveTypeReference("DemoService");
         const scalar = Array.from((namespace as Namespace).scalars.values())[0];
 
-        expect(
-          <Output program={program} externals={getExternals()}>
-            <SourceFile path="test.py">
-              <TypeAliasDeclaration type={scalar} />
-            </SourceFile>
-          </Output>,
+        expect(getOutput(program, [<TypeAliasDeclaration type={scalar} />])
         ).toRenderTo(`
           from datetime import datetime
 
-          MyDate: datetime`);
+          my_date: datetime`);
       });
 
       it("creates a type alias declaration for a utcDateTime with rfc3339 encoding", async () => {
@@ -134,16 +107,11 @@ describe("Python Declaration equivalency to Type Alias", () => {
         const [namespace] = program.resolveTypeReference("DemoService");
         const scalar = Array.from((namespace as Namespace).scalars.values())[0];
 
-        expect(
-          <Output program={program} externals={getExternals()}>
-            <SourceFile path="test.py">
-              <TypeAliasDeclaration type={scalar} />
-            </SourceFile>
-          </Output>,
+        expect(getOutput(program, [<TypeAliasDeclaration type={scalar} />])
         ).toRenderTo(`
           from datetime import datetime
 
-          MyDate: datetime`);
+          my_date: datetime`);
       });
     });
   });

--- a/packages/emitter-framework/src/python/components/type-alias-declaration/type-alias-declaration.test.tsx
+++ b/packages/emitter-framework/src/python/components/type-alias-declaration/type-alias-declaration.test.tsx
@@ -16,8 +16,7 @@ describe("Python Declaration equivalency to Type Alias", () => {
         const [namespace] = program.resolveTypeReference("DemoService");
         const scalar = Array.from((namespace as Namespace).scalars.values())[0];
 
-        expect(getOutput(program, [<TypeAliasDeclaration type={scalar} />])
-        ).toRenderTo(`
+        expect(getOutput(program, [<TypeAliasDeclaration type={scalar} />])).toRenderTo(`
           from datetime import datetime
 
           my_date: datetime`);
@@ -35,8 +34,7 @@ describe("Python Declaration equivalency to Type Alias", () => {
         const [namespace] = program.resolveTypeReference("DemoService");
         const scalar = Array.from((namespace as Namespace).scalars.values())[0];
 
-        expect(getOutput(program, [<TypeAliasDeclaration type={scalar} />])
-        ).toRenderTo(`
+        expect(getOutput(program, [<TypeAliasDeclaration type={scalar} />])).toRenderTo(`
           from datetime import datetime
 
           # Type to represent a date
@@ -55,8 +53,8 @@ describe("Python Declaration equivalency to Type Alias", () => {
         const [namespace] = program.resolveTypeReference("DemoService");
         const scalar = Array.from((namespace as Namespace).scalars.values())[0];
 
-        expect(getOutput(program, [<TypeAliasDeclaration doc={"Overridden Doc"} type={scalar} />])
-        ).toRenderTo(`
+        expect(getOutput(program, [<TypeAliasDeclaration doc={"Overridden Doc"} type={scalar} />]))
+          .toRenderTo(`
           from datetime import datetime
 
           # Overridden Doc
@@ -73,8 +71,7 @@ describe("Python Declaration equivalency to Type Alias", () => {
         const [namespace] = program.resolveTypeReference("DemoService");
         const scalar = Array.from((namespace as Namespace).scalars.values())[0];
 
-        expect(getOutput(program, [<TypeAliasDeclaration type={scalar} />])
-        ).toRenderTo(`
+        expect(getOutput(program, [<TypeAliasDeclaration type={scalar} />])).toRenderTo(`
           from datetime import datetime
 
           my_date: datetime`);
@@ -90,8 +87,7 @@ describe("Python Declaration equivalency to Type Alias", () => {
         const [namespace] = program.resolveTypeReference("DemoService");
         const scalar = Array.from((namespace as Namespace).scalars.values())[0];
 
-        expect(getOutput(program, [<TypeAliasDeclaration type={scalar} />])
-        ).toRenderTo(`
+        expect(getOutput(program, [<TypeAliasDeclaration type={scalar} />])).toRenderTo(`
           from datetime import datetime
 
           my_date: datetime`);
@@ -107,8 +103,7 @@ describe("Python Declaration equivalency to Type Alias", () => {
         const [namespace] = program.resolveTypeReference("DemoService");
         const scalar = Array.from((namespace as Namespace).scalars.values())[0];
 
-        expect(getOutput(program, [<TypeAliasDeclaration type={scalar} />])
-        ).toRenderTo(`
+        expect(getOutput(program, [<TypeAliasDeclaration type={scalar} />])).toRenderTo(`
           from datetime import datetime
 
           my_date: datetime`);

--- a/packages/emitter-framework/src/python/components/type-expression/type-expression.test.tsx
+++ b/packages/emitter-framework/src/python/components/type-expression/type-expression.test.tsx
@@ -1,4 +1,4 @@
-import { render, type Children } from "@alloy-js/core";
+import { render } from "@alloy-js/core";
 import { d } from "@alloy-js/core/testing";
 import type { BasicTestRunner } from "@typespec/compiler/testing";
 import { beforeEach, describe, expect, it } from "vitest";
@@ -53,11 +53,9 @@ describe("map Typespec types to Python built-in types", () => {
     const type = await compileModelPropertyType(tspType, runner);
     const extraImportText = extraImport ? `${extraImport}\n\n` : "";
 
-    expect(
-      getOutput(runner.program, [<TypeExpression type={type} />])
-    ).toRenderTo(d`
+    expect(getOutput(runner.program, [<TypeExpression type={type} />])).toRenderTo(d`
       ${extraImportText}${pythonType}
-    `,);
+    `);
   });
 });
 
@@ -88,13 +86,11 @@ describe("map tuple to Python types", () => {
   it.each([["[int32, int32]", "Tuple[int, int]"]])("%s => %s", async (tspType, pythonType) => {
     const type = await compileModelPropertyType(tspType, runner);
 
-    expect(
-      getOutput(runner.program, [<TypeExpression type={type} />])
-    ).toRenderTo(d`
+    expect(getOutput(runner.program, [<TypeExpression type={type} />])).toRenderTo(d`
       from typing import Tuple
 
       ${pythonType}
-    `,);
+    `);
   });
 });
 
@@ -102,12 +98,10 @@ describe("correctly solves a ModelProperty to Python types", () => {
   it.each([["[int32, int32]", "Tuple[int, int]"]])("%s => %s", async (tspType, pythonType) => {
     const type = await compileModelProperty(tspType, runner);
 
-    expect(
-      getOutput(runner.program, [<TypeExpression type={type} />])
-    ).toRenderTo(d`
+    expect(getOutput(runner.program, [<TypeExpression type={type} />])).toRenderTo(d`
       from typing import Tuple
 
       ${pythonType}
-    `,);
+    `);
   });
 });

--- a/packages/emitter-framework/src/python/components/type-expression/type-expression.test.tsx
+++ b/packages/emitter-framework/src/python/components/type-expression/type-expression.test.tsx
@@ -1,16 +1,14 @@
 import { render, type Children } from "@alloy-js/core";
 import { d } from "@alloy-js/core/testing";
-import { SourceFile } from "@alloy-js/python";
 import type { BasicTestRunner } from "@typespec/compiler/testing";
-import { beforeEach, describe, it } from "vitest";
-import { Output } from "../../../../src/core/components/output.jsx";
+import { beforeEach, describe, expect, it } from "vitest";
 import { createEmitterFrameworkTestRunner } from "../../test-host.js";
 import {
   assertFileContents,
   compileCodeModelPropertyType,
   compileModelProperty,
   compileModelPropertyType,
-  getExternals,
+  getOutput,
 } from "../../test-utils.js";
 import { TypeExpression } from "./type-expression.jsx";
 
@@ -19,14 +17,6 @@ let runner: BasicTestRunner;
 beforeEach(async () => {
   runner = await createEmitterFrameworkTestRunner();
 });
-
-function Wrapper(props: { children: Children }) {
-  return (
-    <Output program={runner.program} externals={getExternals()}>
-      <SourceFile path="test.py">{props.children}</SourceFile>
-    </Output>
-  );
-}
 
 describe("map Typespec types to Python built-in types", () => {
   it.each([
@@ -61,19 +51,13 @@ describe("map Typespec types to Python built-in types", () => {
     ["url", "str"],
   ])("%s => %s", async (tspType, pythonType, extraImport = "") => {
     const type = await compileModelPropertyType(tspType, runner);
-    const res = render(
-      <Wrapper>
-        <TypeExpression type={type} />
-      </Wrapper>,
-    );
     const extraImportText = extraImport ? `${extraImport}\n\n` : "";
 
-    assertFileContents(
-      res,
-      d`
-          ${extraImportText}${pythonType}
-        `,
-    );
+    expect(
+      getOutput(runner.program, [<TypeExpression type={type} />])
+    ).toRenderTo(d`
+      ${extraImportText}${pythonType}
+    `,);
   });
 });
 
@@ -89,11 +73,7 @@ describe("map scalar to Python types", () => {
     `,
       runner,
     );
-    const res = render(
-      <Wrapper>
-        <TypeExpression type={type} />
-      </Wrapper>,
-    );
+    const res = render(getOutput(runner.program, [<TypeExpression type={type} />]));
 
     assertFileContents(
       res,
@@ -107,39 +87,27 @@ describe("map scalar to Python types", () => {
 describe("map tuple to Python types", () => {
   it.each([["[int32, int32]", "Tuple[int, int]"]])("%s => %s", async (tspType, pythonType) => {
     const type = await compileModelPropertyType(tspType, runner);
-    const res = render(
-      <Wrapper>
-        <TypeExpression type={type} />
-      </Wrapper>,
-    );
 
-    assertFileContents(
-      res,
-      d`
-          from typing import Tuple
+    expect(
+      getOutput(runner.program, [<TypeExpression type={type} />])
+    ).toRenderTo(d`
+      from typing import Tuple
 
-          ${pythonType}
-        `,
-    );
+      ${pythonType}
+    `,);
   });
 });
 
 describe("correctly solves a ModelProperty to Python types", () => {
   it.each([["[int32, int32]", "Tuple[int, int]"]])("%s => %s", async (tspType, pythonType) => {
     const type = await compileModelProperty(tspType, runner);
-    const res = render(
-      <Wrapper>
-        <TypeExpression type={type} />
-      </Wrapper>,
-    );
 
-    assertFileContents(
-      res,
-      d`
-          from typing import Tuple
+    expect(
+      getOutput(runner.program, [<TypeExpression type={type} />])
+    ).toRenderTo(d`
+      from typing import Tuple
 
-          ${pythonType}
-        `,
-    );
+      ${pythonType}
+    `,);
   });
 });

--- a/packages/emitter-framework/src/python/test-utils.tsx
+++ b/packages/emitter-framework/src/python/test-utils.tsx
@@ -4,8 +4,8 @@ import { createPythonNamePolicy, SourceFile } from "@alloy-js/python";
 import type { Program } from "@typespec/compiler";
 import { type ModelProperty } from "@typespec/compiler";
 import type { BasicTestRunner } from "@typespec/compiler/testing";
-import { Output } from "../../src/core/components/output.jsx";
 import { assert } from "vitest";
+import { Output } from "../../src/core/components/output.jsx";
 import { datetimeModule, decimalModule, typingModule } from "./builtins.js";
 import { getProgram } from "./test-host.js";
 
@@ -29,16 +29,13 @@ export function assertFileContents(res: OutputDirectory, contents: string) {
   assert.equal(testFile.contents, contents);
 }
 
-export function getOutput(
-  program: Program,
-  children: Children[],
-): Children {
+export function getOutput(program: Program, children: Children[]): Children {
   const policy = createPythonNamePolicy();
-  return <Output program={program} externals={getExternals()} namePolicy={policy}>
-    <SourceFile path="test.py">
-      {children}
-    </SourceFile>
-  </Output>;
+  return (
+    <Output program={program} externals={getExternals()} namePolicy={policy}>
+      <SourceFile path="test.py">{children}</SourceFile>
+    </Output>
+  );
 }
 
 export function getExternals() {

--- a/packages/emitter-framework/src/python/test-utils.tsx
+++ b/packages/emitter-framework/src/python/test-utils.tsx
@@ -29,6 +29,10 @@ export function assertFileContents(res: OutputDirectory, contents: string) {
   assert.equal(testFile.contents, contents);
 }
 
+function getExternals() {
+  return [datetimeModule, decimalModule, typingModule];
+}
+
 export function getOutput(program: Program, children: Children[]): Children {
   const policy = createPythonNamePolicy();
   return (
@@ -38,16 +42,12 @@ export function getOutput(program: Program, children: Children[]): Children {
   );
 }
 
-export function getExternals() {
-  return [datetimeModule, decimalModule, typingModule];
-}
-
-export async function compileCode(code: string, runner: BasicTestRunner) {
+async function compileCode(code: string, runner: BasicTestRunner) {
   const { test } = await runner.compile(code);
   return test;
 }
 
-export async function compileCodeModelProperty(code: string, runner: BasicTestRunner) {
+async function compileCodeModelProperty(code: string, runner: BasicTestRunner) {
   const test = await compileCode(code, runner);
   return test as ModelProperty;
 }

--- a/packages/emitter-framework/src/python/test-utils.tsx
+++ b/packages/emitter-framework/src/python/test-utils.tsx
@@ -1,8 +1,10 @@
 import { type Children, type OutputDirectory, render } from "@alloy-js/core";
 import { Output as StcOutput, SourceFile as StcSourceFile } from "@alloy-js/core/stc";
+import { createPythonNamePolicy, SourceFile } from "@alloy-js/python";
 import type { Program } from "@typespec/compiler";
 import { type ModelProperty } from "@typespec/compiler";
 import type { BasicTestRunner } from "@typespec/compiler/testing";
+import { Output } from "../../src/core/components/output.jsx";
 import { assert } from "vitest";
 import { datetimeModule, decimalModule, typingModule } from "./builtins.js";
 import { getProgram } from "./test-host.js";
@@ -25,6 +27,18 @@ export function assertFileContents(res: OutputDirectory, contents: string) {
   assert(testFile, "test.py file not rendered");
   assert("contents" in testFile, "test.py file does not have contents");
   assert.equal(testFile.contents, contents);
+}
+
+export function getOutput(
+  program: Program,
+  children: Children[],
+): Children {
+  const policy = createPythonNamePolicy();
+  return <Output program={program} externals={getExternals()} namePolicy={policy}>
+    <SourceFile path="test.py">
+      {children}
+    </SourceFile>
+  </Output>;
 }
 
 export function getExternals() {


### PR DESCRIPTION
Unify test utils so all tests share a single interface, that defines all the correct parameters for the `Output` (`externals`, `namePolicy`, etc.).

The interface is:`expect(getOutput(program, [<children>])).toRenderTo(<text>)`

`program` can be either a `BasicTestRunner`, defined with `createEmitterFrameworkTestRunner()`; or a custom Program, based in a TypeSpec schema, defined with `getProgram(<schema text>)`.