### PR TITLE
[Pinterest Only] Add CI checks on pull requests

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -1,0 +1,27 @@
+name: Pull Request Checks (Pinterest)
+on: pull_request
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 ## Needed for Changesets to find `main` branch
+
+      - uses: ./.github/actions/setup
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Build
+        run: pnpm run
+
+      - name: Test
+        run: pnpm test
+


### PR DESCRIPTION
GitHub does not run workflows by default in forked repositories; indeed, we do not want to run the workflows in the parent repo (which include things like publishing artifacts).

Instead, we create our own version of the `Integration` workflow and will manually disable all the others (so those files can still be updated without merge conflict).