### PR TITLE
Add mutation engine for TypeSpec-to-GraphQL type transformation

### DIFF
--- a/packages/graphql/CHANGELOG.md
+++ b/packages/graphql/CHANGELOG.md
@@ -1,1 +1,0 @@
-# Change Log - @typespec/graphql

--- a/packages/graphql/CHANGELOG.md
+++ b/packages/graphql/CHANGELOG.md
@@ -1,0 +1,1 @@
+# Change Log - @typespec/graphql

--- a/packages/graphql/api-extractor.json
+++ b/packages/graphql/api-extractor.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
+  "extends": "../../api-extractor.base.json"
+}

--- a/packages/graphql/lib/main.tsp
+++ b/packages/graphql/lib/main.tsp
@@ -2,3 +2,4 @@ import "./interface.tsp";
 import "./operation-fields.tsp";
 import "./operation-kind.tsp";
 import "./schema.tsp";
+import "./specified-by.tsp";

--- a/packages/graphql/lib/specified-by.tsp
+++ b/packages/graphql/lib/specified-by.tsp
@@ -1,0 +1,19 @@
+import "../dist/src/lib/specified-by.js";
+
+using TypeSpec.Reflection;
+
+namespace TypeSpec.GraphQL;
+
+/**
+ * Provide a specification URL for a custom GraphQL scalar type.
+ * This maps to the `@specifiedBy` directive in the emitted GraphQL schema.
+ *
+ * @param url URL to the scalar type specification
+ * @example
+ *
+ * ```typespec
+ * @specifiedBy("https://scalars.graphql.org/jakobmerrild/long.html")
+ * scalar Long extends int64;
+ * ```
+ */
+extern dec specifiedBy(target: Scalar, url: valueof string);

--- a/packages/graphql/lib/specified-by.tsp
+++ b/packages/graphql/lib/specified-by.tsp
@@ -16,4 +16,4 @@ namespace TypeSpec.GraphQL;
  * scalar Long extends int64;
  * ```
  */
-extern dec specifiedBy(target: Scalar, url: valueof string);
+extern dec specifiedBy(target: Scalar, url: valueof url);

--- a/packages/graphql/package.json
+++ b/packages/graphql/package.json
@@ -17,6 +17,7 @@
     "typespec"
   ],
   "type": "module",
+  "tspMain": "lib/main.tsp",
   "main": "dist/src/index.js",
   "exports": {
     ".": {
@@ -30,14 +31,12 @@
     }
   },
   "engines": {
-    "node": ">=18.0.0"
-  },
-  "graphql": {
-    "documents": "test/**/*.{js,ts}"
+    "node": ">=20.0.0"
   },
   "dependencies": {
     "@alloy-js/core": "^0.11.0",
     "@alloy-js/typescript": "^0.11.0",
+    "change-case": "^5.4.4",
     "graphql": "^16.9.0"
   },
   "scripts": {
@@ -46,8 +45,8 @@
     "watch": "tsc --watch",
     "test": "vitest run",
     "test:watch": "vitest -w",
-    "lint": "eslint src/ test/ --report-unused-disable-directives --max-warnings=0",
-    "lint:fix": "eslint . --report-unused-disable-directives --fix"
+    "lint": "eslint . --max-warnings=0",
+    "lint:fix": "eslint . --fix"
   },
   "files": [
     "lib/*.tsp",
@@ -56,11 +55,16 @@
   ],
   "peerDependencies": {
     "@typespec/compiler": "workspace:~",
+    "@typespec/emitter-framework": "workspace:~",
     "@typespec/http": "workspace:~",
-    "@typespec/emitter-framework": "^0.5.0"
+    "@typespec/mutator-framework": "workspace:~"
   },
   "devDependencies": {
     "@types/node": "~22.13.13",
+    "@typespec/compiler": "workspace:~",
+    "@typespec/emitter-framework": "workspace:~",
+    "@typespec/http": "workspace:~",
+    "@typespec/mutator-framework": "workspace:~",
     "rimraf": "~6.0.1",
     "source-map-support": "~0.5.21",
     "typescript": "~5.8.2",

--- a/packages/graphql/src/index.ts
+++ b/packages/graphql/src/index.ts
@@ -1,3 +1,5 @@
 export { $onEmit } from "./emitter.js";
 export { $lib } from "./lib.js";
 export { $decorators } from "./tsp-index.js";
+
+export { createGraphQLMutationEngine } from "./mutation-engine/index.js";

--- a/packages/graphql/src/lib.ts
+++ b/packages/graphql/src/lib.ts
@@ -136,6 +136,12 @@ export const libDef = {
         default: paramMessage`Property \`${"property"}\` is incompatible with \`${"interface"}\`.`,
       },
     },
+    "unrecognized-union": {
+      severity: "error",
+      messages: {
+        default: "Unrecognized union construction. Union must be named, a return type, a model property, or an alias.",
+      },
+    },
   },
   emitter: {
     options: EmitterOptionsSchema as JSONSchemaType<GraphQLEmitterOptions>,

--- a/packages/graphql/src/lib.ts
+++ b/packages/graphql/src/lib.ts
@@ -142,6 +142,12 @@ export const libDef = {
         default: "Unrecognized union construction. Union must be named, a return type, a model property, or an alias.",
       },
     },
+    "duplicate-union-variant": {
+      severity: "warning",
+      messages: {
+        default: paramMessage`Union variant type "${"type"}" appears multiple times after flattening nested unions. Duplicate removed.`,
+      },
+    },
   },
   emitter: {
     options: EmitterOptionsSchema as JSONSchemaType<GraphQLEmitterOptions>,
@@ -155,6 +161,7 @@ export const libDef = {
     compose: { description: "State for the @compose decorator." },
     interface: { description: "State for the @Interface decorator." },
     schema: { description: "State for the @schema decorator." },
+    specifiedBy: { description: "State for the @specifiedBy decorator." },
   },
 } as const;
 

--- a/packages/graphql/src/lib.ts
+++ b/packages/graphql/src/lib.ts
@@ -162,6 +162,7 @@ export const libDef = {
     interface: { description: "State for the @Interface decorator." },
     schema: { description: "State for the @schema decorator." },
     specifiedBy: { description: "State for the @specifiedBy decorator." },
+    oneOf: { description: "State for tracking @oneOf input objects created from input unions." },
   },
 } as const;
 

--- a/packages/graphql/src/lib.ts
+++ b/packages/graphql/src/lib.ts
@@ -148,6 +148,12 @@ export const libDef = {
         default: paramMessage`Union variant type "${"type"}" appears multiple times after flattening nested unions. Duplicate removed.`,
       },
     },
+    "empty-union": {
+      severity: "error",
+      messages: {
+        default: "Union has no non-null variants. A GraphQL union must contain at least one member type.",
+      },
+    },
   },
   emitter: {
     options: EmitterOptionsSchema as JSONSchemaType<GraphQLEmitterOptions>,
@@ -163,6 +169,10 @@ export const libDef = {
     schema: { description: "State for the @schema decorator." },
     specifiedBy: { description: "State for the @specifiedBy decorator." },
     oneOf: { description: "State for tracking @oneOf input objects created from input unions." },
+    nullable: {
+      description:
+        "State for tracking types that were determined to be nullable from null-variant stripping.",
+    },
   },
 } as const;
 

--- a/packages/graphql/src/lib/interface.ts
+++ b/packages/graphql/src/lib/interface.ts
@@ -11,6 +11,7 @@ import {
 import { useStateMap, useStateSet } from "@typespec/compiler/utils";
 import { GraphQLKeys, NAMESPACE, reportDiagnostic } from "../lib.js";
 import type { Tagged } from "../types.d.ts";
+import { propertiesEqual } from "./utils.js";
 
 // This will set the namespace for decorators implemented in this file
 export const namespace = NAMESPACE;
@@ -73,13 +74,6 @@ function validateNoCircularImplementation(
     });
   }
   return valid;
-}
-
-function propertiesEqual(prop1: ModelProperty, prop2: ModelProperty): boolean {
-  // TODO is there some canonical way to do this?
-  return (
-    prop1.name === prop2.name && prop1.type === prop2.type && prop1.optional === prop2.optional
-  );
 }
 
 function validateImplementsInterfaceProperties(

--- a/packages/graphql/src/lib/nullable.ts
+++ b/packages/graphql/src/lib/nullable.ts
@@ -1,0 +1,21 @@
+import type { Program, Type } from "@typespec/compiler";
+import { useStateSet } from "@typespec/compiler/utils";
+import { GraphQLKeys } from "../lib.js";
+
+const [getNullableState, setNullableState] = useStateSet<Type>(GraphQLKeys.nullable);
+
+/**
+ * Check if a type has been marked as nullable due to null-variant stripping.
+ * For example, `Cat | Dog | null` becomes `union CatDog` marked as nullable.
+ */
+export function isNullable(program: Program, type: Type): boolean {
+  return getNullableState(program, type);
+}
+
+/**
+ * Mark a type as nullable. Called by the mutation engine when null variants
+ * are stripped from a union during processing.
+ */
+export function setNullable(program: Program, type: Type): void {
+  setNullableState(program, type);
+}

--- a/packages/graphql/src/lib/one-of.ts
+++ b/packages/graphql/src/lib/one-of.ts
@@ -1,8 +1,8 @@
 import type { Model, Program } from "@typespec/compiler";
-import { useStateMap } from "@typespec/compiler/utils";
+import { useStateSet } from "@typespec/compiler/utils";
 import { GraphQLKeys } from "../lib.js";
 
-const [getOneOfState, setOneOfState] = useStateMap<Model, boolean>(GraphQLKeys.oneOf);
+const [getOneOfState, setOneOfState] = useStateSet<Model>(GraphQLKeys.oneOf);
 
 /**
  * Check if a model has been marked as a @oneOf input object.
@@ -11,12 +11,12 @@ const [getOneOfState, setOneOfState] = useStateMap<Model, boolean>(GraphQLKeys.o
  * unions become @oneOf input objects.
  */
 export function isOneOf(program: Program, model: Model): boolean {
-  return getOneOfState(program, model) === true;
+  return getOneOfState(program, model);
 }
 
 /**
  * Mark a model as a @oneOf input object.
  */
 export function setOneOf(program: Program, model: Model): void {
-  setOneOfState(program, model, true);
+  setOneOfState(program, model);
 }

--- a/packages/graphql/src/lib/one-of.ts
+++ b/packages/graphql/src/lib/one-of.ts
@@ -1,0 +1,22 @@
+import type { Model, Program } from "@typespec/compiler";
+import { useStateMap } from "@typespec/compiler/utils";
+import { GraphQLKeys } from "../lib.js";
+
+const [getOneOfState, setOneOfState] = useStateMap<Model, boolean>(GraphQLKeys.oneOf);
+
+/**
+ * Check if a model has been marked as a @oneOf input object.
+ * These are synthetic models created by the union mutation when a union
+ * is used in input context — GraphQL unions are output-only, so input
+ * unions become @oneOf input objects.
+ */
+export function isOneOf(program: Program, model: Model): boolean {
+  return getOneOfState(program, model) === true;
+}
+
+/**
+ * Mark a model as a @oneOf input object.
+ */
+export function setOneOf(program: Program, model: Model): void {
+  setOneOfState(program, model, true);
+}

--- a/packages/graphql/src/lib/operation-fields.ts
+++ b/packages/graphql/src/lib/operation-fields.ts
@@ -7,9 +7,6 @@ import {
   type Operation,
   type Program,
 } from "@typespec/compiler";
-
-// import { createTypeRelationChecker } from "../../../compiler/dist/src/core/type-relation-checker.js";
-
 import { useStateMap } from "@typespec/compiler/utils";
 import { GraphQLKeys, NAMESPACE, reportDiagnostic } from "../lib.js";
 import { operationsEqual } from "./utils.js";

--- a/packages/graphql/src/lib/scalar-mappings.ts
+++ b/packages/graphql/src/lib/scalar-mappings.ts
@@ -15,7 +15,6 @@ export interface ScalarMapping {
 
 /**
  * Mapping table for TypeSpec standard library scalars to GraphQL custom scalars.
- * Based on design doc: https://github.com/microsoft/typespec/issues/4933
  */
 const SCALAR_MAPPINGS: Record<string, Record<string, ScalarMapping>> = {
   // int64 → BigInt (String)
@@ -48,7 +47,7 @@ const SCALAR_MAPPINGS: Record<string, Record<string, ScalarMapping>> = {
     },
   },
 
-  // bytes with different encodings
+  // bytes — requires @encode to determine format; without encoding, no GraphQL mapping applies
   bytes: {
     base64: {
       graphqlName: "Bytes",
@@ -62,7 +61,7 @@ const SCALAR_MAPPINGS: Record<string, Record<string, ScalarMapping>> = {
     },
   },
 
-  // utcDateTime with different encodings
+  // utcDateTime — requires @encode to determine wire format; no default mapping without encoding
   utcDateTime: {
     rfc3339: {
       graphqlName: "UTCDateTime",
@@ -80,7 +79,7 @@ const SCALAR_MAPPINGS: Record<string, Record<string, ScalarMapping>> = {
     },
   },
 
-  // offsetDateTime with different encodings
+  // offsetDateTime — requires @encode to determine wire format; no default mapping without encoding
   offsetDateTime: {
     rfc3339: {
       graphqlName: "OffsetDateTime",
@@ -106,7 +105,7 @@ const SCALAR_MAPPINGS: Record<string, Record<string, ScalarMapping>> = {
     },
   },
 
-  // duration with different encodings
+  // duration — requires @encode to determine wire format; no default mapping without encoding
   duration: {
     ISO8601: {
       graphqlName: "Duration",

--- a/packages/graphql/src/lib/scalar-mappings.ts
+++ b/packages/graphql/src/lib/scalar-mappings.ts
@@ -8,7 +8,7 @@ export interface ScalarMapping {
   /** The GraphQL scalar name to emit */
   graphqlName: string;
   /** The base GraphQL type (String, Int, or Float) */
-  baseType: "String" | "Int" | "Float";
+  baseType: "String" | "Int" | "Float" | "Boolean" | "ID";
   /** Optional URL to specification for @specifiedBy directive */
   specificationUrl?: string;
 }
@@ -16,12 +16,13 @@ export interface ScalarMapping {
 /**
  * Mapping table for TypeSpec standard library scalars to GraphQL custom scalars.
  */
-const SCALAR_MAPPINGS: Record<string, Record<string, ScalarMapping>> = {
-  // int64 → BigInt (String)
+const SCALAR_MAPPINGS = {
+  // int64 → Long (String)
   int64: {
     default: {
-      graphqlName: "BigInt",
+      graphqlName: "Long",
       baseType: "String",
+      specificationUrl: "http://scalars.graphql.org/jakobmerrild/long.html",
     },
   },
 
@@ -52,7 +53,7 @@ const SCALAR_MAPPINGS: Record<string, Record<string, ScalarMapping>> = {
     base64: {
       graphqlName: "Bytes",
       baseType: "String",
-      specificationUrl: "https://datatracker.ietf.org/doc/html/rfc4648",
+      specificationUrl: "https://datatracker.ietf.org/doc/html/rfc4648#section-4",
     },
     base64url: {
       graphqlName: "BytesUrl",
@@ -89,7 +90,7 @@ const SCALAR_MAPPINGS: Record<string, Record<string, ScalarMapping>> = {
     rfc7231: {
       graphqlName: "OffsetDateTimeHuman",
       baseType: "String",
-      specificationUrl: "https://datatracker.ietf.org/doc/html/rfc7231",
+      specificationUrl: "https://datatracker.ietf.org/doc/html/rfc7231#section-7.1.1.1",
     },
     unixTimestamp: {
       graphqlName: "OffsetDateTimeUnix",
@@ -172,7 +173,7 @@ export function getScalarMapping(
   }
 
   const scalarName = scalar.name;
-  const mappingTable = SCALAR_MAPPINGS[scalarName];
+  const mappingTable = (SCALAR_MAPPINGS as Record<string, Record<string, ScalarMapping>>)[scalarName];
 
   if (!mappingTable) {
     return undefined;

--- a/packages/graphql/src/lib/scalar-mappings.ts
+++ b/packages/graphql/src/lib/scalar-mappings.ts
@@ -84,7 +84,7 @@ const SCALAR_MAPPINGS: Record<string, Record<string, ScalarMapping>> = {
     rfc3339: {
       graphqlName: "OffsetDateTime",
       baseType: "String",
-      specificationUrl: "https://datatracker.ietf.org/doc/html/rfc3339",
+      specificationUrl: "https://scalars.graphql.org/chillicream/date-time.html",
     },
     rfc7231: {
       graphqlName: "OffsetDateTimeHuman",

--- a/packages/graphql/src/lib/scalar-mappings.ts
+++ b/packages/graphql/src/lib/scalar-mappings.ts
@@ -71,7 +71,7 @@ const SCALAR_MAPPINGS: Record<string, Record<string, ScalarMapping>> = {
     rfc7231: {
       graphqlName: "UTCDateTimeHuman",
       baseType: "String",
-      specificationUrl: "https://datatracker.ietf.org/doc/html/rfc7231",
+      specificationUrl: "https://datatracker.ietf.org/doc/html/rfc7231#section-7.1.1.1",
     },
     unixTimestamp: {
       graphqlName: "UTCDateTimeUnix",

--- a/packages/graphql/src/lib/scalar-mappings.ts
+++ b/packages/graphql/src/lib/scalar-mappings.ts
@@ -150,7 +150,7 @@ const SCALAR_MAPPINGS: Record<string, Record<string, ScalarMapping>> = {
       baseType: "String",
     },
   },
-};
+} as const;
 
 /**
  * Get the GraphQL scalar mapping for a TypeSpec scalar.

--- a/packages/graphql/src/lib/scalar-mappings.ts
+++ b/packages/graphql/src/lib/scalar-mappings.ts
@@ -66,7 +66,7 @@ const SCALAR_MAPPINGS: Record<string, Record<string, ScalarMapping>> = {
     rfc3339: {
       graphqlName: "UTCDateTime",
       baseType: "String",
-      specificationUrl: "https://datatracker.ietf.org/doc/html/rfc3339",
+      specificationUrl: "https://scalars.graphql.org/chillicream/date-time.html",
     },
     rfc7231: {
       graphqlName: "UTCDateTimeHuman",

--- a/packages/graphql/src/lib/scalar-mappings.ts
+++ b/packages/graphql/src/lib/scalar-mappings.ts
@@ -57,7 +57,7 @@ const SCALAR_MAPPINGS: Record<string, Record<string, ScalarMapping>> = {
     base64url: {
       graphqlName: "BytesUrl",
       baseType: "String",
-      specificationUrl: "https://datatracker.ietf.org/doc/html/rfc4648",
+      specificationUrl: "https://datatracker.ietf.org/doc/html/rfc4648#section-5",
     },
   },
 

--- a/packages/graphql/src/lib/scalar-mappings.ts
+++ b/packages/graphql/src/lib/scalar-mappings.ts
@@ -145,13 +145,6 @@ const SCALAR_MAPPINGS = {
 type MappedScalarName = keyof typeof SCALAR_MAPPINGS;
 
 /**
- * Check if a scalar name is a key in the SCALAR_MAPPINGS table.
- */
-function isMappedScalarName(name: string): name is MappedScalarName {
-  return name in SCALAR_MAPPINGS;
-}
-
-/**
  * Check whether a scalar IS a standard library scalar (not just extends one).
  * A std scalar's std base is itself. A user-defined scalar's std base is
  * its ancestor (or null if it has no std ancestor).
@@ -161,11 +154,10 @@ export function isStdScalar(tk: Typekit, scalar: Scalar): boolean {
 }
 
 /**
- * Get the GraphQL custom scalar mapping for a scalar by walking its extends chain.
+ * Get the GraphQL custom scalar mapping for a scalar via its standard library ancestor.
  *
- * For std scalars (e.g. `int64`), returns the direct mapping.
- * For user-defined scalars that extend a mapped std scalar
- * (e.g. `scalar MyInt extends int64`), returns the ancestor's mapping.
+ * Uses `tk.scalar.getStdBase()` to find the std ancestor (e.g. `int64` for
+ * `scalar MyInt extends int64`), then looks up the mapping table by name.
  * Returns undefined for built-in scalars (string, boolean, etc.)
  * and scalars with no mapped ancestor.
  *
@@ -185,29 +177,26 @@ export function getScalarMapping(
 ): ScalarMapping | undefined {
   const tk = $(program);
 
-  // Walk the extends chain to find a mapped std scalar ancestor.
-  // Encoding is checked on the original scalar, not the ancestor.
-  const actualEncoding = encoding ?? tk.scalar.getEncoding(scalar)?.encoding;
-
-  let current: Scalar | undefined = scalar;
-  while (current) {
-    if (isStdScalar(tk, current) && isMappedScalarName(current.name)) {
-      const mappingTable = SCALAR_MAPPINGS[current.name];
-
-      if (actualEncoding) {
-        const encodingMapping = (mappingTable as Record<string, ScalarMapping>)[actualEncoding];
-        if (encodingMapping) {
-          return encodingMapping;
-        }
-      }
-
-      // Fall back to default mapping (not all mapping tables have a default)
-      return "default" in mappingTable
-        ? (mappingTable as Record<string, ScalarMapping>).default
-        : undefined;
-    }
-    current = current.baseScalar;
+  // getStdBase walks the baseScalar chain and returns the first ancestor
+  // in the TypeSpec namespace (identity-safe, not name-based).
+  const stdBase = tk.scalar.getStdBase(scalar);
+  if (!stdBase || !(stdBase.name in SCALAR_MAPPINGS)) {
+    return undefined;
   }
 
-  return undefined;
+  const mappingTable = SCALAR_MAPPINGS[stdBase.name as MappedScalarName];
+
+  // Encoding is checked on the original scalar, not the ancestor.
+  const actualEncoding = encoding ?? tk.scalar.getEncoding(scalar)?.encoding;
+  if (actualEncoding) {
+    const encodingMapping = (mappingTable as Record<string, ScalarMapping>)[actualEncoding];
+    if (encodingMapping) {
+      return encodingMapping;
+    }
+  }
+
+  // Fall back to default mapping (not all mapping tables have a default)
+  return "default" in mappingTable
+    ? (mappingTable as Record<string, ScalarMapping>).default
+    : undefined;
 }

--- a/packages/graphql/src/lib/scalar-mappings.ts
+++ b/packages/graphql/src/lib/scalar-mappings.ts
@@ -1,5 +1,5 @@
 import { type Program, type Scalar } from "@typespec/compiler";
-import { getEncode } from "@typespec/compiler";
+import { $, type Typekit } from "@typespec/compiler/typekit";
 
 /**
  * Represents a mapping from a TypeSpec standard library scalar to a GraphQL custom scalar.
@@ -102,14 +102,6 @@ const SCALAR_MAPPINGS = {
     },
   },
 
-  // unixTimestamp32 → OffsetDateTimeUnix (Int)
-  unixTimestamp32: {
-    default: {
-      graphqlName: "OffsetDateTimeUnix",
-      baseType: "Int",
-    },
-  },
-
   // duration — requires @encode to determine wire format; no default mapping without encoding
   duration: {
     ISO8601: {
@@ -148,14 +140,25 @@ const SCALAR_MAPPINGS = {
     },
   },
 
-  // unknown → Unknown (String)
-  unknown: {
-    default: {
-      graphqlName: "Unknown",
-      baseType: "String",
-    },
-  },
 } as const;
+
+type MappedScalarName = keyof typeof SCALAR_MAPPINGS;
+
+/**
+ * Check if a scalar name is a key in the SCALAR_MAPPINGS table.
+ */
+function isMappedScalarName(name: string): name is MappedScalarName {
+  return name in SCALAR_MAPPINGS;
+}
+
+/**
+ * Check whether a scalar IS a standard library scalar (not just extends one).
+ * A std scalar's std base is itself. A user-defined scalar's std base is
+ * its ancestor (or null if it has no std ancestor).
+ */
+export function isStdScalar(tk: Typekit, scalar: Scalar): boolean {
+  return tk.scalar.getStdBase(scalar) === scalar;
+}
 
 /**
  * Get the GraphQL custom scalar mapping for a TypeSpec standard library scalar.
@@ -170,27 +173,32 @@ const SCALAR_MAPPINGS = {
 export function getScalarMapping(
   program: Program,
   scalar: Scalar,
-  encoding?: string
+  encoding?: string,
 ): ScalarMapping | undefined {
-  // Only map standard library scalars, not user-defined ones
-  if (!program.checker.isStdType(scalar)) {
+  const tk = $(program);
+
+  if (!isStdScalar(tk, scalar)) {
     return undefined;
   }
 
-  const scalarName = scalar.name;
-  const mappingTable = (SCALAR_MAPPINGS as Record<string, Record<string, ScalarMapping>>)[scalarName];
-
-  if (!mappingTable) {
+  if (!isMappedScalarName(scalar.name)) {
     return undefined;
   }
+
+  const mappingTable = SCALAR_MAPPINGS[scalar.name];
 
   // Use provided encoding, or check for @encode decorator on the scalar
-  const actualEncoding = encoding ?? getEncode(program, scalar)?.encoding;
+  const actualEncoding = encoding ?? tk.scalar.getEncoding(scalar)?.encoding;
 
-  if (actualEncoding && mappingTable[actualEncoding]) {
-    return mappingTable[actualEncoding];
+  if (actualEncoding) {
+    const encodingMapping = (mappingTable as Record<string, ScalarMapping>)[actualEncoding];
+    if (encodingMapping) {
+      return encodingMapping;
+    }
   }
 
-  // Fall back to default mapping
-  return mappingTable.default;
+  // Fall back to default mapping (not all mapping tables have a default)
+  return "default" in mappingTable
+    ? (mappingTable as Record<string, ScalarMapping>).default
+    : undefined;
 }

--- a/packages/graphql/src/lib/scalar-mappings.ts
+++ b/packages/graphql/src/lib/scalar-mappings.ts
@@ -189,6 +189,9 @@ export function getScalarMapping(
   }
 
   const mappingTable = SCALAR_MAPPINGS[stdBase.name as MappedScalarName];
+  if (!mappingTable) {
+    return undefined;
+  }
 
   // Encoding is checked on the original scalar, not the ancestor.
   const actualEncoding = encoding ?? tk.scalar.getEncoding(scalar)?.encoding;

--- a/packages/graphql/src/lib/scalar-mappings.ts
+++ b/packages/graphql/src/lib/scalar-mappings.ts
@@ -2,7 +2,7 @@ import { type Program, type Scalar } from "@typespec/compiler";
 import { getEncode } from "@typespec/compiler";
 
 /**
- * Represents a mapping from TypeSpec scalar to GraphQL custom scalar
+ * Represents a mapping from a TypeSpec standard library scalar to a GraphQL custom scalar.
  */
 export interface ScalarMapping {
   /** The GraphQL scalar name to emit */
@@ -15,6 +15,10 @@ export interface ScalarMapping {
 
 /**
  * Mapping table for TypeSpec standard library scalars to GraphQL custom scalars.
+ *
+ * Built-in scalars (string, boolean, int32, float64, etc.) are NOT included here —
+ * they map directly to GraphQL built-in types and are resolved at emit time.
+ * This table only covers scalars that need to become custom GraphQL scalar types.
  */
 const SCALAR_MAPPINGS = {
   // int64 → Long (String)
@@ -154,8 +158,9 @@ const SCALAR_MAPPINGS = {
 } as const;
 
 /**
- * Get the GraphQL scalar mapping for a TypeSpec scalar.
- * Returns undefined if the scalar should be emitted as-is (custom scalar).
+ * Get the GraphQL custom scalar mapping for a TypeSpec standard library scalar.
+ * Returns undefined if the scalar is a built-in type (string, boolean, etc.)
+ * or a user-defined custom scalar — neither of which are in the mapping table.
  *
  * @param program The TypeSpec program
  * @param scalar The scalar type to map

--- a/packages/graphql/src/lib/scalar-mappings.ts
+++ b/packages/graphql/src/lib/scalar-mappings.ts
@@ -161,9 +161,17 @@ export function isStdScalar(tk: Typekit, scalar: Scalar): boolean {
 }
 
 /**
- * Get the GraphQL custom scalar mapping for a TypeSpec standard library scalar.
- * Returns undefined if the scalar is a built-in type (string, boolean, etc.)
- * or a user-defined custom scalar — neither of which are in the mapping table.
+ * Get the GraphQL custom scalar mapping for a scalar by walking its extends chain.
+ *
+ * For std scalars (e.g. `int64`), returns the direct mapping.
+ * For user-defined scalars that extend a mapped std scalar
+ * (e.g. `scalar MyInt extends int64`), returns the ancestor's mapping.
+ * Returns undefined for built-in scalars (string, boolean, etc.)
+ * and scalars with no mapped ancestor.
+ *
+ * The caller (scalar mutation) uses `isStdScalar` to decide whether to
+ * rename with `mapping.graphqlName` or keep the user's name. The mapping
+ * is always useful for metadata like `@specifiedBy`.
  *
  * @param program The TypeSpec program
  * @param scalar The scalar type to map
@@ -177,28 +185,29 @@ export function getScalarMapping(
 ): ScalarMapping | undefined {
   const tk = $(program);
 
-  if (!isStdScalar(tk, scalar)) {
-    return undefined;
-  }
-
-  if (!isMappedScalarName(scalar.name)) {
-    return undefined;
-  }
-
-  const mappingTable = SCALAR_MAPPINGS[scalar.name];
-
-  // Use provided encoding, or check for @encode decorator on the scalar
+  // Walk the extends chain to find a mapped std scalar ancestor.
+  // Encoding is checked on the original scalar, not the ancestor.
   const actualEncoding = encoding ?? tk.scalar.getEncoding(scalar)?.encoding;
 
-  if (actualEncoding) {
-    const encodingMapping = (mappingTable as Record<string, ScalarMapping>)[actualEncoding];
-    if (encodingMapping) {
-      return encodingMapping;
+  let current: Scalar | undefined = scalar;
+  while (current) {
+    if (isStdScalar(tk, current) && isMappedScalarName(current.name)) {
+      const mappingTable = SCALAR_MAPPINGS[current.name];
+
+      if (actualEncoding) {
+        const encodingMapping = (mappingTable as Record<string, ScalarMapping>)[actualEncoding];
+        if (encodingMapping) {
+          return encodingMapping;
+        }
+      }
+
+      // Fall back to default mapping (not all mapping tables have a default)
+      return "default" in mappingTable
+        ? (mappingTable as Record<string, ScalarMapping>).default
+        : undefined;
     }
+    current = current.baseScalar;
   }
 
-  // Fall back to default mapping (not all mapping tables have a default)
-  return "default" in mappingTable
-    ? (mappingTable as Record<string, ScalarMapping>).default
-    : undefined;
+  return undefined;
 }

--- a/packages/graphql/src/lib/scalar-mappings.ts
+++ b/packages/graphql/src/lib/scalar-mappings.ts
@@ -43,12 +43,14 @@ const SCALAR_MAPPINGS = {
     default: {
       graphqlName: "BigDecimal",
       baseType: "String",
+      specificationUrl: "https://scalars.graphql.org/chillicream/decimal.html",
     },
   },
   decimal128: {
     default: {
       graphqlName: "BigDecimal",
       baseType: "String",
+      specificationUrl: "https://scalars.graphql.org/chillicream/decimal.html",
     },
   },
 
@@ -120,6 +122,7 @@ const SCALAR_MAPPINGS = {
     default: {
       graphqlName: "PlainDate",
       baseType: "String",
+      specificationUrl: "https://scalars.graphql.org/andimarek/local-date.html",
     },
   },
 
@@ -128,6 +131,7 @@ const SCALAR_MAPPINGS = {
     default: {
       graphqlName: "PlainTime",
       baseType: "String",
+      specificationUrl: "https://scalars.graphql.org/apollographql/localtime-v0.1.html",
     },
   },
 

--- a/packages/graphql/src/lib/specified-by.ts
+++ b/packages/graphql/src/lib/specified-by.ts
@@ -1,0 +1,34 @@
+import {
+  type DecoratorContext,
+  type DecoratorFunction,
+  type Program,
+  type Scalar,
+  validateDecoratorUniqueOnNode,
+} from "@typespec/compiler";
+import { useStateMap } from "@typespec/compiler/utils";
+import { GraphQLKeys, NAMESPACE } from "../lib.js";
+
+// This will set the namespace for decorators implemented in this file
+export const namespace = NAMESPACE;
+
+const [getSpecifiedByUrl, setSpecifiedByUrl] = useStateMap<Scalar, string>(
+  GraphQLKeys.specifiedBy,
+);
+
+export { getSpecifiedByUrl, setSpecifiedByUrl };
+
+/**
+ * Get the @specifiedBy URL for a scalar, if one has been set.
+ */
+export function getSpecifiedBy(program: Program, scalar: Scalar): string | undefined {
+  return getSpecifiedByUrl(program, scalar);
+}
+
+export const $specifiedBy: DecoratorFunction = (
+  context: DecoratorContext,
+  target: Scalar,
+  url: string,
+) => {
+  validateDecoratorUniqueOnNode(context, target, $specifiedBy);
+  setSpecifiedByUrl(context.program, target, url);
+};

--- a/packages/graphql/src/lib/type-utils.ts
+++ b/packages/graphql/src/lib/type-utils.ts
@@ -1,0 +1,281 @@
+import {
+  type ArrayModelType,
+  type Enum,
+  getDoc,
+  getTypeName,
+  type IndeterminateEntity,
+  isNeverType,
+  isTemplateInstance,
+  type Model,
+  type Program,
+  type RecordModelType,
+  type Scalar,
+  type Type,
+  type Union,
+  type Value,
+  walkPropertiesInherited,
+} from "@typespec/compiler";
+import {
+  type AliasStatementNode,
+  type IdentifierNode,
+  type ModelPropertyNode,
+  type ModelStatementNode,
+  type Node,
+  SyntaxKind,
+  type UnionStatementNode,
+} from "@typespec/compiler/ast";
+import { camelCase, constantCase, pascalCase, split, splitSeparateNumbers } from "change-case";
+
+/** Generate a GraphQL type name for a templated model (e.g., `ListOfString`). */
+export function getTemplatedModelName(model: Model): string {
+  const name = getTypeName(model, {});
+  const baseName = toTypeName(name.replace(/<[^>]*>/g, ""));
+  const templateString = getTemplateString(model);
+  return templateString ? `${baseName}Of${templateString}` : baseName;
+}
+
+function splitWithAcronyms(
+  split: (name: string) => string[],
+  skipStart: boolean,
+  name: string,
+): string[] {
+  const result = split(name);
+
+  if (name === name.toUpperCase()) {
+    return result;
+  }
+  // Preserve strings of capital letters, e.g. "API" should be treated as three words ["A", "P", "I"] instead of one word
+  return result.flatMap((part) => {
+    const result = !skipStart && part.match(/^[A-Z]+$/) ? part.split("") : part;
+    skipStart = false;
+    return result;
+  });
+}
+
+/** Convert a name to PascalCase for GraphQL type names. */
+export function toTypeName(name: string): string {
+  const sanitized = sanitizeNameForGraphQL(getNameWithoutNamespace(name));
+  // Preserve all-caps names (acronyms like API, HTTP, URL)
+  if (/^[A-Z]+$/.test(sanitized)) {
+    return sanitized;
+  }
+  return pascalCase(sanitized, {
+    split: splitWithAcronyms.bind(null, split, false),
+  });
+}
+
+/** Sanitize a name to be a valid GraphQL identifier. */
+export function sanitizeNameForGraphQL(name: string, prefix: string = ""): string {
+  name = name.replace("[]", "Array");
+  name = name.replaceAll(/\W/g, "_");
+  if (!name.match("^[_a-zA-Z]")) {
+    name = `${prefix}_${name}`;
+  }
+  return name;
+}
+
+/** Convert a name to CONSTANT_CASE for GraphQL enum members. */
+export function toEnumMemberName(enumName: string, name: string) {
+  return constantCase(sanitizeNameForGraphQL(name, enumName), {
+    split: splitSeparateNumbers,
+    prefixCharacters: "_",
+  });
+}
+
+/** Convert a name to camelCase for GraphQL field names. */
+export function toFieldName(name: string): string {
+  return camelCase(sanitizeNameForGraphQL(name), {
+    prefixCharacters: "_",
+    split: splitWithAcronyms.bind(null, split, true),
+  });
+}
+
+function getNameWithoutNamespace(name: string): string {
+  const parts = name.trim().split(".");
+  return parts[parts.length - 1];
+}
+
+/** Generate a GraphQL type name for a union, including anonymous unions. */
+export function getUnionName(union: Union, program: Program): string {
+  // SyntaxKind.UnionExpression: Foo | Bar
+  // SyntaxKind.UnionStatement: union FooBarUnion { Foo, Bar }
+  // SyntaxKind.TypeReference: FooBarUnion
+
+  const templateString = getTemplateString(union) ? "Of" + getTemplateString(union) : "";
+
+  switch (true) {
+    case !!union.name:
+      // The union is not anonymous, use its name
+      return union.name;
+
+    case isReturnType(union):
+      // The union is a return type, use the name of the operation
+      // e.g. op getBaz(): Foo | Bar => GetBazUnion
+      return `${getUnionNameForOperation(program, union)}${templateString}Union`;
+
+    case isModelProperty(union):
+      // The union is a model property, name it based on the model + property
+      // e.g. model Foo { bar: Bar | Baz } => FooBarUnion
+      const modelProperty = getModelProperty(union);
+      const propName = toTypeName(getNameForNode(modelProperty!));
+      const unionModel = union.node?.parent?.parent as ModelStatementNode;
+      const modelName = unionModel ? getNameForNode(unionModel) : "";
+      return `${modelName}${propName}${templateString}Union`;
+
+    case isAliased(union):
+      // The union is an alias, name it based on the alias name
+      // e.g. alias Baz = Foo<string> | Bar => Baz
+      const alias = getAlias(union);
+      const aliasName = getNameForNode(alias!);
+      return `${aliasName}${templateString}`;
+
+    default:
+      throw new Error("Unrecognized union construction.");
+  }
+}
+
+function isNamedType(type: Type | Value | IndeterminateEntity): type is { name: string } & Type {
+  return "name" in type && typeof (type as { name: unknown }).name === "string";
+}
+
+function isAliased(union: Union): boolean {
+  return union.node?.parent?.kind === SyntaxKind.AliasStatement;
+}
+
+function getAlias(union: Union): AliasStatementNode | undefined {
+  return isAliased(union) ? (union.node?.parent as AliasStatementNode) : undefined;
+}
+
+function isModelProperty(union: Union): boolean {
+  return union.node?.parent?.kind === SyntaxKind.ModelProperty;
+}
+
+function getModelProperty(union: Union): ModelPropertyNode | undefined {
+  return isModelProperty(union) ? (union.node?.parent as ModelPropertyNode) : undefined;
+}
+
+function isReturnType(type: Type): boolean {
+  return !!(
+    type.node &&
+    type.node.parent?.kind === SyntaxKind.OperationSignatureDeclaration &&
+    type.node.parent?.parent?.kind === SyntaxKind.OperationStatement
+  );
+}
+
+type NamedNode = Node & { id: IdentifierNode };
+
+function getNameForNode(node: NamedNode): string {
+  return "id" in node && node.id?.kind === SyntaxKind.Identifier ? node.id.sv : "";
+}
+
+function getUnionNameForOperation(program: Program, union: Union): string {
+  const operationNode = (union.node as UnionStatementNode).parent?.parent;
+  const operation = program.checker.getTypeForNode(operationNode!);
+
+  return toTypeName(getTypeName(operation));
+}
+
+/** Convert a namespaced name to a single name by replacing dots with underscores. */
+export function getSingleNameWithNamespace(name: string): string {
+  return name.trim().replace(/\./g, "_");
+}
+
+/**
+ * Check if a model is an array type.
+ */
+export function isArray(model: Model): model is ArrayModelType {
+  return Boolean(model.indexer && model.indexer.key.name === "integer");
+}
+
+/**
+ * Check if a model is a record/map type.
+ */
+export function isRecordType(type: Model): type is RecordModelType {
+  return Boolean(type.indexer && type.indexer.key.name === "string");
+}
+
+/** Check if a model is an array of scalars or enums. */
+export function isScalarOrEnumArray(type: Model): type is ArrayModelType {
+  return (
+    isArray(type) && (type.indexer?.value.kind === "Scalar" || type.indexer?.value.kind === "Enum")
+  );
+}
+
+/** Check if a model is an array of unions. */
+export function isUnionArray(type: Model): type is ArrayModelType {
+  return isArray(type) && type.indexer?.value.kind === "Union";
+}
+
+/** Extract the element type from an array model, or return the model itself. */
+export function unwrapModel(model: ArrayModelType): Model | Scalar | Enum | Union;
+export function unwrapModel(model: Exclude<Model, ArrayModelType>): Model;
+export function unwrapModel(model: Model): Model | Scalar | Enum | Union {
+  if (!isArray(model)) {
+    return model;
+  }
+
+  if (model.indexer?.value.kind) {
+    if (["Model", "Scalar", "Enum", "Union"].includes(model.indexer.value.kind)) {
+      return model.indexer.value as Model | Scalar | Enum | Union;
+    }
+    throw new Error(`Unexpected array type: ${model.indexer.value.kind}`);
+  }
+  return model;
+}
+
+/** Unwrap array types to get the inner element type. */
+export function unwrapType(type: Model): Model | Scalar | Enum | Union;
+export function unwrapType(type: Type): Type;
+export function unwrapType(type: Type): Type {
+  if (type.kind === "Model") {
+    return unwrapModel(type);
+  }
+  return type;
+}
+
+/** Get the GraphQL description for a type from its doc comments. */
+export function getGraphQLDoc(program: Program, type: Type): string | undefined {
+  // GraphQL uses CommonMark for descriptions
+  // https://spec.graphql.org/October2021/#sec-Descriptions
+  return getDoc(program, type);
+}
+
+/** Generate a string representation of template arguments (e.g., `StringAndInt`). */
+export function getTemplateString(
+  type: Type,
+  options: { conjunction: string } = { conjunction: "And" },
+): string {
+  if (isTemplateInstance(type)) {
+    const args = type.templateMapper.args.filter(isNamedType).map((arg) => getTypeName(arg));
+    return getTemplateStringInternal(args, options);
+  }
+  return "";
+}
+
+function getTemplateStringInternal(
+  args: string[],
+  options: { conjunction: string } = { conjunction: "And" },
+): string {
+  return args.length > 0 ? toTypeName(args.map(toTypeName).join(options.conjunction)) : "";
+}
+
+/** Check if a model should be emitted as a GraphQL object type (not an array, record, or never). */
+export function isTrueModel(model: Model): boolean {
+  /* eslint-disable no-fallthrough */
+  switch (true) {
+    // A scalar array is represented as a model with an indexer
+    // and a scalar type. We don't want to emit this as a model.
+    case isScalarOrEnumArray(model):
+    // A union array is represented as a model with an indexer
+    // and a union type. We don't want to emit this as a model.
+    case isUnionArray(model):
+    case isNeverType(model):
+    // If the model is purely a record, we don't want to emit it as a model.
+    // Instead, we will need to create a scalar
+    case isRecordType(model) && [...walkPropertiesInherited(model)].length === 0:
+      return false;
+    default:
+      return true;
+  }
+  /* eslint-enable no-fallthrough */
+}

--- a/packages/graphql/src/lib/type-utils.ts
+++ b/packages/graphql/src/lib/type-utils.ts
@@ -64,8 +64,9 @@ function splitWithAcronyms(
   }
   // Preserve strings of capital letters, e.g. "API" should be treated as three words ["A", "P", "I"] instead of one word
   return parts.flatMap((part, index) => {
-    const isFirst = index === 0;
-    return !(skipStart && isFirst) && part.match(/^[A-Z]+$/) ? part.split("") : part;
+    if (skipStart && index === 0) return part;
+    if (part.match(/^[A-Z]+$/)) return part.split("");
+    return part;
   });
 }
 

--- a/packages/graphql/src/lib/type-utils.ts
+++ b/packages/graphql/src/lib/type-utils.ts
@@ -5,6 +5,7 @@ import {
   getTypeName,
   type IndeterminateEntity,
   isNeverType,
+  isNullType,
   isTemplateInstance,
   type Model,
   type Program,
@@ -12,6 +13,7 @@ import {
   type Scalar,
   type Type,
   type Union,
+  type UnionVariant,
   type Value,
   walkPropertiesInherited,
 } from "@typespec/compiler";
@@ -28,20 +30,39 @@ import { camelCase, constantCase, pascalCase, split, splitSeparateNumbers } from
 import { reportDiagnostic } from "../lib.js";
 
 /**
- * Check if a union represents a nullable type (e.g., string | null).
- * @returns The non-null variant type if this is a nullable union, otherwise undefined.
+ * Check if a union exists solely to express nullability of a single type.
+ * Matches only the `T | null` pattern (exactly 2 variants, one of which is null).
+ *
+ * These unions are not "real" unions in GraphQL terms — they're just TypeSpec's
+ * way of spelling "nullable T". The mutation engine skips further union processing for these.
+ *
+ * For multi-variant unions that contain null (e.g. `Cat | Dog | null`),
+ * use {@link stripNullVariants} instead.
  */
-export function getNullableUnionType(union: Union): Type | undefined {
-  if (union.variants.size !== 2) return undefined;
-
+export function isNullableWrapper(union: Union): boolean {
+  if (union.variants.size !== 2) return false;
   const variants = Array.from(union.variants.values());
-  const nullVariant = variants.find(
-    (v) => v.type.kind === "Intrinsic" && v.type.name === "null"
-  );
+  return variants.some((v) => isNullType(v.type));
+}
 
-  if (!nullVariant) return undefined;
-
-  return variants.find((v) => v !== nullVariant)?.type;
+/**
+ * Strip null variants from a union, returning the remaining variants
+ * and whether the union contained null.
+ *
+ * Used by the mutation engine to handle unions like `Cat | Dog | null`:
+ * the null is removed, the remaining variants are processed as a real union,
+ * and the nullability is tracked separately via the nullable state map.
+ */
+export function stripNullVariants(union: Union): {
+  variants: UnionVariant[];
+  isNullable: boolean;
+} {
+  const allVariants = Array.from(union.variants.values());
+  const nonNullVariants = allVariants.filter((v) => !isNullType(v.type));
+  return {
+    variants: nonNullVariants,
+    isNullable: nonNullVariants.length < allVariants.length,
+  };
 }
 
 /** Generate a GraphQL type name for a templated model (e.g., `ListOfString`). */

--- a/packages/graphql/src/lib/type-utils.ts
+++ b/packages/graphql/src/lib/type-utils.ts
@@ -83,42 +83,18 @@ export function toTypeName(name: string): string {
 }
 
 /**
- * Names reserved by the GraphQL specification that cannot be used as identifiers.
- * - `true`, `false`, `null` are keyword literals in GraphQL
- * - Names starting with `__` are reserved for the introspection system
+ * Sanitize a name to conform to GraphQL identifier format.
+ * Handles character-level formatting only (special chars, leading digits, array syntax).
  */
-const GRAPHQL_RESERVED_NAMES = new Set(["true", "false", "null"]);
-
-/** Sanitize a name to be a valid GraphQL identifier. */
 export function sanitizeNameForGraphQL(name: string, prefix: string = ""): string {
   name = name.replace("[]", "Array");
   name = name.replaceAll(/\W/g, "_");
   if (!/^[_a-zA-Z]/.test(name)) {
     name = `${prefix}_${name}`;
   }
-  // Guard against GraphQL reserved keywords
-  if (GRAPHQL_RESERVED_NAMES.has(name.toLowerCase())) {
-    name = `${prefix || "_"}${name}`;
-  }
   return name;
 }
 
-/**
- * Convert a numeric enum value to a valid GraphQL identifier.
- * Examples:
- * - 0 → _0
- * - 0.25 → _0_25
- * - -1 → _NEGATIVE_1
- */
-export function convertNumericEnumValue(value: number): string {
-  if (value < 0) {
-    // Negative numbers: -1 → _NEGATIVE_1, -2.5 → _NEGATIVE_2_5
-    return `_NEGATIVE_${Math.abs(value).toString().replace(/\./g, "_")}`;
-  } else {
-    // Non-negative numbers: 0 → _0, 0.25 → _0_25
-    return `_${value.toString().replace(/\./g, "_")}`;
-  }
-}
 
 /** Convert a name to CONSTANT_CASE for GraphQL enum members. */
 export function toEnumMemberName(enumName: string, name: string) {

--- a/packages/graphql/src/mutation-engine/engine.ts
+++ b/packages/graphql/src/mutation-engine/engine.ts
@@ -1,0 +1,111 @@
+import {
+  type Enum,
+  type Model,
+  type Namespace,
+  type Operation,
+  type Program,
+  type Scalar,
+  type Union,
+} from "@typespec/compiler";
+import { $ } from "@typespec/compiler/typekit";
+import {
+  MutationEngine,
+  SimpleMutationOptions,
+  SimpleInterfaceMutation,
+  SimpleIntrinsicMutation,
+  SimpleLiteralMutation,
+  SimpleUnionVariantMutation,
+} from "@typespec/mutator-framework";
+import {
+  GraphQLEnumMemberMutation,
+  GraphQLEnumMutation,
+  GraphQLModelMutation,
+  GraphQLModelPropertyMutation,
+  GraphQLOperationMutation,
+  GraphQLScalarMutation,
+  GraphQLUnionMutation,
+} from "./mutations/index.js";
+
+/**
+ * Registry configuration for the GraphQL mutation engine.
+ * Maps TypeSpec type kinds to their corresponding GraphQL mutation classes.
+ */
+const graphqlMutationRegistry = {
+  // Custom GraphQL mutations for types we need to transform
+  Enum: GraphQLEnumMutation,
+  EnumMember: GraphQLEnumMemberMutation,
+  Model: GraphQLModelMutation,
+  ModelProperty: GraphQLModelPropertyMutation,
+  Operation: GraphQLOperationMutation,
+  Scalar: GraphQLScalarMutation,
+  Union: GraphQLUnionMutation,
+  // Use Simple* classes from mutator-framework for types we don't customize
+  Interface: SimpleInterfaceMutation,
+  UnionVariant: SimpleUnionVariantMutation,
+  String: SimpleLiteralMutation,
+  Number: SimpleLiteralMutation,
+  Boolean: SimpleLiteralMutation,
+  Intrinsic: SimpleIntrinsicMutation,
+};
+
+/**
+ * GraphQL mutation engine that applies GraphQL-specific transformations
+ * to TypeSpec types, such as name sanitization.
+ */
+export class GraphQLMutationEngine {
+  /**
+   * The underlying mutation engine configured with GraphQL-specific mutation classes.
+   * Type is inferred from MutationEngine constructor to avoid complex generic constraints.
+   */
+  private engine;
+
+  constructor(program: Program, _namespace: Namespace) {
+    const tk = $(program);
+    this.engine = new MutationEngine(tk, graphqlMutationRegistry);
+  }
+
+  /**
+   * Mutate a model, applying GraphQL name sanitization.
+   */
+  mutateModel(model: Model): GraphQLModelMutation {
+    return this.engine.mutate(model, new SimpleMutationOptions()) as GraphQLModelMutation;
+  }
+
+  /**
+   * Mutate an enum, applying GraphQL name sanitization.
+   */
+  mutateEnum(enumType: Enum): GraphQLEnumMutation {
+    return this.engine.mutate(enumType, new SimpleMutationOptions()) as GraphQLEnumMutation;
+  }
+
+  /**
+   * Mutate an operation, applying GraphQL name sanitization.
+   */
+  mutateOperation(operation: Operation): GraphQLOperationMutation {
+    return this.engine.mutate(operation, new SimpleMutationOptions()) as GraphQLOperationMutation;
+  }
+
+  /**
+   * Mutate a scalar, applying GraphQL name sanitization.
+   */
+  mutateScalar(scalar: Scalar): GraphQLScalarMutation {
+    return this.engine.mutate(scalar, new SimpleMutationOptions()) as GraphQLScalarMutation;
+  }
+
+  /**
+   * Mutate a union, creating wrapper types for scalar variants.
+   */
+  mutateUnion(union: Union): GraphQLUnionMutation {
+    return this.engine.mutate(union, new SimpleMutationOptions()) as GraphQLUnionMutation;
+  }
+}
+
+/**
+ * Creates a GraphQL mutation engine for the given program and namespace.
+ */
+export function createGraphQLMutationEngine(
+  program: Program,
+  namespace: Namespace,
+): GraphQLMutationEngine {
+  return new GraphQLMutationEngine(program, namespace);
+}

--- a/packages/graphql/src/mutation-engine/engine.ts
+++ b/packages/graphql/src/mutation-engine/engine.ts
@@ -1,7 +1,6 @@
 import {
   type Enum,
   type Model,
-  type Namespace,
   type Operation,
   type Program,
   type Scalar,
@@ -59,7 +58,7 @@ export class GraphQLMutationEngine {
    */
   private engine;
 
-  constructor(program: Program, _namespace: Namespace) {
+  constructor(program: Program) {
     const tk = $(program);
     this.engine = new MutationEngine(tk, graphqlMutationRegistry);
   }
@@ -101,11 +100,8 @@ export class GraphQLMutationEngine {
 }
 
 /**
- * Creates a GraphQL mutation engine for the given program and namespace.
+ * Creates a GraphQL mutation engine for the given program.
  */
-export function createGraphQLMutationEngine(
-  program: Program,
-  namespace: Namespace,
-): GraphQLMutationEngine {
-  return new GraphQLMutationEngine(program, namespace);
+export function createGraphQLMutationEngine(program: Program): GraphQLMutationEngine {
+  return new GraphQLMutationEngine(program);
 }

--- a/packages/graphql/src/mutation-engine/engine.ts
+++ b/packages/graphql/src/mutation-engine/engine.ts
@@ -58,10 +58,9 @@ const graphqlMutationRegistry = {
  * cache ensures each (type, context) pair produces a separate mutation.
  */
 export class GraphQLMutationEngine {
-  /**
-   * The underlying mutation engine configured with GraphQL-specific mutation classes.
-   * Type is inferred from MutationEngine constructor to avoid complex generic constraints.
-   */
+  // Type is inferred from the MutationEngine constructor. Explicitly typing as
+  // MutationEngine<typeof graphqlMutationRegistry> doesn't work because the
+  // generic expects instance types, not constructor types.
   private engine;
 
   constructor(program: Program) {
@@ -70,7 +69,8 @@ export class GraphQLMutationEngine {
   }
 
   /**
-   * Mutate a model, applying GraphQL name sanitization.
+   * Mutate a model without input/output context, applying GraphQL name sanitization.
+   * Use `mutateModelAs` when the model needs to be split into input/output variants.
    */
   mutateModel(model: Model): GraphQLModelMutation {
     return this.engine.mutate(model, new SimpleMutationOptions()) as GraphQLModelMutation;

--- a/packages/graphql/src/mutation-engine/engine.ts
+++ b/packages/graphql/src/mutation-engine/engine.ts
@@ -69,19 +69,11 @@ export class GraphQLMutationEngine {
   }
 
   /**
-   * Mutate a model without input/output context, applying GraphQL name sanitization.
-   * Use `mutateModelAs` when the model needs to be split into input/output variants.
-   */
-  mutateModel(model: Model): GraphQLModelMutation {
-    return this.engine.mutate(model, new SimpleMutationOptions()) as GraphQLModelMutation;
-  }
-
-  /**
    * Mutate a model with explicit input/output context.
    * Models mutated with different contexts produce separate cached mutations,
    * allowing the same source model to have both an input and output variant.
    */
-  mutateModelAs(model: Model, context: GraphQLTypeContext): GraphQLModelMutation {
+  mutateModel(model: Model, context: GraphQLTypeContext): GraphQLModelMutation {
     return this.engine.mutate(model, new GraphQLMutationOptions(context)) as GraphQLModelMutation;
   }
 

--- a/packages/graphql/src/mutation-engine/engine.ts
+++ b/packages/graphql/src/mutation-engine/engine.ts
@@ -101,10 +101,13 @@ export class GraphQLMutationEngine {
   }
 
   /**
-   * Mutate a union, creating wrapper types for scalar variants.
+   * Mutate a union with explicit input/output context.
+   * In output context: creates wrapper types for scalar variants. mutatedType is a Union.
+   * In input context: replaces the union with a @oneOf input Model in the type graph,
+   *   since GraphQL unions are output-only. mutatedType is a Model.
    */
-  mutateUnion(union: Union): GraphQLUnionMutation {
-    return this.engine.mutate(union, new SimpleMutationOptions()) as GraphQLUnionMutation;
+  mutateUnion(union: Union, context: GraphQLTypeContext): GraphQLUnionMutation {
+    return this.engine.mutate(union, new GraphQLMutationOptions(context)) as GraphQLUnionMutation;
   }
 }
 

--- a/packages/graphql/src/mutation-engine/index.ts
+++ b/packages/graphql/src/mutation-engine/index.ts
@@ -1,4 +1,5 @@
 export { GraphQLMutationEngine, createGraphQLMutationEngine } from "./engine.js";
+export { GraphQLMutationOptions, GraphQLTypeContext } from "./options.js";
 export {
   GraphQLEnumMemberMutation,
   GraphQLEnumMutation,

--- a/packages/graphql/src/mutation-engine/index.ts
+++ b/packages/graphql/src/mutation-engine/index.ts
@@ -1,0 +1,9 @@
+export { GraphQLMutationEngine, createGraphQLMutationEngine } from "./engine.js";
+export {
+  GraphQLEnumMemberMutation,
+  GraphQLEnumMutation,
+  GraphQLModelMutation,
+  GraphQLModelPropertyMutation,
+  GraphQLOperationMutation,
+  GraphQLScalarMutation,
+} from "./mutations/index.js";

--- a/packages/graphql/src/mutation-engine/index.ts
+++ b/packages/graphql/src/mutation-engine/index.ts
@@ -6,4 +6,5 @@ export {
   GraphQLModelPropertyMutation,
   GraphQLOperationMutation,
   GraphQLScalarMutation,
+  GraphQLUnionMutation,
 } from "./mutations/index.js";

--- a/packages/graphql/src/mutation-engine/mutations/enum-member.ts
+++ b/packages/graphql/src/mutation-engine/mutations/enum-member.ts
@@ -47,7 +47,6 @@ export class GraphQLEnumMemberMutation extends EnumMemberMutation<
       // use that value to generate the name. Check node.value to see if it was explicit.
       if (
         this.sourceType.node?.value &&
-        this.sourceType.value !== undefined &&
         typeof this.sourceType.value === "number"
       ) {
         member.name = convertNumericEnumValue(this.sourceType.value);

--- a/packages/graphql/src/mutation-engine/mutations/enum-member.ts
+++ b/packages/graphql/src/mutation-engine/mutations/enum-member.ts
@@ -1,0 +1,60 @@
+import type { EnumMember, MemberType } from "@typespec/compiler";
+import {
+  EnumMemberMutation,
+  EnumMemberMutationNode,
+  MutationEngine,
+  type MutationInfo,
+  type MutationOptions,
+} from "@typespec/mutator-framework";
+import { convertNumericEnumValue, sanitizeNameForGraphQL } from "../../lib/type-utils.js";
+
+/**
+ * GraphQL-specific EnumMember mutation.
+ */
+export class GraphQLEnumMemberMutation extends EnumMemberMutation<
+  MutationOptions,
+  any,
+  MutationEngine<any>
+> {
+  #mutationNode: EnumMemberMutationNode;
+
+  constructor(
+    engine: MutationEngine<any>,
+    sourceType: EnumMember,
+    referenceTypes: MemberType[],
+    options: MutationOptions,
+    info: MutationInfo,
+  ) {
+    super(engine, sourceType, referenceTypes, options, info);
+    this.#mutationNode = this.engine.getMutationNode(this.sourceType, {
+      mutationKey: info.mutationKey,
+      isSynthetic: info.isSynthetic,
+    }) as EnumMemberMutationNode;
+  }
+
+  get mutationNode() {
+    return this.#mutationNode;
+  }
+
+  get mutatedType() {
+    return this.#mutationNode.mutatedType;
+  }
+
+  mutate() {
+    // Trigger mutation with a callback to set the name
+    this.#mutationNode.mutate((member) => {
+      // If the source enum member has an EXPLICIT numeric value (not auto-generated),
+      // use that value to generate the name. Check node.value to see if it was explicit.
+      if (
+        this.sourceType.node?.value &&
+        this.sourceType.value !== undefined &&
+        typeof this.sourceType.value === "number"
+      ) {
+        member.name = convertNumericEnumValue(this.sourceType.value);
+      } else {
+        member.name = sanitizeNameForGraphQL(member.name);
+      }
+    });
+    super.mutate();
+  }
+}

--- a/packages/graphql/src/mutation-engine/mutations/enum-member.ts
+++ b/packages/graphql/src/mutation-engine/mutations/enum-member.ts
@@ -6,7 +6,7 @@ import {
   type MutationInfo,
   type MutationOptions,
 } from "@typespec/mutator-framework";
-import { convertNumericEnumValue, sanitizeNameForGraphQL } from "../../lib/type-utils.js";
+import { sanitizeNameForGraphQL } from "../../lib/type-utils.js";
 
 /**
  * GraphQL-specific EnumMember mutation.
@@ -41,18 +41,8 @@ export class GraphQLEnumMemberMutation extends EnumMemberMutation<
   }
 
   mutate() {
-    // Trigger mutation with a callback to set the name
     this.#mutationNode.mutate((member) => {
-      // If the source enum member has an EXPLICIT numeric value (not auto-generated),
-      // use that value to generate the name. Check node.value to see if it was explicit.
-      if (
-        this.sourceType.node?.value &&
-        typeof this.sourceType.value === "number"
-      ) {
-        member.name = convertNumericEnumValue(this.sourceType.value);
-      } else {
-        member.name = sanitizeNameForGraphQL(member.name);
-      }
+      member.name = sanitizeNameForGraphQL(member.name);
     });
     super.mutate();
   }

--- a/packages/graphql/src/mutation-engine/mutations/enum.ts
+++ b/packages/graphql/src/mutation-engine/mutations/enum.ts
@@ -1,0 +1,74 @@
+import type { Enum, MemberType } from "@typespec/compiler";
+import {
+  EnumMemberMutationNode,
+  EnumMutation,
+  EnumMutationNode,
+  MutationEngine,
+  MutationHalfEdge,
+  type MutationInfo,
+  type MutationOptions,
+} from "@typespec/mutator-framework";
+import { sanitizeNameForGraphQL } from "../../lib/type-utils.js";
+import type { GraphQLEnumMemberMutation } from "./enum-member.js";
+
+/**
+ * GraphQL-specific Enum mutation.
+ */
+export class GraphQLEnumMutation extends EnumMutation<MutationOptions, any, MutationEngine<any>> {
+  #mutationNode: EnumMutationNode;
+
+  constructor(
+    engine: MutationEngine<any>,
+    sourceType: Enum,
+    referenceTypes: MemberType[],
+    options: MutationOptions,
+    info: MutationInfo,
+  ) {
+    super(engine, sourceType, referenceTypes, options, info);
+    this.#mutationNode = this.engine.getMutationNode(this.sourceType, {
+      mutationKey: info.mutationKey,
+      isSynthetic: info.isSynthetic,
+    }) as EnumMutationNode;
+  }
+
+  get mutationNode() {
+    return this.#mutationNode;
+  }
+
+  get mutatedType() {
+    return this.#mutationNode.mutatedType;
+  }
+
+  /**
+   * Creates a MutationHalfEdge that wraps the node-level edge.
+   * This ensures proper bidirectional updates when members are renamed.
+   */
+  protected startMemberEdge(): MutationHalfEdge<GraphQLEnumMutation, GraphQLEnumMemberMutation> {
+    return new MutationHalfEdge("member", this, (tail) => {
+      this.#mutationNode.connectMember(tail.mutationNode as EnumMemberMutationNode);
+    });
+  }
+
+  /**
+   * Override to pass half-edge for proper bidirectional updates.
+   */
+  protected override mutateMembers() {
+    for (const member of this.sourceType.members.values()) {
+      this.members.set(
+        member.name,
+        this.engine.mutate(member, this.options, this.startMemberEdge()),
+      );
+    }
+  }
+
+  mutate() {
+    // Apply GraphQL name sanitization to the enum
+    this.#mutationNode.mutate((enumType) => {
+      enumType.name = sanitizeNameForGraphQL(enumType.name);
+    });
+    // Handle member mutations with proper edges
+    this.mutateMembers();
+    // Call super to finalize
+    super.mutate();
+  }
+}

--- a/packages/graphql/src/mutation-engine/mutations/index.ts
+++ b/packages/graphql/src/mutation-engine/mutations/index.ts
@@ -1,0 +1,8 @@
+export { GraphQLEnumMutation } from "./enum.js";
+export { GraphQLEnumMemberMutation } from "./enum-member.js";
+export { GraphQLModelMutation } from "./model.js";
+export { GraphQLModelPropertyMutation } from "./model-property.js";
+export { GraphQLOperationMutation } from "./operation.js";
+export { GraphQLScalarMutation } from "./scalar.js";
+export { GraphQLUnionMutation } from "./union.js";
+

--- a/packages/graphql/src/mutation-engine/mutations/model-property.ts
+++ b/packages/graphql/src/mutation-engine/mutations/model-property.ts
@@ -1,0 +1,36 @@
+import type { MemberType, ModelProperty } from "@typespec/compiler";
+import {
+  SimpleModelPropertyMutation,
+  type MutationInfo,
+  type SimpleMutationEngine,
+  type SimpleMutationOptions,
+  type SimpleMutations,
+} from "@typespec/mutator-framework";
+import { sanitizeNameForGraphQL } from "../../lib/type-utils.js";
+
+/** GraphQL-specific ModelProperty mutation. */
+export class GraphQLModelPropertyMutation extends SimpleModelPropertyMutation<SimpleMutationOptions> {
+  constructor(
+    engine: SimpleMutationEngine<SimpleMutations<SimpleMutationOptions>>,
+    sourceType: ModelProperty,
+    referenceTypes: MemberType[],
+    options: SimpleMutationOptions,
+    info: MutationInfo,
+  ) {
+    super(engine, sourceType, referenceTypes, options, info);
+    // Register rename callback BEFORE any edge connections trigger mutation.
+    // whenMutated fires when the node is mutated (even via edge propagation),
+    // ensuring the name is sanitized before edge callbacks read it.
+    this.mutationNode.whenMutated((property) => {
+      if (property) {
+        property.name = sanitizeNameForGraphQL(property.name);
+      }
+    });
+  }
+
+  mutate() {
+    // Trigger mutation if not already mutated (whenMutated callback will run)
+    this.mutationNode.mutate();
+    super.mutate();
+  }
+}

--- a/packages/graphql/src/mutation-engine/mutations/model.ts
+++ b/packages/graphql/src/mutation-engine/mutations/model.ts
@@ -7,6 +7,7 @@ import {
   type SimpleMutations,
 } from "@typespec/mutator-framework";
 import { sanitizeNameForGraphQL } from "../../lib/type-utils.js";
+import { GraphQLMutationOptions, GraphQLTypeContext } from "../options.js";
 
 /**
  * GraphQL-specific Model mutation.
@@ -20,6 +21,16 @@ export class GraphQLModelMutation extends SimpleModelMutation<SimpleMutationOpti
     info: MutationInfo,
   ) {
     super(engine, sourceType, referenceTypes, options, info);
+  }
+
+  /**
+   * The input/output context this model was mutated with, if any.
+   * Undefined when the model was mutated directly (not through an operation).
+   */
+  get typeContext(): GraphQLTypeContext | undefined {
+    return this.options instanceof GraphQLMutationOptions
+      ? this.options.typeContext
+      : undefined;
   }
 
   mutate() {

--- a/packages/graphql/src/mutation-engine/mutations/model.ts
+++ b/packages/graphql/src/mutation-engine/mutations/model.ts
@@ -1,0 +1,32 @@
+import type { MemberType, Model } from "@typespec/compiler";
+import {
+  SimpleModelMutation,
+  type MutationInfo,
+  type SimpleMutationEngine,
+  type SimpleMutationOptions,
+  type SimpleMutations,
+} from "@typespec/mutator-framework";
+import { sanitizeNameForGraphQL } from "../../lib/type-utils.js";
+
+/**
+ * GraphQL-specific Model mutation.
+ */
+export class GraphQLModelMutation extends SimpleModelMutation<SimpleMutationOptions> {
+  constructor(
+    engine: SimpleMutationEngine<SimpleMutations<SimpleMutationOptions>>,
+    sourceType: Model,
+    referenceTypes: MemberType[],
+    options: SimpleMutationOptions,
+    info: MutationInfo,
+  ) {
+    super(engine, sourceType, referenceTypes, options, info);
+  }
+
+  mutate() {
+    // Apply GraphQL name sanitization
+    this.mutationNode.mutate((model) => {
+      model.name = sanitizeNameForGraphQL(model.name);
+    });
+    super.mutate();
+  }
+}

--- a/packages/graphql/src/mutation-engine/mutations/operation.ts
+++ b/packages/graphql/src/mutation-engine/mutations/operation.ts
@@ -7,6 +7,7 @@ import {
   type SimpleMutations,
 } from "@typespec/mutator-framework";
 import { sanitizeNameForGraphQL } from "../../lib/type-utils.js";
+import { GraphQLMutationOptions, GraphQLTypeContext } from "../options.js";
 
 /** GraphQL-specific Operation mutation. */
 export class GraphQLOperationMutation extends SimpleOperationMutation<SimpleMutationOptions> {
@@ -18,6 +19,32 @@ export class GraphQLOperationMutation extends SimpleOperationMutation<SimpleMuta
     info: MutationInfo,
   ) {
     super(engine, sourceType, referenceTypes, options, info);
+  }
+
+  /**
+   * Override to mutate parameters with input context.
+   * Types reachable from operation parameters become GraphQL input types.
+   */
+  protected override mutateParameters() {
+    const inputOptions = new GraphQLMutationOptions(GraphQLTypeContext.Input);
+    this.parameters = this.engine.mutate(
+      this.sourceType.parameters,
+      inputOptions,
+      this.startParametersEdge(),
+    );
+  }
+
+  /**
+   * Override to mutate return type with output context.
+   * Types reachable from operation return types become GraphQL object types.
+   */
+  protected override mutateReturnType() {
+    const outputOptions = new GraphQLMutationOptions(GraphQLTypeContext.Output);
+    this.returnType = this.engine.mutate(
+      this.sourceType.returnType,
+      outputOptions,
+      this.startReturnTypeEdge(),
+    );
   }
 
   mutate() {

--- a/packages/graphql/src/mutation-engine/mutations/operation.ts
+++ b/packages/graphql/src/mutation-engine/mutations/operation.ts
@@ -1,0 +1,30 @@
+import type { MemberType, Operation } from "@typespec/compiler";
+import {
+  SimpleOperationMutation,
+  type MutationInfo,
+  type SimpleMutationEngine,
+  type SimpleMutationOptions,
+  type SimpleMutations,
+} from "@typespec/mutator-framework";
+import { sanitizeNameForGraphQL } from "../../lib/type-utils.js";
+
+/** GraphQL-specific Operation mutation. */
+export class GraphQLOperationMutation extends SimpleOperationMutation<SimpleMutationOptions> {
+  constructor(
+    engine: SimpleMutationEngine<SimpleMutations<SimpleMutationOptions>>,
+    sourceType: Operation,
+    referenceTypes: MemberType[],
+    options: SimpleMutationOptions,
+    info: MutationInfo,
+  ) {
+    super(engine, sourceType, referenceTypes, options, info);
+  }
+
+  mutate() {
+    // Apply GraphQL name sanitization via callback
+    this.mutationNode.mutate((operation) => {
+      operation.name = sanitizeNameForGraphQL(operation.name);
+    });
+    super.mutate();
+  }
+}

--- a/packages/graphql/src/mutation-engine/mutations/scalar.ts
+++ b/packages/graphql/src/mutation-engine/mutations/scalar.ts
@@ -1,0 +1,50 @@
+import type { MemberType, Scalar } from "@typespec/compiler";
+import {
+  SimpleScalarMutation,
+  type MutationInfo,
+  type SimpleMutationEngine,
+  type SimpleMutationOptions,
+  type SimpleMutations,
+} from "@typespec/mutator-framework";
+import { sanitizeNameForGraphQL } from "../../lib/type-utils.js";
+import { getScalarMapping } from "../../lib/scalar-mappings.js";
+
+/** GraphQL-specific Scalar mutation */
+export class GraphQLScalarMutation extends SimpleScalarMutation<SimpleMutationOptions> {
+  #specificationUrl?: string;
+
+  constructor(
+    engine: SimpleMutationEngine<SimpleMutations<SimpleMutationOptions>>,
+    sourceType: Scalar,
+    referenceTypes: MemberType[],
+    options: SimpleMutationOptions,
+    info: MutationInfo,
+  ) {
+    super(engine, sourceType, referenceTypes, options, info);
+  }
+
+  /**
+   * Get the specification URL for @specifiedBy directive (if any)
+   */
+  get specificationUrl(): string | undefined {
+    return this.#specificationUrl;
+  }
+
+  mutate() {
+    // Check if this is a TypeSpec standard library scalar that maps to a GraphQL custom scalar
+    const mapping = getScalarMapping(this.engine.$.program, this.sourceType);
+
+    // Apply name transformation and store specification URL
+    this.mutationNode.mutate((scalar) => {
+      if (mapping) {
+        // Use the mapped GraphQL scalar name
+        scalar.name = mapping.graphqlName;
+        this.#specificationUrl = mapping.specificationUrl;
+      } else {
+        // Custom scalar - just sanitize the name
+        scalar.name = sanitizeNameForGraphQL(scalar.name);
+      }
+    });
+    super.mutate();
+  }
+}

--- a/packages/graphql/src/mutation-engine/mutations/scalar.ts
+++ b/packages/graphql/src/mutation-engine/mutations/scalar.ts
@@ -6,7 +6,7 @@ import {
   type SimpleMutationOptions,
   type SimpleMutations,
 } from "@typespec/mutator-framework";
-import { getScalarMapping } from "../../lib/scalar-mappings.js";
+import { getScalarMapping, isStdScalar } from "../../lib/scalar-mappings.js";
 import { getSpecifiedBy, setSpecifiedByUrl } from "../../lib/specified-by.js";
 import { sanitizeNameForGraphQL } from "../../lib/type-utils.js";
 
@@ -23,7 +23,8 @@ export class GraphQLScalarMutation extends SimpleScalarMutation<SimpleMutationOp
   }
 
   mutate() {
-    const program = this.engine.$.program;
+    const tk = this.engine.$;
+    const program = tk.program;
     const mapping = getScalarMapping(program, this.sourceType);
 
     if (mapping) {
@@ -31,7 +32,7 @@ export class GraphQLScalarMutation extends SimpleScalarMutation<SimpleMutationOp
       this.mutationNode.mutate((scalar) => {
         scalar.name = mapping.graphqlName;
       });
-    } else if (!program.checker.isStdType(this.sourceType)) {
+    } else if (!isStdScalar(tk, this.sourceType)) {
       // User-defined custom scalar — sanitize the name
       this.mutationNode.mutate((scalar) => {
         scalar.name = sanitizeNameForGraphQL(scalar.name);

--- a/packages/graphql/src/mutation-engine/mutations/scalar.ts
+++ b/packages/graphql/src/mutation-engine/mutations/scalar.ts
@@ -6,13 +6,12 @@ import {
   type SimpleMutationOptions,
   type SimpleMutations,
 } from "@typespec/mutator-framework";
-import { sanitizeNameForGraphQL } from "../../lib/type-utils.js";
 import { getScalarMapping } from "../../lib/scalar-mappings.js";
+import { getSpecifiedBy, setSpecifiedByUrl } from "../../lib/specified-by.js";
+import { sanitizeNameForGraphQL } from "../../lib/type-utils.js";
 
 /** GraphQL-specific Scalar mutation */
 export class GraphQLScalarMutation extends SimpleScalarMutation<SimpleMutationOptions> {
-  #specificationUrl?: string;
-
   constructor(
     engine: SimpleMutationEngine<SimpleMutations<SimpleMutationOptions>>,
     sourceType: Scalar,
@@ -23,28 +22,31 @@ export class GraphQLScalarMutation extends SimpleScalarMutation<SimpleMutationOp
     super(engine, sourceType, referenceTypes, options, info);
   }
 
-  /**
-   * Get the specification URL for @specifiedBy directive (if any)
-   */
-  get specificationUrl(): string | undefined {
-    return this.#specificationUrl;
-  }
-
   mutate() {
-    // Check if this is a TypeSpec standard library scalar that maps to a GraphQL custom scalar
-    const mapping = getScalarMapping(this.engine.$.program, this.sourceType);
+    const program = this.engine.$.program;
+    const mapping = getScalarMapping(program, this.sourceType);
 
-    // Apply name transformation and store specification URL
-    this.mutationNode.mutate((scalar) => {
-      if (mapping) {
-        // Use the mapped GraphQL scalar name
+    if (mapping) {
+      // Standard library scalar that maps to a custom GraphQL scalar (e.g. int64 → Long)
+      this.mutationNode.mutate((scalar) => {
         scalar.name = mapping.graphqlName;
-        this.#specificationUrl = mapping.specificationUrl;
-      } else {
-        // Custom scalar - just sanitize the name
+      });
+    } else if (!program.checker.isStdType(this.sourceType)) {
+      // User-defined custom scalar — sanitize the name
+      this.mutationNode.mutate((scalar) => {
         scalar.name = sanitizeNameForGraphQL(scalar.name);
-      }
-    });
+      });
+    }
+    // Built-in std scalars (string, boolean, int32, etc.) are left untouched —
+    // they map to GraphQL built-in types and are resolved at emit time.
+
+    // Apply @specifiedBy to the mutated scalar: explicit decorator on source wins, then mapping table
+    const specUrl =
+      getSpecifiedBy(program, this.sourceType) ?? mapping?.specificationUrl;
+    if (specUrl) {
+      setSpecifiedByUrl(program, this.mutatedType, specUrl);
+    }
+
     super.mutate();
   }
 }

--- a/packages/graphql/src/mutation-engine/mutations/scalar.ts
+++ b/packages/graphql/src/mutation-engine/mutations/scalar.ts
@@ -26,22 +26,28 @@ export class GraphQLScalarMutation extends SimpleScalarMutation<SimpleMutationOp
     const tk = this.engine.$;
     const program = tk.program;
     const mapping = getScalarMapping(program, this.sourceType);
+    const isDirectStd = isStdScalar(tk, this.sourceType);
 
-    if (mapping) {
-      // Standard library scalar that maps to a custom GraphQL scalar (e.g. int64 → Long)
+    if (mapping && isDirectStd) {
+      // Std library scalar that maps to a custom GraphQL scalar (e.g. int64 → Long)
       this.mutationNode.mutate((scalar) => {
         scalar.name = mapping.graphqlName;
+        scalar.baseScalar = undefined;
       });
-    } else if (!isStdScalar(tk, this.sourceType)) {
-      // User-defined custom scalar — sanitize the name
+    } else if (!isDirectStd) {
+      // User-defined custom scalar — sanitize name, strip extends.
+      // May still have a mapping via extends chain (e.g. scalar MyInt extends int64),
+      // which is used for @specifiedBy below but not for renaming.
       this.mutationNode.mutate((scalar) => {
         scalar.name = sanitizeNameForGraphQL(scalar.name);
+        scalar.baseScalar = undefined;
       });
     }
     // Built-in std scalars (string, boolean, int32, etc.) are left untouched —
     // they map to GraphQL built-in types and are resolved at emit time.
 
-    // Apply @specifiedBy to the mutated scalar: explicit decorator on source wins, then mapping table
+    // Apply @specifiedBy: explicit decorator on source wins, then mapping table
+    // (mapping may come from an ancestor via the extends chain)
     const specUrl =
       getSpecifiedBy(program, this.sourceType) ?? mapping?.specificationUrl;
     if (specUrl) {

--- a/packages/graphql/src/mutation-engine/mutations/union.ts
+++ b/packages/graphql/src/mutation-engine/mutations/union.ts
@@ -1,0 +1,159 @@
+import type { MemberType, Model, Type, Union } from "@typespec/compiler";
+import {
+  MutationEngine,
+  MutationHalfEdge,
+  type MutationInfo,
+  type MutationOptions,
+  SimpleUnionVariantMutation,
+  UnionMutation,
+  UnionMutationNode,
+  UnionVariantMutationNode,
+} from "@typespec/mutator-framework";
+import { getNullableUnionType, toTypeName } from "../../lib/type-utils.js";
+
+/**
+ * GraphQL-specific Union mutation.
+ * Creates synthetic wrapper models for scalar union variants since
+ * GraphQL unions can only contain object types.
+ */
+export class GraphQLUnionMutation extends UnionMutation<MutationOptions, any, MutationEngine<any>> {
+  #mutationNode: UnionMutationNode;
+  #wrapperModels: Model[] = [];
+  #flattenedUnion: Union | null = null;
+
+  constructor(
+    engine: MutationEngine<any>,
+    sourceType: Union,
+    referenceTypes: MemberType[],
+    options: MutationOptions,
+    info: MutationInfo,
+  ) {
+    super(engine, sourceType, referenceTypes, options, info);
+    this.#mutationNode = this.engine.getMutationNode(this.sourceType, {
+      mutationKey: info.mutationKey,
+      isSynthetic: info.isSynthetic,
+    }) as UnionMutationNode;
+  }
+
+  get mutationNode() {
+    return this.#mutationNode;
+  }
+
+  get mutatedType() {
+    // Return flattened union if we created one, otherwise use mutation node's type
+    return this.#flattenedUnion || this.#mutationNode.mutatedType;
+  }
+
+  /**
+   * Get the wrapper models that were created for scalar variants
+   */
+  get wrapperModels() {
+    return this.#wrapperModels;
+  }
+
+  /**
+   * Creates a MutationHalfEdge that wraps the node-level edge.
+   * This ensures proper bidirectional updates when variants are mutated.
+   */
+  protected startVariantEdge(): MutationHalfEdge<
+    GraphQLUnionMutation,
+    SimpleUnionVariantMutation<MutationOptions>
+  > {
+    return new MutationHalfEdge("variant", this, (tail) => {
+      this.#mutationNode.connectVariant(tail.mutationNode as UnionVariantMutationNode);
+    });
+  }
+
+  mutate() {
+    const tk = this.engine.$;
+
+    // Check if this is a nullable union (e.g., string | null)
+    // Don't create wrappers for nullable unions
+    if (getNullableUnionType(this.sourceType) !== undefined) {
+      // Skip wrapper creation for nullable unions
+      this.#mutationNode.mutate();
+      super.mutate();
+      return;
+    }
+
+    // Flatten nested unions: collect all variants recursively
+    const flattenedVariants = this.flattenUnionVariants(this.sourceType);
+
+    // Check if we need to flatten (contains nested unions)
+    const needsFlattening = flattenedVariants.length !== this.sourceType.variants.size;
+
+    if (needsFlattening) {
+      // Create a new flattened union using TypeKit
+      const variantArray = flattenedVariants.map((variant) => {
+        return tk.unionVariant.create({
+          name: variant.name,
+          type: variant.type,
+        });
+      });
+
+      const flattenedUnion = tk.union.create({
+        name: this.sourceType.name,
+        variants: variantArray,
+      });
+
+      // Store the flattened union - it will be returned by the mutatedType getter
+      this.#flattenedUnion = flattenedUnion;
+    } else {
+      // No flattening needed - use normal mutation
+      this.#mutationNode.mutate();
+    }
+
+    // Process each variant to wrap scalars (for non-nullable unions)
+    for (const variant of flattenedVariants) {
+      const isScalar = variant.type.kind === "Scalar" || variant.type.kind === "Intrinsic";
+
+      if (isScalar) {
+        // Create a synthetic wrapper model for this scalar variant
+        // Include union name to prevent collisions between different unions with same variant names
+        const variantName = typeof variant.name === "string" ? variant.name : String(variant.name);
+        const unionName = this.sourceType.name ?? "";
+        const wrapperName = toTypeName(unionName) + toTypeName(variantName) + "UnionVariant";
+
+        // Create a synthetic model property for the value field
+        const valueProp = tk.modelProperty.create({
+          name: "value",
+          type: variant.type,
+          optional: false,
+        });
+
+        // Create a synthetic wrapper model using TypeKit
+        const wrapperModel = tk.model.create({
+          name: wrapperName,
+          properties: { value: valueProp },
+        });
+
+        // Store the wrapper model so it can be added to classified types
+        this.#wrapperModels.push(wrapperModel);
+      }
+    }
+
+    super.mutate();
+  }
+
+  /**
+   * Recursively flatten nested unions into a single list of variants.
+   * GraphQL doesn't support nested unions, so union Pet { cat: Cat, animal: Animal }
+   * where Animal is itself a union becomes union Pet { Cat | Bear | Lion }
+   */
+  private flattenUnionVariants(union: Union): Array<{ name: string | symbol; type: Type }> {
+    const flattened: Array<{ name: string | symbol; type: Type }> = [];
+
+    for (const variant of union.variants.values()) {
+      if (variant.type.kind === "Union") {
+        // Recursively flatten nested union
+        const nestedVariants = this.flattenUnionVariants(variant.type as Union);
+        flattened.push(...nestedVariants);
+      } else {
+        // Regular variant (not a union)
+        flattened.push({ name: variant.name, type: variant.type });
+      }
+    }
+
+    return flattened;
+  }
+}

--- a/packages/graphql/src/mutation-engine/mutations/union.ts
+++ b/packages/graphql/src/mutation-engine/mutations/union.ts
@@ -13,8 +13,8 @@ import { getNullableUnionType, toTypeName } from "../../lib/type-utils.js";
 
 /**
  * GraphQL-specific Union mutation.
- * Creates synthetic wrapper models for scalar union variants since
- * GraphQL unions can only contain object types.
+ * Flattens nested unions and creates synthetic wrapper models for scalar
+ * union variants since GraphQL unions can only contain object types.
  */
 export class GraphQLUnionMutation extends UnionMutation<MutationOptions, any, MutationEngine<any>> {
   #mutationNode: UnionMutationNode;
@@ -45,7 +45,8 @@ export class GraphQLUnionMutation extends UnionMutation<MutationOptions, any, Mu
   }
 
   /**
-   * Get the wrapper models that were created for scalar variants
+   * Synthetic wrapper models created for scalar union variants.
+   * These are collected by the emitter and emitted as separate GraphQL object types.
    */
   get wrapperModels() {
     return this.#wrapperModels;
@@ -110,7 +111,7 @@ export class GraphQLUnionMutation extends UnionMutation<MutationOptions, any, Mu
       if (isScalar) {
         // Create a synthetic wrapper model for this scalar variant
         // Include union name to prevent collisions between different unions with same variant names
-        const variantName = typeof variant.name === "string" ? variant.name : String(variant.name);
+        const variantName = typeof variant.name === "string" ? variant.name : (variant.name.description ?? "");
         const unionName = this.sourceType.name ?? "";
         const wrapperName = toTypeName(unionName) + toTypeName(variantName) + "UnionVariant";
 

--- a/packages/graphql/src/mutation-engine/mutations/union.ts
+++ b/packages/graphql/src/mutation-engine/mutations/union.ts
@@ -106,8 +106,10 @@ export class GraphQLUnionMutation extends UnionMutation<MutationOptions, any, Mu
 
   mutate() {
     // A nullable wrapper (e.g. `string | null`) is not a real union —
-    // it's just TypeSpec's way of spelling "nullable T". Skip union processing.
+    // it's just TypeSpec's way of spelling "nullable T". Skip union processing,
+    // but mark as nullable so the emitter knows not to emit `!`.
     if (isNullableWrapper(this.sourceType)) {
+      setNullable(this.engine.$.program, this.sourceType);
       this.#mutationNode.mutate();
       super.mutate();
       return;

--- a/packages/graphql/src/mutation-engine/mutations/union.ts
+++ b/packages/graphql/src/mutation-engine/mutations/union.ts
@@ -10,12 +10,33 @@ import {
   UnionVariantMutationNode,
 } from "@typespec/mutator-framework";
 import { reportDiagnostic } from "../../lib.js";
-import { getNullableUnionType, toTypeName } from "../../lib/type-utils.js";
+import { setOneOf } from "../../lib/one-of.js";
+import {
+  getNullableUnionType,
+  getUnionName,
+  sanitizeNameForGraphQL,
+  toTypeName,
+} from "../../lib/type-utils.js";
+import { GraphQLMutationOptions, GraphQLTypeContext } from "../options.js";
+
+/**
+ * Get the string name from a union variant name, which may be a string or symbol.
+ * Symbols arise from anonymous/expression unions; we use their description as the name.
+ */
+function variantNameToString(name: string | symbol): string {
+  return typeof name === "string" ? name : (name.description ?? "");
+}
 
 /**
  * GraphQL-specific Union mutation.
- * Flattens nested unions and creates synthetic wrapper models for scalar
- * union variants since GraphQL unions can only contain object types.
+ *
+ * In output context: flattens nested unions, deduplicates variants,
+ * and creates synthetic wrapper models for scalar variants since GraphQL unions
+ * can only contain object types.
+ *
+ * In input context: creates a synthetic @oneOf input object, because GraphQL unions
+ * are output-only. Each variant becomes a nullable field on the input object, and
+ * exactly one field must be provided (oneOf semantics).
  */
 export class GraphQLUnionMutation extends UnionMutation<MutationOptions, any, MutationEngine<any>> {
   #mutationNode: UnionMutationNode;
@@ -36,11 +57,26 @@ export class GraphQLUnionMutation extends UnionMutation<MutationOptions, any, Mu
     }) as UnionMutationNode;
   }
 
+  /**
+   * The input/output context this union was mutated with.
+   * Undefined when the options are not GraphQLMutationOptions (e.g. via
+   * SimpleMutationOptions edge propagation).
+   */
+  get typeContext(): GraphQLTypeContext | undefined {
+    return this.options instanceof GraphQLMutationOptions
+      ? this.options.typeContext
+      : undefined;
+  }
+
   get mutationNode() {
     return this.#mutationNode;
   }
 
-  get mutatedType() {
+  get mutatedType(): Union | Model {
+    // In input context, the union node is replaced with a @oneOf Model
+    if (this.#mutationNode.isReplaced && this.#mutationNode.replacementNode) {
+      return this.#mutationNode.replacementNode.mutatedType as Model;
+    }
     // Return flattened union if we created one, otherwise use mutation node's type
     return this.#flattenedUnion || this.#mutationNode.mutatedType;
   }
@@ -67,30 +103,44 @@ export class GraphQLUnionMutation extends UnionMutation<MutationOptions, any, Mu
   }
 
   mutate() {
-    const tk = this.engine.$;
-
     // Check if this is a nullable union (e.g., string | null)
-    // Don't create wrappers for nullable unions
+    // Nullable unions are handled by the nullability system, not as unions
     if (getNullableUnionType(this.sourceType) !== undefined) {
-      // Skip wrapper creation for nullable unions
       this.#mutationNode.mutate();
       super.mutate();
       return;
     }
 
-    // Flatten nested unions: collect all variants recursively
+    if (this.typeContext === GraphQLTypeContext.Input) {
+      this.mutateAsOneOfInput();
+      // Don't call super.mutate() — the union node has been replaced with a
+      // Model, so iterating union variants is not needed
+      return;
+    }
+
+    this.mutateAsOutputUnion();
+    super.mutate();
+  }
+
+  /**
+   * Mutate as an output union: flatten nested unions, deduplicate, and
+   * wrap scalar variants in synthetic models.
+   */
+  private mutateAsOutputUnion() {
+    const tk = this.engine.$;
+
     const flattenedVariants = this.deduplicateVariants(
       this.flattenUnionVariants(this.sourceType),
     );
 
-    // Check if we need to flatten (contains nested unions)
     const needsFlattening = flattenedVariants.length !== this.sourceType.variants.size;
 
     if (needsFlattening) {
       // Create a new flattened union using TypeKit
+      // Convert symbol names to strings — GraphQL identifiers must be strings
       const variantArray = flattenedVariants.map((variant) => {
         return tk.unionVariant.create({
-          name: variant.name,
+          name: variantNameToString(variant.name),
           type: variant.type,
         });
       });
@@ -100,43 +150,79 @@ export class GraphQLUnionMutation extends UnionMutation<MutationOptions, any, Mu
         variants: variantArray,
       });
 
-      // Store the flattened union - it will be returned by the mutatedType getter
       this.#flattenedUnion = flattenedUnion;
     } else {
-      // No flattening needed - use normal mutation
       this.#mutationNode.mutate();
     }
 
-    // Process each variant to wrap scalars (for non-nullable unions)
+    // Wrap scalar variants in synthetic models (GraphQL unions can only contain object types)
     for (const variant of flattenedVariants) {
       const isScalar = variant.type.kind === "Scalar" || variant.type.kind === "Intrinsic";
 
       if (isScalar) {
-        // Create a synthetic wrapper model for this scalar variant
-        // Include union name to prevent collisions between different unions with same variant names
-        const variantName = typeof variant.name === "string" ? variant.name : (variant.name.description ?? "");
+        const variantName = variantNameToString(variant.name);
         const unionName = this.sourceType.name ?? "";
         const wrapperName = toTypeName(unionName) + toTypeName(variantName) + "UnionVariant";
 
-        // Create a synthetic model property for the value field
         const valueProp = tk.modelProperty.create({
           name: "value",
           type: variant.type,
           optional: false,
         });
 
-        // Create a synthetic wrapper model using TypeKit
         const wrapperModel = tk.model.create({
           name: wrapperName,
           properties: { value: valueProp },
         });
 
-        // Store the wrapper model so it can be added to classified types
         this.#wrapperModels.push(wrapperModel);
       }
     }
+  }
 
-    super.mutate();
+  /**
+   * Mutate as a @oneOf input object. GraphQL unions are output-only, so when
+   * a union appears in input context it becomes a oneOf Input Object where
+   * each variant is a nullable field and exactly one must be provided.
+   *
+   * @see https://spec.graphql.org/September2025/#sec-OneOf-Input-Objects
+   */
+  private mutateAsOneOfInput() {
+    const tk = this.engine.$;
+    const program = tk.program;
+
+    const flattenedVariants = this.deduplicateVariants(
+      this.flattenUnionVariants(this.sourceType),
+    );
+
+    // Create one nullable field per variant
+    const properties: Record<string, ReturnType<typeof tk.modelProperty.create>> = {};
+    for (const variant of flattenedVariants) {
+      const fieldName = sanitizeNameForGraphQL(variantNameToString(variant.name));
+      properties[fieldName] = tk.modelProperty.create({
+        name: fieldName,
+        type: variant.type,
+        // All fields are optional — oneOf semantics mean exactly one must be provided,
+        // but from the schema perspective each individual field is nullable
+        optional: true,
+      });
+    }
+
+    const unionName = getUnionName(this.sourceType, program);
+    const modelName = sanitizeNameForGraphQL(unionName) + "Input";
+
+    const oneOfModel = tk.model.create({
+      name: modelName,
+      properties,
+    });
+
+    // Mark as @oneOf so the emitter can emit the directive
+    setOneOf(program, oneOfModel);
+
+    // Replace the union node with the model in the type graph.
+    // This notifies all parent edges (ModelProperty, UnionVariant) via onTailReplaced,
+    // so their mutatedType.type automatically points to the oneOf Model.
+    this.#mutationNode.replace(oneOfModel);
   }
 
   /**

--- a/packages/graphql/src/mutation-engine/mutations/union.ts
+++ b/packages/graphql/src/mutation-engine/mutations/union.ts
@@ -1,4 +1,4 @@
-import type { MemberType, Model, Type, Union } from "@typespec/compiler";
+import { type MemberType, type Model, type Type, type Union, getTypeName } from "@typespec/compiler";
 import {
   MutationEngine,
   MutationHalfEdge,
@@ -9,6 +9,7 @@ import {
   UnionMutationNode,
   UnionVariantMutationNode,
 } from "@typespec/mutator-framework";
+import { reportDiagnostic } from "../../lib.js";
 import { getNullableUnionType, toTypeName } from "../../lib/type-utils.js";
 
 /**
@@ -78,7 +79,9 @@ export class GraphQLUnionMutation extends UnionMutation<MutationOptions, any, Mu
     }
 
     // Flatten nested unions: collect all variants recursively
-    const flattenedVariants = this.flattenUnionVariants(this.sourceType);
+    const flattenedVariants = this.deduplicateVariants(
+      this.flattenUnionVariants(this.sourceType),
+    );
 
     // Check if we need to flatten (contains nested unions)
     const needsFlattening = flattenedVariants.length !== this.sourceType.variants.size;
@@ -162,5 +165,31 @@ export class GraphQLUnionMutation extends UnionMutation<MutationOptions, any, Mu
     }
 
     return flattened;
+  }
+
+  /**
+   * Remove duplicate variants by type identity. If two variants reference the
+   * same type, the first occurrence wins and a diagnostic is emitted.
+   */
+  private deduplicateVariants(
+    variants: Array<{ name: string | symbol; type: Type }>,
+  ): Array<{ name: string | symbol; type: Type }> {
+    const seen = new Map<Type, { name: string | symbol; type: Type }>();
+    const result: Array<{ name: string | symbol; type: Type }> = [];
+
+    for (const variant of variants) {
+      if (seen.has(variant.type)) {
+        reportDiagnostic(this.engine.$.program, {
+          code: "duplicate-union-variant",
+          format: { type: getTypeName(variant.type) },
+          target: this.sourceType,
+        });
+      } else {
+        seen.set(variant.type, variant);
+        result.push(variant);
+      }
+    }
+
+    return result;
   }
 }

--- a/packages/graphql/src/mutation-engine/mutations/union.ts
+++ b/packages/graphql/src/mutation-engine/mutations/union.ts
@@ -10,11 +10,13 @@ import {
   UnionVariantMutationNode,
 } from "@typespec/mutator-framework";
 import { reportDiagnostic } from "../../lib.js";
+import { setNullable } from "../../lib/nullable.js";
 import { setOneOf } from "../../lib/one-of.js";
 import {
-  getNullableUnionType,
   getUnionName,
+  isNullableWrapper,
   sanitizeNameForGraphQL,
+  stripNullVariants,
   toTypeName,
 } from "../../lib/type-utils.js";
 import { GraphQLMutationOptions, GraphQLTypeContext } from "../options.js";
@@ -103,9 +105,9 @@ export class GraphQLUnionMutation extends UnionMutation<MutationOptions, any, Mu
   }
 
   mutate() {
-    // Check if this is a nullable union (e.g., string | null)
-    // Nullable unions are handled by the nullability system, not as unions
-    if (getNullableUnionType(this.sourceType) !== undefined) {
+    // A nullable wrapper (e.g. `string | null`) is not a real union —
+    // it's just TypeSpec's way of spelling "nullable T". Skip union processing.
+    if (isNullableWrapper(this.sourceType)) {
       this.#mutationNode.mutate();
       super.mutate();
       return;
@@ -128,15 +130,25 @@ export class GraphQLUnionMutation extends UnionMutation<MutationOptions, any, Mu
    */
   private mutateAsOutputUnion() {
     const tk = this.engine.$;
+    const program = tk.program;
+
+    // Strip null variants before processing — null is not a valid GraphQL union member.
+    // Nullability is tracked separately via the state map.
+    const { variants: sourceVariants, isNullable: hasNull } = stripNullVariants(this.sourceType);
 
     const flattenedVariants = this.deduplicateVariants(
-      this.flattenUnionVariants(this.sourceType),
+      this.flattenVariants(sourceVariants),
     );
 
-    const needsFlattening = flattenedVariants.length !== this.sourceType.variants.size;
+    if (flattenedVariants.length === 0) {
+      reportDiagnostic(program, { code: "empty-union", target: this.sourceType });
+      return;
+    }
 
-    if (needsFlattening) {
-      // Create a new flattened union using TypeKit
+    const needsFlattening = flattenedVariants.length !== sourceVariants.length;
+
+    if (needsFlattening || hasNull) {
+      // Create a new union using TypeKit
       // Convert symbol names to strings — GraphQL identifiers must be strings
       const variantArray = flattenedVariants.map((variant) => {
         return tk.unionVariant.create({
@@ -153,6 +165,10 @@ export class GraphQLUnionMutation extends UnionMutation<MutationOptions, any, Mu
       this.#flattenedUnion = flattenedUnion;
     } else {
       this.#mutationNode.mutate();
+    }
+
+    if (hasNull) {
+      setNullable(program, this.mutatedType);
     }
 
     // Wrap scalar variants in synthetic models (GraphQL unions can only contain object types)
@@ -191,9 +207,17 @@ export class GraphQLUnionMutation extends UnionMutation<MutationOptions, any, Mu
     const tk = this.engine.$;
     const program = tk.program;
 
+    // Strip null variants before processing
+    const { variants: sourceVariants, isNullable: hasNull } = stripNullVariants(this.sourceType);
+
     const flattenedVariants = this.deduplicateVariants(
-      this.flattenUnionVariants(this.sourceType),
+      this.flattenVariants(sourceVariants),
     );
+
+    if (flattenedVariants.length === 0) {
+      reportDiagnostic(program, { code: "empty-union", target: this.sourceType });
+      return;
+    }
 
     // Create one nullable field per variant
     const properties: Record<string, ReturnType<typeof tk.modelProperty.create>> = {};
@@ -219,6 +243,10 @@ export class GraphQLUnionMutation extends UnionMutation<MutationOptions, any, Mu
     // Mark as @oneOf so the emitter can emit the directive
     setOneOf(program, oneOfModel);
 
+    if (hasNull) {
+      setNullable(program, oneOfModel);
+    }
+
     // Replace the union node with the model in the type graph.
     // This notifies all parent edges (ModelProperty, UnionVariant) via onTailReplaced,
     // so their mutatedType.type automatically points to the oneOf Model.
@@ -228,23 +256,25 @@ export class GraphQLUnionMutation extends UnionMutation<MutationOptions, any, Mu
   /**
    * Recursively flatten nested unions into a single list of variants.
    * GraphQL doesn't support nested unions, so union Pet { cat: Cat, animal: Animal }
-   * where Animal is itself a union becomes union Pet { Cat | Bear | Lion }
+   * where Animal is itself a union becomes union Pet { Cat | Bear | Lion }.
+   *
+   * Null variants are stripped at each level — nested unions may also contain null.
    */
-  private flattenUnionVariants(
-    union: Union,
+  private flattenVariants(
+    variants: readonly { name: string | symbol; type: Type }[],
     seen: Set<Union> = new Set(),
   ): Array<{ name: string | symbol; type: Type }> {
-    if (seen.has(union)) {
-      return [];
-    }
-    seen.add(union);
-
     const flattened: Array<{ name: string | symbol; type: Type }> = [];
 
-    for (const variant of union.variants.values()) {
+    for (const variant of variants) {
       if (variant.type.kind === "Union") {
-        const nestedVariants = this.flattenUnionVariants(variant.type as Union, seen);
-        flattened.push(...nestedVariants);
+        const nestedUnion = variant.type as Union;
+        if (seen.has(nestedUnion)) continue;
+        seen.add(nestedUnion);
+
+        // Strip null from nested unions too
+        const { variants: nestedVariants } = stripNullVariants(nestedUnion);
+        flattened.push(...this.flattenVariants(nestedVariants, seen));
       } else {
         flattened.push({ name: variant.name, type: variant.type });
       }

--- a/packages/graphql/src/mutation-engine/options.ts
+++ b/packages/graphql/src/mutation-engine/options.ts
@@ -1,0 +1,30 @@
+import { SimpleMutationOptions } from "@typespec/mutator-framework";
+
+/**
+ * Context for how a type is used in GraphQL operations.
+ * Determines whether a model becomes an object type (output) or input type (input).
+ */
+export enum GraphQLTypeContext {
+  /** Type reachable from operation parameters */
+  Input = "input",
+  /** Type reachable from operation return types */
+  Output = "output",
+}
+
+/**
+ * Mutation options that carry input/output context through the type graph.
+ * The mutationKey ensures the framework caches input and output variants
+ * separately for the same source type.
+ */
+export class GraphQLMutationOptions extends SimpleMutationOptions {
+  readonly typeContext: GraphQLTypeContext;
+
+  constructor(typeContext: GraphQLTypeContext) {
+    super();
+    this.typeContext = typeContext;
+  }
+
+  override get mutationKey(): string {
+    return this.typeContext;
+  }
+}

--- a/packages/graphql/src/testing/index.ts
+++ b/packages/graphql/src/testing/index.ts
@@ -1,7 +1,7 @@
 import type { TypeSpecTestLibrary } from "@typespec/compiler/testing";
 import { createTestLibrary, findTestPackageRoot } from "@typespec/compiler/testing";
 
-export const GraphqlTestLibrary: TypeSpecTestLibrary = createTestLibrary({
+export const GraphQLTestLibrary: TypeSpecTestLibrary = createTestLibrary({
   name: "@typespec/graphql",
   packageRoot: await findTestPackageRoot(import.meta.url),
 });

--- a/packages/graphql/src/tsp-index.ts
+++ b/packages/graphql/src/tsp-index.ts
@@ -4,6 +4,7 @@ import { $compose, $Interface } from "./lib/interface.js";
 import { $operationFields } from "./lib/operation-fields.js";
 import { $mutation, $query, $subscription } from "./lib/operation-kind.js";
 import { $schema } from "./lib/schema.js";
+import { $specifiedBy } from "./lib/specified-by.js";
 
 export const $decorators: DecoratorImplementations = {
   [NAMESPACE]: {
@@ -13,6 +14,7 @@ export const $decorators: DecoratorImplementations = {
     query: $query,
     operationFields: $operationFields,
     schema: $schema,
+    specifiedBy: $specifiedBy,
     subscription: $subscription,
   },
 };

--- a/packages/graphql/test/lib/type-utils.test.ts
+++ b/packages/graphql/test/lib/type-utils.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from "vitest";
+import {
+  getSingleNameWithNamespace,
+  sanitizeNameForGraphQL,
+  toEnumMemberName,
+  toFieldName,
+  toTypeName,
+} from "../../src/lib/type-utils.js";
+
+describe("type-utils", () => {
+  describe("sanitizeNameForGraphQL", () => {
+    it("replaces special characters with underscores", () => {
+      expect(sanitizeNameForGraphQL("$Money$")).toBe("_Money_");
+      expect(sanitizeNameForGraphQL("My-Name")).toBe("My_Name");
+      expect(sanitizeNameForGraphQL("Hello.World")).toBe("Hello_World");
+    });
+
+    it("replaces [] with Array", () => {
+      expect(sanitizeNameForGraphQL("Item[]")).toBe("ItemArray");
+    });
+
+    it("leaves valid names unchanged", () => {
+      expect(sanitizeNameForGraphQL("ValidName")).toBe("ValidName");
+      expect(sanitizeNameForGraphQL("_underscore")).toBe("_underscore");
+      expect(sanitizeNameForGraphQL("name123")).toBe("name123");
+    });
+
+    it("adds prefix for names starting with numbers", () => {
+      expect(sanitizeNameForGraphQL("123Name")).toBe("_123Name");
+      expect(sanitizeNameForGraphQL("1")).toBe("_1");
+    });
+
+    it("handles multiple special characters", () => {
+      expect(sanitizeNameForGraphQL("$My-Special.Name$")).toBe("_My_Special_Name_");
+    });
+
+    it("handles empty prefix parameter", () => {
+      expect(sanitizeNameForGraphQL("123Name", "")).toBe("_123Name");
+    });
+
+    it("uses custom prefix for invalid starting character", () => {
+      expect(sanitizeNameForGraphQL("123Name", "Num")).toBe("Num_123Name");
+    });
+  });
+
+  describe("toTypeName", () => {
+    it("converts to PascalCase", () => {
+      expect(toTypeName("my_name")).toBe("MyName");
+      expect(toTypeName("some-value")).toBe("SomeValue");
+      expect(toTypeName("hello_world")).toBe("HelloWorld");
+    });
+
+    it("preserves all-caps acronyms", () => {
+      expect(toTypeName("API")).toBe("API");
+      expect(toTypeName("APIResponse")).toBe("APIResponse");
+      expect(toTypeName("myAPIKey")).toBe("MyAPIKey");
+      expect(toTypeName("HTTPResponse")).toBe("HTTPResponse");
+    });
+
+    it("handles namespaced names by using only the last part", () => {
+      expect(toTypeName("MyNamespace.MyType")).toBe("MyType");
+      expect(toTypeName("A.B.C.MyType")).toBe("MyType");
+    });
+
+    it("sanitizes and converts special characters", () => {
+      // Special chars become underscores, then PascalCase removes them
+      expect(toTypeName("my-special$name")).toBe("MySpecialName");
+      expect(toTypeName("$invalid")).toBe("Invalid");
+    });
+  });
+
+  describe("toEnumMemberName", () => {
+    it("converts to CONSTANT_CASE", () => {
+      expect(toEnumMemberName("MyEnum", "myValue")).toBe("MY_VALUE");
+      expect(toEnumMemberName("Status", "inProgress")).toBe("IN_PROGRESS");
+    });
+
+    it("handles already uppercase names", () => {
+      expect(toEnumMemberName("MyEnum", "ACTIVE")).toBe("ACTIVE");
+    });
+
+    it("uses enum name as prefix for invalid starting characters", () => {
+      expect(toEnumMemberName("Priority", "1High")).toBe("PRIORITY_1_HIGH");
+    });
+
+    it("handles special characters", () => {
+      expect(toEnumMemberName("MyEnum", "value-with-dashes")).toBe("VALUE_WITH_DASHES");
+    });
+
+    it("separates numbers", () => {
+      expect(toEnumMemberName("MyEnum", "value123")).toBe("VALUE_123");
+    });
+  });
+
+  describe("toFieldName", () => {
+    it("converts to camelCase", () => {
+      expect(toFieldName("MyField")).toBe("myField");
+      expect(toFieldName("SOME_VALUE")).toBe("someValue");
+    });
+
+    it("handles snake_case", () => {
+      expect(toFieldName("my_field_name")).toBe("myFieldName");
+    });
+
+    it("handles special characters", () => {
+      expect(toFieldName("my-field")).toBe("myField");
+      expect(toFieldName("$special")).toBe("_special");
+    });
+
+    it("preserves leading underscores", () => {
+      expect(toFieldName("_private")).toBe("_private");
+      expect(toFieldName("__internal")).toBe("__internal");
+    });
+  });
+
+  describe("getSingleNameWithNamespace", () => {
+    it("replaces dots with underscores", () => {
+      expect(getSingleNameWithNamespace("My.Namespace.Type")).toBe("My_Namespace_Type");
+    });
+
+    it("trims whitespace", () => {
+      expect(getSingleNameWithNamespace("  My.Type  ")).toBe("My_Type");
+    });
+
+    it("handles names without namespace", () => {
+      expect(getSingleNameWithNamespace("MyType")).toBe("MyType");
+    });
+  });
+});

--- a/packages/graphql/test/lib/type-utils.test.ts
+++ b/packages/graphql/test/lib/type-utils.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, it } from "vitest";
 import {
-  convertNumericEnumValue,
   getSingleNameWithNamespace,
   sanitizeNameForGraphQL,
   toEnumMemberName,
@@ -41,29 +40,6 @@ describe("type-utils", () => {
 
     it("uses custom prefix for invalid starting character", () => {
       expect(sanitizeNameForGraphQL("123Name", "Num")).toBe("Num_123Name");
-    });
-
-    it("prefixes GraphQL reserved keywords", () => {
-      expect(sanitizeNameForGraphQL("true")).toBe("_true");
-      expect(sanitizeNameForGraphQL("false")).toBe("_false");
-      expect(sanitizeNameForGraphQL("null")).toBe("_null");
-    });
-
-    it("uses custom prefix for reserved keywords", () => {
-      expect(sanitizeNameForGraphQL("true", "Val")).toBe("Valtrue");
-    });
-
-    it("handles case-insensitive reserved keyword check", () => {
-      expect(sanitizeNameForGraphQL("True")).toBe("_True");
-      expect(sanitizeNameForGraphQL("FALSE")).toBe("_FALSE");
-      expect(sanitizeNameForGraphQL("Null")).toBe("_Null");
-    });
-
-    it("preserves double-underscore prefix", () => {
-      // Double-underscore names are reserved by GraphQL introspection, but sanitizeNameForGraphQL
-      // doesn't strip them since TypeSpec names won't normally start with __ and the camelCase
-      // prefixCharacters option relies on preserving leading underscores.
-      expect(sanitizeNameForGraphQL("__typename")).toBe("__typename");
     });
   });
 
@@ -151,40 +127,4 @@ describe("type-utils", () => {
     });
   });
 
-  describe("convertNumericEnumValue", () => {
-    it("converts zero", () => {
-      expect(convertNumericEnumValue(0)).toBe("_0");
-    });
-
-    it("converts positive integers", () => {
-      expect(convertNumericEnumValue(1)).toBe("_1");
-      expect(convertNumericEnumValue(42)).toBe("_42");
-    });
-
-    it("converts negative integers", () => {
-      expect(convertNumericEnumValue(-1)).toBe("_NEGATIVE_1");
-      expect(convertNumericEnumValue(-42)).toBe("_NEGATIVE_42");
-    });
-
-    it("converts positive decimals", () => {
-      expect(convertNumericEnumValue(0.25)).toBe("_0_25");
-      expect(convertNumericEnumValue(3.14)).toBe("_3_14");
-    });
-
-    it("converts negative decimals", () => {
-      expect(convertNumericEnumValue(-2.5)).toBe("_NEGATIVE_2_5");
-    });
-
-    it("handles NaN", () => {
-      expect(convertNumericEnumValue(NaN)).toBe("_NaN");
-    });
-
-    it("handles Infinity", () => {
-      expect(convertNumericEnumValue(Infinity)).toBe("_Infinity");
-    });
-
-    it("handles negative Infinity", () => {
-      expect(convertNumericEnumValue(-Infinity)).toBe("_NEGATIVE_Infinity");
-    });
-  });
 });

--- a/packages/graphql/test/mutation-engine/graphql-mutation-engine.test.ts
+++ b/packages/graphql/test/mutation-engine/graphql-mutation-engine.test.ts
@@ -4,13 +4,8 @@ import { beforeEach, describe, expect, it } from "vitest";
 import { createGraphQLMutationEngine } from "../../src/mutation-engine/index.js";
 import { Tester } from "../test-host.js";
 
-/**
- * Helper to create the engine with the global namespace.
- * For unit tests, we use the global namespace since individual types
- * aren't placed in a custom namespace.
- */
 function createTestEngine(program: Parameters<typeof createGraphQLMutationEngine>[0]) {
-  return createGraphQLMutationEngine(program, program.getGlobalNamespaceType());
+  return createGraphQLMutationEngine(program);
 }
 
 describe("GraphQL Mutation Engine - Enums", () => {

--- a/packages/graphql/test/mutation-engine/graphql-mutation-engine.test.ts
+++ b/packages/graphql/test/mutation-engine/graphql-mutation-engine.test.ts
@@ -1,0 +1,315 @@
+import type { EnumMember } from "@typespec/compiler";
+import { t } from "@typespec/compiler/testing";
+import { beforeEach, describe, expect, it } from "vitest";
+import { createGraphQLMutationEngine } from "../../src/mutation-engine/index.js";
+import { Tester } from "../test-host.js";
+
+/**
+ * Helper to create the engine with the global namespace.
+ * For unit tests, we use the global namespace since individual types
+ * aren't placed in a custom namespace.
+ */
+function createTestEngine(program: Parameters<typeof createGraphQLMutationEngine>[0]) {
+  return createGraphQLMutationEngine(program, program.getGlobalNamespaceType());
+}
+
+describe("GraphQL Mutation Engine - Enums", () => {
+  let tester: Awaited<ReturnType<typeof Tester.createInstance>>;
+  beforeEach(async () => {
+    tester = await Tester.createInstance();
+  });
+
+  it("leaves valid enum names alone", async () => {
+    const { ValidEnum } = await tester.compile(
+      t.code`enum ${t.enum("ValidEnum")} {
+        Value
+      }`,
+    );
+
+    const engine = createTestEngine(tester.program);
+    const mutated = engine.mutateEnum(ValidEnum).mutatedType;
+
+    expect(mutated.name).toBe("ValidEnum");
+  });
+
+  it("renames invalid enum names", async () => {
+    await tester.compile(
+      t.code`enum ${t.enum("$Invalid$")} {
+        Value
+      }`,
+    );
+
+    const InvalidEnum = tester.program.getGlobalNamespaceType().enums.get("$Invalid$")!;
+    const engine = createTestEngine(tester.program);
+    const mutated = engine.mutateEnum(InvalidEnum).mutatedType;
+
+    expect(mutated.name).toBe("_Invalid_");
+  });
+
+  it("processes enum members through sanitization", async () => {
+    const { MyEnum } = await tester.compile(
+      t.code`enum ${t.enum("MyEnum")} {
+        ValidMember
+      }`,
+    );
+
+    const engine = createTestEngine(tester.program);
+    const mutated = engine.mutateEnum(MyEnum).mutatedType;
+
+    expect(mutated.name).toBe("MyEnum");
+    expect(mutated.members.has("ValidMember")).toBe(true);
+  });
+});
+
+describe("GraphQL Mutation Engine - Enum Members", () => {
+  let tester: Awaited<ReturnType<typeof Tester.createInstance>>;
+  beforeEach(async () => {
+    tester = await Tester.createInstance();
+  });
+
+  it("leaves valid enum member names alone", async () => {
+    const { MyEnum } = await tester.compile(
+      t.code`enum ${t.enum("MyEnum")} {
+        ${t.enumMember("ValidMember")}
+      }`,
+    );
+
+    // Mutate the enum and check the member via the enum's mutation
+    const engine = createTestEngine(tester.program);
+    const mutated = engine.mutateEnum(MyEnum).mutatedType;
+    const member = mutated.members.get("ValidMember");
+
+    expect(member?.name).toBe("ValidMember");
+  });
+
+  it("renames invalid enum member names", async () => {
+    const { MyEnum } = await tester.compile(
+      t.code`enum ${t.enum("MyEnum")} {
+        \`$Value$\`
+      }`,
+    );
+
+    const engine = createTestEngine(tester.program);
+    const mutated = engine.mutateEnum(MyEnum).mutatedType;
+
+    // Check that the member was renamed in the mutated enum
+    const member = Array.from(mutated.members.values())[0] as EnumMember;
+    expect(member.name).toBe("_Value_");
+  });
+});
+
+describe("GraphQL Mutation Engine - Models", () => {
+  let tester: Awaited<ReturnType<typeof Tester.createInstance>>;
+  beforeEach(async () => {
+    tester = await Tester.createInstance();
+  });
+
+  it("leaves valid model names alone", async () => {
+    const { ValidModel } = await tester.compile(t.code`model ${t.model("ValidModel")} { }`);
+
+    const engine = createTestEngine(tester.program);
+    const mutation = engine.mutateModel(ValidModel);
+
+    expect(mutation.mutatedType.name).toBe("ValidModel");
+  });
+
+  it("renames invalid model names", async () => {
+    await tester.compile(t.code`model ${t.model("$Invalid$")} { }`);
+
+    const InvalidModel = tester.program.getGlobalNamespaceType().models.get("$Invalid$")!;
+    const engine = createTestEngine(tester.program);
+    const mutation = engine.mutateModel(InvalidModel);
+
+    expect(mutation.mutatedType.name).toBe("_Invalid_");
+  });
+
+  it("processes model properties through sanitization", async () => {
+    const { TestModel } = await tester.compile(
+      t.code`model ${t.model("TestModel")} { validProp: string }`,
+    );
+
+    const engine = createTestEngine(tester.program);
+    const mutation = engine.mutateModel(TestModel);
+
+    expect(mutation.mutatedType.name).toBe("TestModel");
+    expect(mutation.mutatedType.properties.has("validProp")).toBe(true);
+  });
+});
+
+describe("GraphQL Mutation Engine - Model Properties", () => {
+  let tester: Awaited<ReturnType<typeof Tester.createInstance>>;
+  beforeEach(async () => {
+    tester = await Tester.createInstance();
+  });
+
+  it("leaves valid property names alone", async () => {
+    const { M } = await tester.compile(
+      t.code`model ${t.model("M")} { ${t.modelProperty("prop")}: string }`,
+    );
+
+    const engine = createTestEngine(tester.program);
+    const mutation = engine.mutateModel(M);
+    const prop = mutation.mutatedType.properties.get("prop");
+
+    expect(prop?.name).toBe("prop");
+  });
+
+  it("renames invalid property names", async () => {
+    const { M } = await tester.compile(t.code`model ${t.model("M")} { \`$prop$\`: string }`);
+
+    const engine = createTestEngine(tester.program);
+    const mutation = engine.mutateModel(M);
+
+    // Check that the property was renamed in the mutated model
+    expect(mutation.mutatedType.properties.has("_prop_")).toBe(true);
+    expect(mutation.mutatedType.properties.has("$prop$")).toBe(false);
+  });
+});
+
+describe("GraphQL Mutation Engine - Operations", () => {
+  let tester: Awaited<ReturnType<typeof Tester.createInstance>>;
+  beforeEach(async () => {
+    tester = await Tester.createInstance();
+  });
+
+  it("leaves valid operation names alone", async () => {
+    const { ValidOp } = await tester.compile(t.code`op ${t.op("ValidOp")}(): void;`);
+
+    const engine = createTestEngine(tester.program);
+    const mutation = engine.mutateOperation(ValidOp);
+
+    expect(mutation.mutatedType.name).toBe("ValidOp");
+  });
+
+  it("renames invalid operation names", async () => {
+    await tester.compile(t.code`op ${t.op("$Do$")}(): void;`);
+
+    const DoOp = tester.program.getGlobalNamespaceType().operations.get("$Do$")!;
+    const engine = createTestEngine(tester.program);
+    const mutation = engine.mutateOperation(DoOp);
+
+    expect(mutation.mutatedType.name).toBe("_Do_");
+  });
+
+  it("renames operation names with hyphens", async () => {
+    await tester.compile(t.code`op \`get-data\`(): void;`);
+
+    const GetDataOp = tester.program.getGlobalNamespaceType().operations.get("get-data")!;
+    const engine = createTestEngine(tester.program);
+    const mutation = engine.mutateOperation(GetDataOp);
+
+    expect(mutation.mutatedType.name).toBe("get_data");
+  });
+});
+
+describe("GraphQL Mutation Engine - Scalars", () => {
+  let tester: Awaited<ReturnType<typeof Tester.createInstance>>;
+  beforeEach(async () => {
+    tester = await Tester.createInstance();
+  });
+
+  it("leaves valid scalar names alone", async () => {
+    const { ValidScalar } = await tester.compile(
+      t.code`scalar ${t.scalar("ValidScalar")} extends string;`,
+    );
+
+    const engine = createTestEngine(tester.program);
+    const mutation = engine.mutateScalar(ValidScalar);
+
+    expect(mutation.mutatedType.name).toBe("ValidScalar");
+  });
+
+  it("renames invalid scalar names", async () => {
+    await tester.compile(t.code`scalar ${t.scalar("$Invalid$")} extends string;`);
+
+    const InvalidScalar = tester.program.getGlobalNamespaceType().scalars.get("$Invalid$")!;
+    const engine = createTestEngine(tester.program);
+    const mutation = engine.mutateScalar(InvalidScalar);
+
+    expect(mutation.mutatedType.name).toBe("_Invalid_");
+  });
+});
+
+describe("GraphQL Mutation Engine - Edge Cases", () => {
+  let tester: Awaited<ReturnType<typeof Tester.createInstance>>;
+  beforeEach(async () => {
+    tester = await Tester.createInstance();
+  });
+
+  it("handles model with multiple invalid properties", async () => {
+    const { M } = await tester.compile(
+      t.code`model ${t.model("M")} { 
+        \`$prop1$\`: string;
+        \`prop-2\`: int32;
+        \`prop.3\`: boolean;
+      }`,
+    );
+
+    const engine = createTestEngine(tester.program);
+    const mutation = engine.mutateModel(M);
+    const mutated = mutation.mutatedType;
+
+    expect(mutated.properties.has("_prop1_")).toBe(true);
+    expect(mutated.properties.has("prop_2")).toBe(true);
+    expect(mutated.properties.has("prop_3")).toBe(true);
+    expect(mutated.properties.has("$prop1$")).toBe(false);
+    expect(mutated.properties.has("prop-2")).toBe(false);
+    expect(mutated.properties.has("prop.3")).toBe(false);
+  });
+
+  it("handles enum with multiple invalid members", async () => {
+    const { E } = await tester.compile(
+      t.code`enum ${t.enum("E")} {
+        \`$val1$\`,
+        \`val-2\`,
+        \`val.3\`
+      }`,
+    );
+
+    const engine = createTestEngine(tester.program);
+    const mutated = engine.mutateEnum(E).mutatedType;
+
+    expect(mutated.members.has("_val1_")).toBe(true);
+    expect(mutated.members.has("val_2")).toBe(true);
+    expect(mutated.members.has("val_3")).toBe(true);
+  });
+
+  it("preserves valid underscore-prefixed names", async () => {
+    const { _ValidName } = await tester.compile(t.code`model ${t.model("_ValidName")} { }`);
+
+    const engine = createTestEngine(tester.program);
+    const mutation = engine.mutateModel(_ValidName);
+
+    expect(mutation.mutatedType.name).toBe("_ValidName");
+  });
+
+  it("preserves names with numbers in the middle", async () => {
+    const { Model123 } = await tester.compile(t.code`model ${t.model("Model123")} { }`);
+
+    const engine = createTestEngine(tester.program);
+    const mutation = engine.mutateModel(Model123);
+
+    expect(mutation.mutatedType.name).toBe("Model123");
+  });
+
+  it("handles property names starting with numbers", async () => {
+    const { M } = await tester.compile(t.code`model ${t.model("M")} { \`123prop\`: string; }`);
+
+    const engine = createTestEngine(tester.program);
+    const mutation = engine.mutateModel(M);
+    const mutated = mutation.mutatedType;
+
+    expect(mutated.properties.has("_123prop")).toBe(true);
+    expect(mutated.properties.has("123prop")).toBe(false);
+  });
+
+  it("handles enum member names starting with numbers", async () => {
+    const { E } = await tester.compile(t.code`enum ${t.enum("E")} { \`123value\` }`);
+
+    const engine = createTestEngine(tester.program);
+    const mutated = engine.mutateEnum(E).mutatedType;
+
+    expect(mutated.members.has("_123value")).toBe(true);
+    expect(mutated.members.has("123value")).toBe(false);
+  });
+});

--- a/packages/graphql/test/mutation-engine/graphql-mutation-engine.test.ts
+++ b/packages/graphql/test/mutation-engine/graphql-mutation-engine.test.ts
@@ -403,6 +403,7 @@ describe("GraphQL Mutation Engine - Unions", () => {
     const mutation = engine.mutateUnion(NullableString, GraphQLTypeContext.Output);
 
     expect(mutation.wrapperModels).toHaveLength(0);
+    expect(isNullable(tester.program, NullableString)).toBe(true);
   });
 
   it("skips union processing for nullable model wrapper", async () => {
@@ -420,6 +421,7 @@ describe("GraphQL Mutation Engine - Unions", () => {
     // it should pass through without union processing
     expect(mutation.mutatedType.kind).toBe("Union");
     expect(mutation.wrapperModels).toHaveLength(0);
+    expect(isNullable(tester.program, MaybeDog)).toBe(true);
   });
 
   it("creates wrapper models for scalar variants", async () => {

--- a/packages/graphql/test/mutation-engine/graphql-mutation-engine.test.ts
+++ b/packages/graphql/test/mutation-engine/graphql-mutation-engine.test.ts
@@ -107,7 +107,7 @@ describe("GraphQL Mutation Engine - Models", () => {
     const { ValidModel } = await tester.compile(t.code`model ${t.model("ValidModel")} { }`);
 
     const engine = createTestEngine(tester.program);
-    const mutation = engine.mutateModel(ValidModel);
+    const mutation = engine.mutateModel(ValidModel, GraphQLTypeContext.Output);
 
     expect(mutation.mutatedType.name).toBe("ValidModel");
   });
@@ -117,7 +117,7 @@ describe("GraphQL Mutation Engine - Models", () => {
 
     const InvalidModel = tester.program.getGlobalNamespaceType().models.get("$Invalid$")!;
     const engine = createTestEngine(tester.program);
-    const mutation = engine.mutateModel(InvalidModel);
+    const mutation = engine.mutateModel(InvalidModel, GraphQLTypeContext.Output);
 
     expect(mutation.mutatedType.name).toBe("_Invalid_");
   });
@@ -128,7 +128,7 @@ describe("GraphQL Mutation Engine - Models", () => {
     );
 
     const engine = createTestEngine(tester.program);
-    const mutation = engine.mutateModel(TestModel);
+    const mutation = engine.mutateModel(TestModel, GraphQLTypeContext.Output);
 
     expect(mutation.mutatedType.name).toBe("TestModel");
     expect(mutation.mutatedType.properties.has("validProp")).toBe(true);
@@ -147,7 +147,7 @@ describe("GraphQL Mutation Engine - Model Properties", () => {
     );
 
     const engine = createTestEngine(tester.program);
-    const mutation = engine.mutateModel(M);
+    const mutation = engine.mutateModel(M, GraphQLTypeContext.Output);
     const prop = mutation.mutatedType.properties.get("prop");
 
     expect(prop?.name).toBe("prop");
@@ -157,7 +157,7 @@ describe("GraphQL Mutation Engine - Model Properties", () => {
     const { M } = await tester.compile(t.code`model ${t.model("M")} { \`$prop$\`: string }`);
 
     const engine = createTestEngine(tester.program);
-    const mutation = engine.mutateModel(M);
+    const mutation = engine.mutateModel(M, GraphQLTypeContext.Output);
 
     // Check that the property was renamed in the mutated model
     expect(mutation.mutatedType.properties.has("_prop_")).toBe(true);
@@ -271,7 +271,7 @@ describe("GraphQL Mutation Engine - Edge Cases", () => {
     );
 
     const engine = createTestEngine(tester.program);
-    const mutation = engine.mutateModel(M);
+    const mutation = engine.mutateModel(M, GraphQLTypeContext.Output);
     const mutated = mutation.mutatedType;
 
     expect(mutated.properties.has("_prop1_")).toBe(true);
@@ -303,7 +303,7 @@ describe("GraphQL Mutation Engine - Edge Cases", () => {
     const { _ValidName } = await tester.compile(t.code`model ${t.model("_ValidName")} { }`);
 
     const engine = createTestEngine(tester.program);
-    const mutation = engine.mutateModel(_ValidName);
+    const mutation = engine.mutateModel(_ValidName, GraphQLTypeContext.Output);
 
     expect(mutation.mutatedType.name).toBe("_ValidName");
   });
@@ -312,7 +312,7 @@ describe("GraphQL Mutation Engine - Edge Cases", () => {
     const { Model123 } = await tester.compile(t.code`model ${t.model("Model123")} { }`);
 
     const engine = createTestEngine(tester.program);
-    const mutation = engine.mutateModel(Model123);
+    const mutation = engine.mutateModel(Model123, GraphQLTypeContext.Output);
 
     expect(mutation.mutatedType.name).toBe("Model123");
   });
@@ -321,7 +321,7 @@ describe("GraphQL Mutation Engine - Edge Cases", () => {
     const { M } = await tester.compile(t.code`model ${t.model("M")} { \`123prop\`: string; }`);
 
     const engine = createTestEngine(tester.program);
-    const mutation = engine.mutateModel(M);
+    const mutation = engine.mutateModel(M, GraphQLTypeContext.Output);
     const mutated = mutation.mutatedType;
 
     expect(mutated.properties.has("_123prop")).toBe(true);
@@ -446,8 +446,8 @@ describe("GraphQL Mutation Engine - Input/Output Context", () => {
     );
 
     const engine = createTestEngine(tester.program);
-    const inputMutation = engine.mutateModelAs(Book, GraphQLTypeContext.Input);
-    const outputMutation = engine.mutateModelAs(Book, GraphQLTypeContext.Output);
+    const inputMutation = engine.mutateModel(Book, GraphQLTypeContext.Input);
+    const outputMutation = engine.mutateModel(Book, GraphQLTypeContext.Output);
 
     // Different mutation objects (different cache entries)
     expect(inputMutation).not.toBe(outputMutation);
@@ -462,8 +462,8 @@ describe("GraphQL Mutation Engine - Input/Output Context", () => {
     );
 
     const engine = createTestEngine(tester.program);
-    const first = engine.mutateModelAs(Book, GraphQLTypeContext.Input);
-    const second = engine.mutateModelAs(Book, GraphQLTypeContext.Input);
+    const first = engine.mutateModel(Book, GraphQLTypeContext.Input);
+    const second = engine.mutateModel(Book, GraphQLTypeContext.Input);
 
     expect(first).toBe(second);
   });
@@ -474,23 +474,13 @@ describe("GraphQL Mutation Engine - Input/Output Context", () => {
     );
 
     const engine = createTestEngine(tester.program);
-    const inputMutation = engine.mutateModelAs(Book, GraphQLTypeContext.Input);
-    const outputMutation = engine.mutateModelAs(Book, GraphQLTypeContext.Output);
+    const inputMutation = engine.mutateModel(Book, GraphQLTypeContext.Input);
+    const outputMutation = engine.mutateModel(Book, GraphQLTypeContext.Output);
 
     expect(inputMutation.typeContext).toBe(GraphQLTypeContext.Input);
     expect(outputMutation.typeContext).toBe(GraphQLTypeContext.Output);
   });
 
-  it("has no typeContext when mutated without explicit context", async () => {
-    const { Book } = await tester.compile(
-      t.code`model ${t.model("Book")} { title: string; }`,
-    );
-
-    const engine = createTestEngine(tester.program);
-    const mutation = engine.mutateModel(Book);
-
-    expect(mutation.typeContext).toBeUndefined();
-  });
 });
 
 describe("GraphQL Mutation Engine - Operation Context Propagation", () => {
@@ -511,7 +501,7 @@ describe("GraphQL Mutation Engine - Operation Context Propagation", () => {
     engine.mutateOperation(createBook);
 
     // The model should now be cached under the input key
-    const inputMutation = engine.mutateModelAs(Book, GraphQLTypeContext.Input);
+    const inputMutation = engine.mutateModel(Book, GraphQLTypeContext.Input);
     expect(inputMutation.typeContext).toBe(GraphQLTypeContext.Input);
   });
 
@@ -527,7 +517,7 @@ describe("GraphQL Mutation Engine - Operation Context Propagation", () => {
     engine.mutateOperation(getBook);
 
     // The model should now be cached under the output key
-    const outputMutation = engine.mutateModelAs(Book, GraphQLTypeContext.Output);
+    const outputMutation = engine.mutateModel(Book, GraphQLTypeContext.Output);
     expect(outputMutation.typeContext).toBe(GraphQLTypeContext.Output);
   });
 
@@ -542,8 +532,8 @@ describe("GraphQL Mutation Engine - Operation Context Propagation", () => {
     const engine = createTestEngine(tester.program);
     engine.mutateOperation(createBook);
 
-    const inputMutation = engine.mutateModelAs(Book, GraphQLTypeContext.Input);
-    const outputMutation = engine.mutateModelAs(Book, GraphQLTypeContext.Output);
+    const inputMutation = engine.mutateModel(Book, GraphQLTypeContext.Input);
+    const outputMutation = engine.mutateModel(Book, GraphQLTypeContext.Output);
 
     expect(inputMutation).not.toBe(outputMutation);
     expect(inputMutation.typeContext).toBe(GraphQLTypeContext.Input);
@@ -563,7 +553,7 @@ describe("GraphQL Mutation Engine - Operation Context Propagation", () => {
     engine.mutateOperation(createBook);
 
     // Author should also be cached under input context via Book's property
-    const authorInput = engine.mutateModelAs(Author, GraphQLTypeContext.Input);
+    const authorInput = engine.mutateModel(Author, GraphQLTypeContext.Input);
     expect(authorInput.typeContext).toBe(GraphQLTypeContext.Input);
   });
 
@@ -579,7 +569,7 @@ describe("GraphQL Mutation Engine - Operation Context Propagation", () => {
     const engine = createTestEngine(tester.program);
     engine.mutateOperation(getBook);
 
-    const authorOutput = engine.mutateModelAs(Author, GraphQLTypeContext.Output);
+    const authorOutput = engine.mutateModel(Author, GraphQLTypeContext.Output);
     expect(authorOutput.typeContext).toBe(GraphQLTypeContext.Output);
   });
 });

--- a/packages/graphql/test/mutation-engine/graphql-mutation-engine.test.ts
+++ b/packages/graphql/test/mutation-engine/graphql-mutation-engine.test.ts
@@ -1,6 +1,7 @@
-import type { EnumMember, Model } from "@typespec/compiler";
+import type { EnumMember, Model, Union } from "@typespec/compiler";
 import { t } from "@typespec/compiler/testing";
 import { beforeEach, describe, expect, it } from "vitest";
+import { isNullable } from "../../src/lib/nullable.js";
 import { isOneOf } from "../../src/lib/one-of.js";
 import { getSpecifiedBy } from "../../src/lib/specified-by.js";
 import {
@@ -404,6 +405,23 @@ describe("GraphQL Mutation Engine - Unions", () => {
     expect(mutation.wrapperModels).toHaveLength(0);
   });
 
+  it("skips union processing for nullable model wrapper", async () => {
+    const { MaybeDog } = await tester.compile(
+      t.code`
+        model ${t.model("Dog")} { breed: string; }
+        union ${t.union("MaybeDog")} { Dog, null }
+      `,
+    );
+
+    const engine = createTestEngine(tester.program);
+    const mutation = engine.mutateUnion(MaybeDog, GraphQLTypeContext.Output);
+
+    // This is a nullable wrapper (Dog | null), not a real union —
+    // it should pass through without union processing
+    expect(mutation.mutatedType.kind).toBe("Union");
+    expect(mutation.wrapperModels).toHaveLength(0);
+  });
+
   it("creates wrapper models for scalar variants", async () => {
     const { Mixed } = await tester.compile(
       t.code`
@@ -774,6 +792,66 @@ describe("GraphQL Mutation Engine - oneOf Input Objects", () => {
 
     // Nullable unions are not real unions — union is kept, not replaced
     expect(mutation.mutatedType.kind).toBe("Union");
+  });
+
+  it("strips null from multi-variant union in output context", async () => {
+    const { Pet } = await tester.compile(
+      t.code`
+        model ${t.model("Cat")} { name: string; }
+        model ${t.model("Dog")} { breed: string; }
+        union ${t.union("Pet")} { cat: Cat; dog: Dog; null; }
+      `,
+    );
+
+    const engine = createTestEngine(tester.program);
+    const mutation = engine.mutateUnion(Pet, GraphQLTypeContext.Output);
+
+    // Null should be stripped — only Cat and Dog remain
+    const mutatedUnion = mutation.mutatedType as Union;
+    expect(mutatedUnion.kind).toBe("Union");
+    expect(mutatedUnion.variants.size).toBe(2);
+
+    // The result should be marked as nullable
+    expect(isNullable(tester.program, mutatedUnion)).toBe(true);
+  });
+
+  it("strips null from multi-variant union in input context", async () => {
+    const { Pet } = await tester.compile(
+      t.code`
+        model ${t.model("Cat")} { name: string; }
+        model ${t.model("Dog")} { breed: string; }
+        union ${t.union("Pet")} { cat: Cat; dog: Dog; null; }
+      `,
+    );
+
+    const engine = createTestEngine(tester.program);
+    const mutation = engine.mutateUnion(Pet, GraphQLTypeContext.Input);
+
+    // Should become a @oneOf model with 2 fields (null stripped)
+    const model = mutation.mutatedType as Model;
+    expect(model.kind).toBe("Model");
+    expect(model.properties.size).toBe(2);
+    expect(model.properties.has("cat")).toBe(true);
+    expect(model.properties.has("dog")).toBe(true);
+
+    // Should be marked as both @oneOf and nullable
+    expect(isOneOf(tester.program, model)).toBe(true);
+    expect(isNullable(tester.program, model)).toBe(true);
+  });
+
+  it("non-nullable union is not marked as nullable", async () => {
+    const { Pet } = await tester.compile(
+      t.code`
+        model ${t.model("Cat")} { name: string; }
+        model ${t.model("Dog")} { breed: string; }
+        union ${t.union("Pet")} { cat: Cat; dog: Dog; }
+      `,
+    );
+
+    const engine = createTestEngine(tester.program);
+    const mutation = engine.mutateUnion(Pet, GraphQLTypeContext.Output);
+
+    expect(isNullable(tester.program, mutation.mutatedType)).toBe(false);
   });
 
   it("exposes typeContext on union mutation", async () => {

--- a/packages/graphql/test/mutation-engine/graphql-mutation-engine.test.ts
+++ b/packages/graphql/test/mutation-engine/graphql-mutation-engine.test.ts
@@ -1,6 +1,7 @@
 import type { EnumMember } from "@typespec/compiler";
 import { t } from "@typespec/compiler/testing";
 import { beforeEach, describe, expect, it } from "vitest";
+import { getSpecifiedBy } from "../../src/lib/specified-by.js";
 import {
   createGraphQLMutationEngine,
   GraphQLTypeContext,
@@ -226,6 +227,32 @@ describe("GraphQL Mutation Engine - Scalars", () => {
 
     expect(mutation.mutatedType.name).toBe("_Invalid_");
   });
+
+  it("has no @specifiedBy when decorator is not applied", async () => {
+    const { MyScalar } = await tester.compile(
+      t.code`scalar ${t.scalar("MyScalar")} extends string;`,
+    );
+
+    const engine = createTestEngine(tester.program);
+    const mutation = engine.mutateScalar(MyScalar);
+
+    expect(getSpecifiedBy(tester.program, mutation.mutatedType)).toBeUndefined();
+  });
+
+  it("applies @specifiedBy from decorator to mutated scalar", async () => {
+    const { MyScalar } = await tester.compile(
+      t.code`
+        @specifiedBy("https://example.com/my-scalar-spec")
+        scalar ${t.scalar("MyScalar")} extends string;
+      `,
+    );
+
+    const engine = createTestEngine(tester.program);
+    const mutation = engine.mutateScalar(MyScalar);
+
+    expect(getSpecifiedBy(tester.program, mutation.mutatedType)).toBe("https://example.com/my-scalar-spec");
+  });
+
 });
 
 describe("GraphQL Mutation Engine - Edge Cases", () => {

--- a/packages/graphql/test/mutation-engine/graphql-mutation-engine.test.ts
+++ b/packages/graphql/test/mutation-engine/graphql-mutation-engine.test.ts
@@ -1,6 +1,7 @@
-import type { EnumMember } from "@typespec/compiler";
+import type { EnumMember, Model } from "@typespec/compiler";
 import { t } from "@typespec/compiler/testing";
 import { beforeEach, describe, expect, it } from "vitest";
+import { isOneOf } from "../../src/lib/one-of.js";
 import { getSpecifiedBy } from "../../src/lib/specified-by.js";
 import {
   createGraphQLMutationEngine,
@@ -398,7 +399,7 @@ describe("GraphQL Mutation Engine - Unions", () => {
     );
 
     const engine = createTestEngine(tester.program);
-    const mutation = engine.mutateUnion(NullableString);
+    const mutation = engine.mutateUnion(NullableString, GraphQLTypeContext.Output);
 
     expect(mutation.wrapperModels).toHaveLength(0);
   });
@@ -412,7 +413,7 @@ describe("GraphQL Mutation Engine - Unions", () => {
     );
 
     const engine = createTestEngine(tester.program);
-    const mutation = engine.mutateUnion(Mixed);
+    const mutation = engine.mutateUnion(Mixed, GraphQLTypeContext.Output);
 
     // Only the scalar variant (string) should get a wrapper
     expect(mutation.wrapperModels).toHaveLength(1);
@@ -429,7 +430,7 @@ describe("GraphQL Mutation Engine - Unions", () => {
     );
 
     const engine = createTestEngine(tester.program);
-    const mutation = engine.mutateUnion(Pet);
+    const mutation = engine.mutateUnion(Pet, GraphQLTypeContext.Output);
 
     expect(mutation.wrapperModels).toHaveLength(0);
   });
@@ -440,7 +441,7 @@ describe("GraphQL Mutation Engine - Unions", () => {
     );
 
     const engine = createTestEngine(tester.program);
-    const mutation = engine.mutateUnion(Data);
+    const mutation = engine.mutateUnion(Data, GraphQLTypeContext.Output);
 
     expect(mutation.wrapperModels).toHaveLength(1);
     const wrapper = mutation.wrapperModels[0];
@@ -458,7 +459,7 @@ describe("GraphQL Mutation Engine - Unions", () => {
     );
 
     const engine = createTestEngine(tester.program);
-    const mutation = engine.mutateUnion(Mixed);
+    const mutation = engine.mutateUnion(Mixed, GraphQLTypeContext.Output);
 
     expect(mutation.wrapperModels).toHaveLength(2);
     const names = mutation.wrapperModels.map((m) => m.name).sort();
@@ -475,7 +476,7 @@ describe("GraphQL Mutation Engine - Unions", () => {
     );
 
     const engine = createTestEngine(tester.program);
-    const mutation = engine.mutateUnion(ValidUnion);
+    const mutation = engine.mutateUnion(ValidUnion, GraphQLTypeContext.Output);
 
     expect(mutation.mutatedType.name).toBe("ValidUnion");
   });
@@ -618,5 +619,176 @@ describe("GraphQL Mutation Engine - Operation Context Propagation", () => {
 
     const authorOutput = engine.mutateModel(Author, GraphQLTypeContext.Output);
     expect(authorOutput.typeContext).toBe(GraphQLTypeContext.Output);
+  });
+
+  it("replaces union parameter with oneOf model via operation mutation", async () => {
+    const { Pet, createPet } = await tester.compile(
+      t.code`
+        model ${t.model("Cat")} { name: string; }
+        model ${t.model("Dog")} { breed: string; }
+        union ${t.union("Pet")} { cat: Cat; dog: Dog; }
+        op ${t.op("createPet")}(input: Pet): void;
+      `,
+    );
+
+    const engine = createTestEngine(tester.program);
+    engine.mutateOperation(createPet);
+
+    // The union should be cached under input context and replaced with a oneOf model
+    const unionMutation = engine.mutateUnion(Pet, GraphQLTypeContext.Input);
+    expect(unionMutation.mutatedType.kind).toBe("Model");
+    expect(unionMutation.mutatedType.name).toBe("PetInput");
+    expect(isOneOf(tester.program, unionMutation.mutatedType as Model)).toBe(true);
+  });
+
+  it("keeps union return type as union via operation mutation", async () => {
+    const { Pet, getPet } = await tester.compile(
+      t.code`
+        model ${t.model("Cat")} { name: string; }
+        model ${t.model("Dog")} { breed: string; }
+        union ${t.union("Pet")} { cat: Cat; dog: Dog; }
+        op ${t.op("getPet")}(): Pet;
+      `,
+    );
+
+    const engine = createTestEngine(tester.program);
+    engine.mutateOperation(getPet);
+
+    // The union in output context stays a union (not replaced)
+    const unionMutation = engine.mutateUnion(Pet, GraphQLTypeContext.Output);
+    expect(unionMutation.mutatedType.kind).toBe("Union");
+  });
+});
+
+describe("GraphQL Mutation Engine - oneOf Input Objects", () => {
+  let tester: Awaited<ReturnType<typeof Tester.createInstance>>;
+  beforeEach(async () => {
+    tester = await Tester.createInstance();
+  });
+
+  it("replaces union with oneOf model in input context", async () => {
+    const { Pet } = await tester.compile(
+      t.code`
+        model ${t.model("Cat")} { name: string; }
+        model ${t.model("Dog")} { breed: string; }
+        union ${t.union("Pet")} { cat: Cat; dog: Dog; }
+      `,
+    );
+
+    const engine = createTestEngine(tester.program);
+    const mutation = engine.mutateUnion(Pet, GraphQLTypeContext.Input);
+
+    // Union is replaced with a Model in the type graph
+    expect(mutation.mutatedType.kind).toBe("Model");
+    expect(mutation.mutatedType.name).toBe("PetInput");
+    expect(isOneOf(tester.program, mutation.mutatedType as Model)).toBe(true);
+  });
+
+  it("oneOf model has one field per variant, all optional", async () => {
+    const { Pet } = await tester.compile(
+      t.code`
+        model ${t.model("Cat")} { name: string; }
+        model ${t.model("Dog")} { breed: string; }
+        union ${t.union("Pet")} { cat: Cat; dog: Dog; }
+      `,
+    );
+
+    const engine = createTestEngine(tester.program);
+    const mutation = engine.mutateUnion(Pet, GraphQLTypeContext.Input);
+    const model = mutation.mutatedType as Model;
+
+    expect(model.properties.size).toBe(2);
+    expect(model.properties.has("cat")).toBe(true);
+    expect(model.properties.has("dog")).toBe(true);
+    // All fields are optional (oneOf semantics)
+    expect(model.properties.get("cat")!.optional).toBe(true);
+    expect(model.properties.get("dog")!.optional).toBe(true);
+  });
+
+  it("keeps union in output context (no replacement)", async () => {
+    const { Pet } = await tester.compile(
+      t.code`
+        model ${t.model("Cat")} { name: string; }
+        model ${t.model("Dog")} { breed: string; }
+        union ${t.union("Pet")} { cat: Cat; dog: Dog; }
+      `,
+    );
+
+    const engine = createTestEngine(tester.program);
+    const mutation = engine.mutateUnion(Pet, GraphQLTypeContext.Output);
+
+    expect(mutation.mutatedType.kind).toBe("Union");
+  });
+
+  it("oneOf model handles scalar variants", async () => {
+    const { Data } = await tester.compile(
+      t.code`
+        model ${t.model("Foo")} { x: int32; }
+        union ${t.union("Data")} { text: string; num: int32; foo: Foo; }
+      `,
+    );
+
+    const engine = createTestEngine(tester.program);
+    const mutation = engine.mutateUnion(Data, GraphQLTypeContext.Input);
+    const model = mutation.mutatedType as Model;
+
+    // All variants become fields — no wrapper models needed for oneOf
+    expect(model.properties.size).toBe(3);
+    expect(model.properties.has("text")).toBe(true);
+    expect(model.properties.has("num")).toBe(true);
+    expect(model.properties.has("foo")).toBe(true);
+    // No wrapper models created in input context
+    expect(mutation.wrapperModels).toHaveLength(0);
+  });
+
+  it("oneOf model flattens and deduplicates nested unions", async () => {
+    const { Outer } = await tester.compile(
+      t.code`
+        model ${t.model("Cat")} { name: string; }
+        model ${t.model("Dog")} { breed: string; }
+        model ${t.model("Bird")} { wingspan: int32; }
+        union ${t.union("Inner")} { cat: Cat; dog: Dog; }
+        union ${t.union("Outer")} { inner: Inner; bird: Bird; dog2: Dog; }
+      `,
+    );
+
+    const engine = createTestEngine(tester.program);
+    const mutation = engine.mutateUnion(Outer, GraphQLTypeContext.Input);
+    const model = mutation.mutatedType as Model;
+
+    // Inner is flattened: Cat + Dog from Inner, Bird from Outer
+    // Dog appears twice (from Inner and as dog2) — deduplicated to one
+    expect(model.properties.size).toBe(3);
+    expect(model.properties.has("cat")).toBe(true);
+    expect(model.properties.has("dog")).toBe(true);
+    expect(model.properties.has("bird")).toBe(true);
+  });
+
+  it("nullable union in input context is not replaced", async () => {
+    const { MaybeString } = await tester.compile(
+      t.code`union ${t.union("MaybeString")} { string, null }`,
+    );
+
+    const engine = createTestEngine(tester.program);
+    const mutation = engine.mutateUnion(MaybeString, GraphQLTypeContext.Input);
+
+    // Nullable unions are not real unions — union is kept, not replaced
+    expect(mutation.mutatedType.kind).toBe("Union");
+  });
+
+  it("exposes typeContext on union mutation", async () => {
+    const { Pet } = await tester.compile(
+      t.code`
+        model ${t.model("Cat")} { name: string; }
+        union ${t.union("Pet")} { cat: Cat; }
+      `,
+    );
+
+    const engine = createTestEngine(tester.program);
+    const inputMutation = engine.mutateUnion(Pet, GraphQLTypeContext.Input);
+    const outputMutation = engine.mutateUnion(Pet, GraphQLTypeContext.Output);
+
+    expect(inputMutation.typeContext).toBe(GraphQLTypeContext.Input);
+    expect(outputMutation.typeContext).toBe(GraphQLTypeContext.Output);
   });
 });

--- a/packages/graphql/test/mutation-engine/graphql-mutation-engine.test.ts
+++ b/packages/graphql/test/mutation-engine/graphql-mutation-engine.test.ts
@@ -253,6 +253,53 @@ describe("GraphQL Mutation Engine - Scalars", () => {
     expect(getSpecifiedBy(tester.program, mutation.mutatedType)).toBe("https://example.com/my-scalar-spec");
   });
 
+  it("inherits @specifiedBy from mapped ancestor via extends chain", async () => {
+    const { MyDate } = await tester.compile(
+      t.code`
+        @encode("rfc3339")
+        scalar ${t.scalar("MyDate")} extends utcDateTime;
+      `,
+    );
+
+    const engine = createTestEngine(tester.program);
+    const mutation = engine.mutateScalar(MyDate);
+
+    // User-defined name is preserved (sanitized), not replaced with mapping's graphqlName
+    expect(mutation.mutatedType.name).toBe("MyDate");
+    // @specifiedBy inherited from utcDateTime's rfc3339 mapping
+    expect(getSpecifiedBy(tester.program, mutation.mutatedType)).toBe(
+      "https://scalars.graphql.org/chillicream/date-time.html",
+    );
+  });
+
+  it("strips baseScalar from user-defined scalars", async () => {
+    const { MyScalar } = await tester.compile(
+      t.code`scalar ${t.scalar("MyScalar")} extends string;`,
+    );
+
+    const engine = createTestEngine(tester.program);
+    const mutation = engine.mutateScalar(MyScalar);
+
+    expect(mutation.mutatedType.baseScalar).toBeUndefined();
+  });
+
+  it("explicit @specifiedBy wins over inherited mapping", async () => {
+    const { MyDate } = await tester.compile(
+      t.code`
+        @encode("rfc3339")
+        @specifiedBy("https://example.com/custom-spec")
+        scalar ${t.scalar("MyDate")} extends utcDateTime;
+      `,
+    );
+
+    const engine = createTestEngine(tester.program);
+    const mutation = engine.mutateScalar(MyDate);
+
+    expect(getSpecifiedBy(tester.program, mutation.mutatedType)).toBe(
+      "https://example.com/custom-spec",
+    );
+  });
+
 });
 
 describe("GraphQL Mutation Engine - Edge Cases", () => {

--- a/packages/graphql/test/test-host.ts
+++ b/packages/graphql/test/test-host.ts
@@ -11,17 +11,17 @@ import type { GraphQLSchema } from "graphql";
 import { buildSchema } from "graphql";
 import { expect } from "vitest";
 import type { GraphQLEmitterOptions } from "../src/lib.js";
-import { GraphqlTestLibrary } from "../src/testing/index.js";
+import { GraphQLTestLibrary } from "../src/testing/index.js";
 
 export const Tester = createTester(resolvePath(import.meta.dirname, ".."), {
-  libraries: [GraphqlTestLibrary.name],
+  libraries: [GraphQLTestLibrary.name],
 })
   .importLibraries()
   .using("TypeSpec.GraphQL");
 
-export async function createGraphqlTestHost() {
+export async function createGraphQLTestHost() {
   return createTestHost({
-    libraries: [GraphqlTestLibrary],
+    libraries: [GraphQLTestLibrary],
   });
 }
 
@@ -31,8 +31,8 @@ export interface GraphQLTestResult {
   readonly diagnostics: readonly Diagnostic[];
 }
 
-export async function createGraphqlTestRunner() {
-  const host = await createGraphqlTestHost();
+export async function createGraphQLTestRunner() {
+  const host = await createGraphQLTestHost();
 
   return createTestWrapper(host, {
     autoUsings: ["TypeSpec.GraphQL"],
@@ -44,14 +44,14 @@ export async function createGraphqlTestRunner() {
 }
 
 export async function diagnose(code: string): Promise<readonly Diagnostic[]> {
-  const runner = await createGraphqlTestRunner();
+  const runner = await createGraphQLTestRunner();
   return runner.diagnose(code);
 }
 
 export async function compileAndDiagnose<T extends Record<string, Type>>(
   code: string,
 ): Promise<[Program, T, readonly Diagnostic[]]> {
-  const runner = await createGraphqlTestRunner();
+  const runner = await createGraphQLTestRunner();
   const [testTypes, diagnostics] = await runner.compileAndDiagnose(code);
   return [runner.program, testTypes as T, diagnostics];
 }
@@ -60,7 +60,7 @@ export async function emitWithDiagnostics(
   code: string,
   options: GraphQLEmitterOptions = {},
 ): Promise<readonly GraphQLTestResult[]> {
-  const runner = await createGraphqlTestRunner();
+  const runner = await createGraphQLTestRunner();
   const outputFile = resolveVirtualPath("schema.graphql");
   const compilerOptions = { ...options, "output-file": outputFile };
   const diagnostics = await runner.diagnose(code, {


### PR DESCRIPTION
  This PR introduces a mutation engine that bridges the gap between TypeSpec's type system and
  GraphQL's naming/structural constraints. It builds on `@typespec/mutator-framework` to apply
  GraphQL-specific transformations to TypeSpec types before they're emitted as SDL.

  ## What this does

  TypeSpec and GraphQL have different conventions and rules around type naming and structure. For
  example:
  - TypeSpec uses `camelCase` for properties, GraphQL enum values use `SCREAMING_SNAKE_CASE`
  - TypeSpec allows unions of scalars, but GraphQL unions can only contain object types
  - TypeSpec template instantiations like `List<string>` need readable names like `ListOfString`

  The mutation engine handles these transformations by defining per-type mutation classes that hook
  into the mutator framework's traversal:

  - Enum/EnumMember — Sanitizes names to `PascalCase` (types) and `SCREAMING_SNAKE_CASE` (values)
  - Model/ModelProperty — Sanitizes model and property names for GraphQL compatibility
  - Operation — Normalizes operation names; automatically propagates input context to parameters and
  output context to return types
  - Scalar — Maps TypeSpec scalars to their GraphQL equivalents via a scalar mapping table
  - Union — Detects nullable unions (`T | null`) and flattens them; wraps scalar variants in synthetic
  object types (since GraphQL unions only allow object members)

 ### Input/output type context splitting

  GraphQL distinguishes between input types (used in operation arguments) and output types (used in
  return values). The mutation engine handles this via GraphQLMutationOptions, which overrides the
  framework's mutationKey to produce separate cached mutations per context ("input" vs "output").

  When an operation is mutated, GraphQLOperationMutation overrides mutateParameters() and
  mutateReturnType() to inject the appropriate context. The framework's built-in options propagation
  carries that context to all nested types automatically.

  ## Also included

  - `src/lib/type-utils.ts` — Shared utilities for name sanitization (`toTypeName`, `toFieldName`,
  `sanitizeNameForGraphQL`), nullable union detection, template name generation, and `splitWithAcronyms`
  for handling acronyms in casing conversions
  - `src/lib/scalar-mappings.ts` — Complete mapping table from TypeSpec scalars to GraphQL scalar types
  (including `int64` → `BigInt`, `float32` → `Float`, custom scalar specs, etc.)
  - 56 tests across type-utils (35) and mutation engine (21)
  - Package hygiene: `tspMain`, node engine bump to `>=20`, `api-extractor.json`, consistent casing in test
  helpers

  ## Testing
  `npx vitest run`