### PR TITLE
Add Alloy infrastructure, context system, and type analysis

### DIFF
--- a/packages/graphql/package.json
+++ b/packages/graphql/package.json
@@ -30,15 +30,15 @@
     "node": ">=20.0.0"
   },
   "dependencies": {
-    "@alloy-js/core": "^0.11.0",
-    "@alloy-js/typescript": "^0.11.0",
+    "@alloy-js/core": "^0.22.0",
+    "@alloy-js/typescript": "^0.22.0",
     "change-case": "^5.4.4",
     "graphql": "^16.9.0"
   },
   "scripts": {
     "clean": "rimraf ./dist ./temp",
-    "build": "tsc -p .",
-    "watch": "tsc --watch",
+    "build": "alloy build",
+    "watch": "alloy build --watch",
     "test": "vitest run",
     "test:watch": "vitest -w",
     "lint": "eslint . --max-warnings=0",
@@ -56,6 +56,8 @@
     "@typespec/mutator-framework": "workspace:~"
   },
   "devDependencies": {
+    "@alloy-js/cli": "^0.22.0",
+    "@alloy-js/rollup-plugin": "^0.1.0",
     "@types/node": "~22.13.13",
     "@typespec/compiler": "workspace:~",
     "@typespec/emitter-framework": "workspace:~",

--- a/packages/graphql/src/components/fields/index.ts
+++ b/packages/graphql/src/components/fields/index.ts
@@ -1,0 +1,1 @@
+export { TypeAnalyzer, type TypeAnalyzerProps } from "./type-analyzer.js";

--- a/packages/graphql/src/components/fields/type-analysis.ts
+++ b/packages/graphql/src/components/fields/type-analysis.ts
@@ -1,0 +1,172 @@
+import {
+  type Type,
+  type Program,
+  type Union,
+  type Scalar,
+  type ModelProperty,
+  isArrayModelType,
+  getEncode,
+  isUnknownType,
+} from "@typespec/compiler";
+import { type ModelVariants } from "../../context/index.js";
+import { isNullable } from "../../lib/nullable.js";
+import { getUnionName } from "../../lib/type-utils.js";
+import { getGraphQLBuiltinName, getScalarMapping } from "../../lib/scalar-mappings.js";
+
+/**
+ * Information about a GraphQL type after analysis
+ */
+export interface TypeInfo {
+  /** The base type name (without wrappers) */
+  typeName: string;
+  /** Whether this is a list type */
+  isList: boolean;
+  /** Whether the field itself is non-null */
+  isNonNull: boolean;
+  /** Whether list items are non-null (only meaningful if isList is true) */
+  itemNonNull: boolean;
+}
+
+/**
+ * Analyze a TypeSpec type and return GraphQL type information
+ *
+ * This extracts:
+ * - Base type name
+ * - Whether it's a list
+ * - Nullability at field and item level
+ *
+ * @param type The TypeSpec type to analyze
+ * @param isOptional Whether the field is marked as optional
+ * @param mode Whether we're in input or output context
+ * @param program The TypeSpec program
+ * @param modelVariants Model variant lookups
+ * @param targetType Optional target type (property/parameter) to check for @encode
+ * @returns Type information for rendering
+ */
+export function analyzeType(
+  type: Type,
+  isOptional: boolean,
+  mode: "input" | "output",
+  program: Program,
+  modelVariants: ModelVariants,
+  targetType?: Type
+): TypeInfo {
+  // Check nullability from the mutation engine's state map.
+  // The engine strips T | null unions (replacing with the inner type) and marks
+  // the result via setNullable(). For multi-variant unions (Cat | Dog | null),
+  // null is stripped and the resulting union is marked.
+  const nullable = isNullable(program, type);
+
+  // In output context: non-null unless optional or nullable (? or | null means nullable)
+  // In input context: non-null unless nullable (? doesn't affect nullability, only | null does)
+  const isNonNull = nullable ? false : mode === "input" ? true : !isOptional;
+
+  // Handle arrays
+  if (type.kind === "Model" && isArrayModelType(program, type)) {
+    if (type.indexer?.value) {
+      const elementType = type.indexer.value;
+
+      // Recursively analyze the element type to get its base name
+      const elementInfo = analyzeType(elementType, false, mode, program, modelVariants, targetType);
+
+      return {
+        typeName: elementInfo.typeName,
+        isList: true,
+        isNonNull,
+        // Elements are non-null unless the element type is nullable
+        itemNonNull: !isNullable(program, elementType),
+      };
+    }
+  }
+
+  // Not a list - get the base type name
+  const typeName = resolveBaseTypeName(type, mode, program, modelVariants, targetType);
+
+  return {
+    typeName,
+    isList: false,
+    isNonNull,
+    itemNonNull: false, // Not meaningful for non-list types
+  };
+}
+
+/**
+ * Resolve the base type name (without wrappers)
+ * @param type The TypeSpec type to resolve
+ * @param mode Whether we're in input or output context
+ * @param program The TypeSpec program
+ * @param modelVariants Model variant lookups
+ * @param targetType Optional target type (property/parameter) to check for @encode
+ * @returns The GraphQL type name
+ */
+function resolveBaseTypeName(
+  type: Type,
+  mode: "input" | "output",
+  program: Program,
+  modelVariants: ModelVariants,
+  targetType?: Type
+): string {
+  // Handle unknown intrinsic type
+  if (isUnknownType(type)) {
+    return "Unknown";
+  }
+
+  // Handle scalars
+  if (type.kind === "Scalar") {
+    // Check for GraphQL builtins first (string → String, int32 → Int, etc.)
+    const builtinName = getGraphQLBuiltinName(program, type);
+    if (builtinName) return builtinName;
+
+    // Check for scalar mappings (int64 → Long, utcDateTime → UTCDateTime, etc.)
+    if (program.checker.isStdType(type)) {
+      // Check for encoding-specific mapping via the target (property/parameter)
+      if (targetType && (targetType.kind === "Scalar" || targetType.kind === "ModelProperty")) {
+        const encodeData = getEncode(program, targetType as Scalar | ModelProperty);
+        const encoding = encodeData?.encoding;
+        const mapping = getScalarMapping(program, type, encoding);
+        if (mapping) {
+          return mapping.graphqlName;
+        }
+      }
+
+      // Check for default mapping (not all mapping tables have a default)
+      const mapping = getScalarMapping(program, type);
+      if (mapping) {
+        return mapping.graphqlName;
+      }
+    }
+
+    // Custom scalar — use the name directly
+    return type.name;
+  }
+
+  // Handle models
+  if (type.kind === "Model") {
+    // Name-based lookup: we need the model's string name to determine whether
+    // an "Input" suffix is required. The modelVariants maps are keyed by name
+    // because both input and output variants share the same source model identity
+    // — the distinction is purely nominal at the GraphQL output level.
+    const hasOutputVariant = modelVariants.outputModels.has(type.name);
+    const hasInputVariant = modelVariants.inputModels.has(type.name);
+
+    if (mode === "input" && hasOutputVariant && hasInputVariant) {
+      return `${type.name}Input`;
+    }
+    return type.name;
+  }
+
+  // Handle enums
+  if (type.kind === "Enum") {
+    return type.name;
+  }
+
+  // Handle unions (non-nullable unions)
+  if (type.kind === "Union") {
+    return getUnionName(type as Union, program);
+  }
+
+  throw new Error(
+    `Unexpected type kind "${type.kind}" in resolveBaseTypeName. ` +
+    `This is a bug in the GraphQL emitter.`
+  );
+}

--- a/packages/graphql/src/components/fields/type-analyzer.tsx
+++ b/packages/graphql/src/components/fields/type-analyzer.tsx
@@ -1,0 +1,37 @@
+import { type Type } from "@typespec/compiler";
+import { type Children, useContext } from "@alloy-js/core";
+import { useTsp } from "@typespec/emitter-framework";
+import { GraphQLTypeResolutionContext, useGraphQLSchema } from "../../context/index.js";
+import { type TypeInfo, analyzeType } from "./type-analysis.js";
+
+export interface TypeAnalyzerProps {
+  type: Type;
+  isOptional: boolean;
+  /** The property or parameter that contains the type (for @encode checking) */
+  targetType?: Type;
+  key?: string;
+  children: (typeInfo: TypeInfo) => Children;
+}
+
+/**
+ * Helper component to analyze a TypeSpec type and extract GraphQL type information.
+ * Resolves the type using the current input/output context and returns TypeInfo
+ * via render props (children function).
+ */
+export function TypeAnalyzer(props: TypeAnalyzerProps) {
+  const { program } = useTsp();
+  const { modelVariants } = useGraphQLSchema();
+  const context = useContext(GraphQLTypeResolutionContext);
+  const mode = context?.mode ?? "output";
+
+  const typeInfo = analyzeType(
+    props.type,
+    props.isOptional,
+    mode,
+    program,
+    modelVariants,
+    props.targetType
+  );
+
+  return props.children(typeInfo);
+}

--- a/packages/graphql/src/context/graphql-schema-context.tsx
+++ b/packages/graphql/src/context/graphql-schema-context.tsx
@@ -1,0 +1,99 @@
+import { type ComponentContext, createNamedContext, useContext } from "@alloy-js/core";
+import {
+  type Model,
+  type Enum,
+  type Scalar,
+  type Type,
+  type Union,
+  type Operation,
+} from "@typespec/compiler";
+
+/**
+ * Classified types separated by category for schema generation
+ */
+export interface ClassifiedTypes {
+  /** Interface types marked with @Interface */
+  interfaces: Model[];
+  /** Models used as output types (return values) */
+  outputModels: Model[];
+  /** Models used as input types (parameters) */
+  inputModels: Model[];
+  /** Enum types */
+  enums: Enum[];
+  /** Custom scalar types */
+  scalars: Scalar[];
+  /** Scalar variants for encoded scalars (e.g., bytes + base64 → Bytes) */
+  scalarVariants: ScalarVariant[];
+  /** Union types */
+  unions: Union[];
+  /** Query operations */
+  queries: Operation[];
+  /** Mutation operations */
+  mutations: Operation[];
+  /** Subscription operations */
+  subscriptions: Operation[];
+}
+
+/**
+ * Model variant lookups for quick checking whether output and/or input variants exist.
+ * Used to determine when to append "Input" suffix during type resolution.
+ */
+export interface ModelVariants {
+  /** Output model variants indexed by name */
+  outputModels: Map<string, Model>;
+  /** Input model variants indexed by name */
+  inputModels: Map<string, Model>;
+}
+
+/**
+ * Scalar variant information for encoded scalars.
+ * When a scalar has @encode, we emit it as a different GraphQL scalar (e.g., bytes + base64 → Bytes)
+ */
+export interface ScalarVariant {
+  /** The original TypeSpec scalar type (or Intrinsic for `unknown`) */
+  sourceScalar: Scalar | Type;
+  /** The encoding used (e.g., "base64", "rfc3339") */
+  encoding: string;
+  /** The GraphQL scalar name to emit (e.g., "Bytes", "UTCDateTime") */
+  graphqlName: string;
+  /** Optional specification URL for @specifiedBy directive */
+  specificationUrl?: string;
+}
+
+/**
+ * Context value containing GraphQL-specific schema information.
+ *
+ * For access to the TypeSpec program and typekit, use `useTsp()` from
+ * `@typespec/emitter-framework` instead.
+ */
+export interface GraphQLSchemaContextValue {
+  /** Classified types for schema generation */
+  classifiedTypes: ClassifiedTypes;
+  /** Model variant lookups for input/output type resolution */
+  modelVariants: ModelVariants;
+  /** Scalar specification URLs for @specifiedBy directives */
+  scalarSpecifications: Map<string, string>;
+}
+
+/**
+ * Context provider for GraphQL schema generation
+ */
+export const GraphQLSchemaContext: ComponentContext<GraphQLSchemaContextValue> =
+  createNamedContext<GraphQLSchemaContextValue>("GraphQLSchema");
+
+/**
+ * Hook to access GraphQL schema context
+ * @returns The GraphQL schema context value
+ * @throws Error if used outside of GraphQLSchemaContext.Provider
+ */
+export function useGraphQLSchema(): GraphQLSchemaContextValue {
+  const context = useContext(GraphQLSchemaContext);
+
+  if (!context) {
+    throw new Error(
+      "useGraphQLSchema must be used within GraphQLSchemaContext.Provider."
+    );
+  }
+
+  return context;
+}

--- a/packages/graphql/src/context/index.ts
+++ b/packages/graphql/src/context/index.ts
@@ -1,0 +1,14 @@
+export {
+  GraphQLSchemaContext,
+  useGraphQLSchema,
+  type GraphQLSchemaContextValue,
+  type ClassifiedTypes,
+  type ModelVariants,
+  type ScalarVariant,
+} from "./graphql-schema-context.js";
+
+export {
+  GraphQLTypeResolutionContext,
+  type TypeResolutionMode,
+  type GraphQLTypeResolutionContextValue,
+} from "./type-resolution-context.js";

--- a/packages/graphql/src/context/type-resolution-context.tsx
+++ b/packages/graphql/src/context/type-resolution-context.tsx
@@ -1,0 +1,20 @@
+import { type ComponentContext, createNamedContext } from "@alloy-js/core";
+
+/**
+ * Type resolution mode for context-aware type name resolution
+ */
+export type TypeResolutionMode = "input" | "output";
+
+/**
+ * Context value for type resolution
+ */
+export interface GraphQLTypeResolutionContextValue {
+  /** Whether we're resolving types in input or output context */
+  mode: TypeResolutionMode;
+}
+
+/**
+ * Context provider for type resolution mode
+ */
+export const GraphQLTypeResolutionContext: ComponentContext<GraphQLTypeResolutionContextValue> =
+  createNamedContext<GraphQLTypeResolutionContextValue>("TypeResolution");

--- a/packages/graphql/src/lib/scalar-mappings.ts
+++ b/packages/graphql/src/lib/scalar-mappings.ts
@@ -158,17 +158,36 @@ export function isStdScalar(tk: Typekit, scalar: Scalar): boolean {
 }
 
 /**
- * TypeSpec std scalar names that map directly to GraphQL built-in scalar types:
- * string → String, boolean → Boolean, int32 → Int, float32/float64 → Float.
+ * TypeSpec std scalars that map directly to GraphQL built-in scalar types.
  *
  * These must NOT be renamed by the scalar mutation — they're resolved to
  * GraphQL builtins at emit time.
  *
  * @see https://spec.graphql.org/September2025/#sec-Scalars.Built-in-Scalars
  */
-const TSP_SCALARS_TO_GQL_BUILTINS: IntrinsicScalarName[] = [
-  "string", "boolean", "int32", "float32", "float64",
-];
+const GQL_BUILTIN_SCALARS: Partial<Record<IntrinsicScalarName, string>> = {
+  string: "String",
+  boolean: "Boolean",
+  int32: "Int",
+  float32: "Float",
+  float64: "Float",
+};
+
+const TSP_SCALARS_TO_GQL_BUILTINS = Object.keys(GQL_BUILTIN_SCALARS) as IntrinsicScalarName[];
+
+/**
+ * Get the GraphQL built-in scalar name for a TypeSpec scalar, if it is one.
+ * Uses identity-based check via typekit to avoid false positives from
+ * user-defined scalars that share the same name in a different namespace.
+ * Returns undefined for non-builtin scalars.
+ */
+export function getGraphQLBuiltinName(program: Program, scalar: Scalar): string | undefined {
+  const checker = program.checker;
+  for (const [name, gqlName] of Object.entries(GQL_BUILTIN_SCALARS)) {
+    if (checker.isStdType(scalar, name as IntrinsicScalarName)) return gqlName;
+  }
+  return undefined;
+}
 
 /**
  * Get the GraphQL scalar mapping for a scalar via its standard library ancestor.

--- a/packages/graphql/tsconfig.json
+++ b/packages/graphql/tsconfig.json
@@ -1,10 +1,18 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "useDefineForClassFields": true,
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "target": "es2022",
+    "skipLibCheck": true,
+    "isolatedModules": true,
+    "verbatimModuleSyntax": true,
+    "jsx": "preserve",
+    "jsxImportSource": "@alloy-js/core",
+    "emitDeclarationOnly": true,
     "rootDir": ".",
-    "outDir": "dist",
-    "verbatimModuleSyntax": true
+    "outDir": "dist"
   },
-  "include": ["src", "test"]
+  "include": ["src/**/*.ts", "src/**/*.tsx", "test/**/*.ts", "test/**/*.tsx"],
+  "exclude": ["node_modules", "dist"]
 }

--- a/packages/graphql/vitest.config.ts
+++ b/packages/graphql/vitest.config.ts
@@ -1,4 +1,14 @@
+import alloyPlugin from "@alloy-js/rollup-plugin";
 import { defineConfig, mergeConfig } from "vitest/config";
 import { defaultTypeSpecVitestConfig } from "../../vitest.config.js";
 
-export default mergeConfig(defaultTypeSpecVitestConfig, defineConfig({}));
+export default mergeConfig(
+  defaultTypeSpecVitestConfig,
+  defineConfig({
+    esbuild: {
+      jsx: "preserve",
+      sourcemap: "both",
+    },
+    plugins: [alloyPlugin()],
+  }),
+);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -540,6 +540,55 @@ importers:
         specifier: ^4.0.18
         version: 4.0.18(@types/node@25.3.0)(@vitest/ui@4.0.18)(happy-dom@20.7.0)(jsdom@25.0.1)(tsx@4.21.0)(yaml@2.8.2)
 
+  packages/graphql:
+    dependencies:
+      '@alloy-js/core':
+        specifier: ^0.22.0
+        version: 0.22.0
+      '@alloy-js/typescript':
+        specifier: ^0.22.0
+        version: 0.22.0
+      change-case:
+        specifier: ^5.4.4
+        version: 5.4.4
+      graphql:
+        specifier: ^16.9.0
+        version: 16.13.2
+    devDependencies:
+      '@alloy-js/cli':
+        specifier: ^0.22.0
+        version: 0.22.0
+      '@alloy-js/rollup-plugin':
+        specifier: ^0.1.0
+        version: 0.1.0(@babel/core@7.29.0)(@types/babel__core@7.20.5)(rollup@4.49.0)
+      '@types/node':
+        specifier: ~22.13.13
+        version: 22.13.17
+      '@typespec/compiler':
+        specifier: workspace:~
+        version: link:../compiler
+      '@typespec/emitter-framework':
+        specifier: workspace:~
+        version: link:../emitter-framework
+      '@typespec/http':
+        specifier: workspace:~
+        version: link:../http
+      '@typespec/mutator-framework':
+        specifier: workspace:~
+        version: link:../mutator-framework
+      rimraf:
+        specifier: ~6.0.1
+        version: 6.0.1
+      source-map-support:
+        specifier: ~0.5.21
+        version: 0.5.21
+      typescript:
+        specifier: ~5.8.2
+        version: 5.8.2
+      vitest:
+        specifier: ^3.0.9
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@22.13.17)(@vitest/ui@4.0.18)(happy-dom@20.7.0)(jsdom@25.0.1)(tsx@4.21.0)(yaml@2.8.2)
+
   packages/html-program-viewer:
     dependencies:
       '@fluentui/react-components':
@@ -1544,6 +1593,9 @@ importers:
       '@typespec/events':
         specifier: workspace:^
         version: link:../events
+      '@typespec/graphql':
+        specifier: workspace:^
+        version: link:../graphql
       '@typespec/html-program-viewer':
         specifier: workspace:^
         version: link:../html-program-viewer
@@ -6315,6 +6367,9 @@ packages:
   '@types/node@18.19.130':
     resolution: {integrity: sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==}
 
+  '@types/node@22.13.17':
+    resolution: {integrity: sha512-nAJuQXoyPj04uLgu+obZcSmsfOenUg6DxPKogeUy6yNCFwWaj5sBF8/G/pNo8EtBJjAfSVgfIlugR/BCOleO+g==}
+
   '@types/node@25.3.0':
     resolution: {integrity: sha512-4K3bqJpXpqfg2XKGK9bpDTc6xO/xoUP/RBWS7AtRMug6zZFaRekiLzjVtAoZMquxoAbzBvy5nxQ7veS5eYzf8A==}
 
@@ -6525,6 +6580,17 @@ packages:
   '@vitest/expect@4.0.18':
     resolution: {integrity: sha512-8sCWUyckXXYvx4opfzVY03EOiYVxyNrHS5QxX3DAIi5dpJAAkyJezHCP77VMX4HKA2LDT/Jpfo8i2r5BE3GnQQ==}
 
+  '@vitest/mocker@3.2.4':
+    resolution: {integrity: sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^5.0.0 || ^6.0.0 || ^7.0.0-0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
   '@vitest/mocker@4.0.18':
     resolution: {integrity: sha512-HhVd0MDnzzsgevnOWCBj5Otnzobjy5wLBe4EdeeFGv8luMsGcYqDuFRMcttKWZA5vVO8RFjexVovXvAM4JoJDQ==}
     peerDependencies:
@@ -6542,8 +6608,14 @@ packages:
   '@vitest/pretty-format@4.0.18':
     resolution: {integrity: sha512-P24GK3GulZWC5tz87ux0m8OADrQIUVDPIjjj65vBXYG17ZeU3qD7r+MNZ1RNv4l8CGU2vtTRqixrOi9fYk/yKw==}
 
+  '@vitest/runner@3.2.4':
+    resolution: {integrity: sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==}
+
   '@vitest/runner@4.0.18':
     resolution: {integrity: sha512-rpk9y12PGa22Jg6g5M3UVVnTS7+zycIGk9ZNGN+m6tZHKQb7jrP7/77WfZy13Y/EUDd52NDsLRQhYKtv7XfPQw==}
+
+  '@vitest/snapshot@3.2.4':
+    resolution: {integrity: sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==}
 
   '@vitest/snapshot@4.0.18':
     resolution: {integrity: sha512-PCiV0rcl7jKQjbgYqjtakly6T1uwv/5BQ9SwBLekVg/EaYeQFPiXcgrC2Y7vDMA8dM1SUEAEV82kgSQIlXNMvA==}
@@ -7425,6 +7497,10 @@ packages:
     peerDependenciesMeta:
       monocart-coverage-reports:
         optional: true
+
+  cac@6.7.14:
+    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
+    engines: {node: '>=8'}
 
   cacache@19.0.1:
     resolution: {integrity: sha512-hdsUxulXCi5STId78vRVYEtDAjq99ICAUktLTeTYsLoTE6Z8dS0c8pWNCxwdrk9YfJeobDZc2Y186hD/5ZQgFQ==}
@@ -9120,6 +9196,10 @@ packages:
   grapheme-splitter@1.0.4:
     resolution: {integrity: sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==}
 
+  graphql@16.13.2:
+    resolution: {integrity: sha512-5bJ+nf/UCpAjHM8i06fl7eLyVC9iuNAjm9qzkiu2ZGhM0VscSvS6WDPfAwkdkBuoXGM9FJSbKl6wylMwP9Ktig==}
+    engines: {node: ^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0}
+
   gray-matter@4.0.3:
     resolution: {integrity: sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==}
     engines: {node: '>=6.0'}
@@ -9793,6 +9873,9 @@ packages:
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+
+  js-tokens@9.0.1:
+    resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
 
   js-yaml@3.14.2:
     resolution: {integrity: sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==}
@@ -11706,6 +11789,11 @@ packages:
     deprecated: Rimraf versions prior to v4 are no longer supported
     hasBin: true
 
+  rimraf@6.0.1:
+    resolution: {integrity: sha512-9dkvaxAsk/xNXSJzMgFqqMCuFgt2+KsOFek3TMLfo8NCPfWpBmqwyNn5Y+NX56QUYfCtsyhF3ayiboEoUmJk/A==}
+    engines: {node: 20 || >=22}
+    hasBin: true
+
   rimraf@6.1.3:
     resolution: {integrity: sha512-LKg+Cr2ZF61fkcaK1UdkH2yEBBKnYjTyWzTJT6KNPcSPaiT7HSdhtMXQuN5wkTX0Xu72KQ1l8S42rlmexS2hSA==}
     engines: {node: 20 || >=22}
@@ -12232,6 +12320,9 @@ packages:
     resolution: {integrity: sha512-1tB5mhVo7U+ETBKNf92xT4hrQa3pm0MZ0PQvuDnWgAAGHDsfp4lPSpiS6psrSiet87wyGPh9ft6wmhOMQ0hDiw==}
     engines: {node: '>=14.16'}
 
+  strip-literal@3.1.0:
+    resolution: {integrity: sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==}
+
   strnum@2.1.2:
     resolution: {integrity: sha512-l63NF9y/cLROq/yqKXSLtcMeeyOfnSQlfMSlzFt/K73oIaD8DGaQWd7Z34X9GPiKqP5rbSh84Hl4bOlLcjiSrQ==}
 
@@ -12395,6 +12486,9 @@ packages:
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
 
+  tinyexec@0.3.2:
+    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
+
   tinyexec@1.0.2:
     resolution: {integrity: sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==}
     engines: {node: '>=18'}
@@ -12405,6 +12499,10 @@ packages:
 
   tinylogic@2.0.0:
     resolution: {integrity: sha512-dljTkiLLITtsjqBvTA1MRZQK/sGP4kI3UJKc3yA9fMzYbMF2RhcN04SeROVqJBIYYOoJMM8u0WDnhFwMSFQotw==}
+
+  tinypool@1.1.1:
+    resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
+    engines: {node: ^18.0.0 || >=20.0.0}
 
   tinyrainbow@2.0.0:
     resolution: {integrity: sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==}
@@ -12724,6 +12822,9 @@ packages:
   undici-types@5.26.5:
     resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
 
+  undici-types@6.20.0:
+    resolution: {integrity: sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==}
+
   undici-types@7.18.2:
     resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
 
@@ -12976,6 +13077,11 @@ packages:
   vfile@6.0.3:
     resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
 
+  vite-node@3.2.4:
+    resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+
   vite-plugin-checker@0.12.0:
     resolution: {integrity: sha512-CmdZdDOGss7kdQwv73UyVgLPv0FVYe5czAgnmRX2oKljgEvSrODGuClaV3PDR2+3ou7N/OKGauDDBjy2MB07Rg==}
     engines: {node: '>=16.11'}
@@ -13113,6 +13219,34 @@ packages:
       vite: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-beta.0
     peerDependenciesMeta:
       vite:
+        optional: true
+
+  vitest@3.2.4:
+    resolution: {integrity: sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/debug': ^4.1.12
+      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      '@vitest/browser': 3.2.4
+      '@vitest/ui': 3.2.4
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/debug':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
         optional: true
 
   vitest@4.0.18:
@@ -18624,6 +18758,10 @@ snapshots:
     dependencies:
       undici-types: 5.26.5
 
+  '@types/node@22.13.17':
+    dependencies:
+      undici-types: 6.20.0
+
   '@types/node@25.3.0':
     dependencies:
       undici-types: 7.18.2
@@ -18901,6 +19039,14 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.0.3
 
+  '@vitest/mocker@3.2.4(vite@7.3.1(@types/node@22.13.17)(tsx@4.21.0)(yaml@2.8.2))':
+    dependencies:
+      '@vitest/spy': 3.2.4
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 7.3.1(@types/node@22.13.17)(tsx@4.21.0)(yaml@2.8.2)
+
   '@vitest/mocker@4.0.18(vite@7.3.1(@types/node@25.3.0)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
       '@vitest/spy': 4.0.18
@@ -18917,9 +19063,21 @@ snapshots:
     dependencies:
       tinyrainbow: 3.0.3
 
+  '@vitest/runner@3.2.4':
+    dependencies:
+      '@vitest/utils': 3.2.4
+      pathe: 2.0.3
+      strip-literal: 3.1.0
+
   '@vitest/runner@4.0.18':
     dependencies:
       '@vitest/utils': 4.0.18
+      pathe: 2.0.3
+
+  '@vitest/snapshot@3.2.4':
+    dependencies:
+      '@vitest/pretty-format': 3.2.4
+      magic-string: 0.30.21
       pathe: 2.0.3
 
   '@vitest/snapshot@4.0.18':
@@ -19376,7 +19534,7 @@ snapshots:
       algoliasearch: 4.27.0
       clipanion: 4.0.0-rc.4(typanion@3.14.0)
       diff: 5.2.2
-      ink: 3.2.0(@types/react@19.2.14)(react@19.2.4)
+      ink: 3.2.0(@types/react@19.2.14)(react@17.0.2)
       ink-text-input: 4.0.3(ink@3.2.0(@types/react@19.2.14)(react@17.0.2))(react@17.0.2)
       react: 17.0.2
       semver: 7.7.4
@@ -19526,7 +19684,7 @@ snapshots:
       '@yarnpkg/plugin-git': 3.1.4(@yarnpkg/core@4.5.0(typanion@3.14.0))(typanion@3.14.0)
       clipanion: 4.0.0-rc.4(typanion@3.14.0)
       es-toolkit: 1.44.0
-      ink: 3.2.0(@types/react@19.2.14)(react@17.0.2)
+      ink: 3.2.0(@types/react@19.2.14)(react@19.2.4)
       react: 17.0.2
       semver: 7.7.4
       tslib: 2.8.1
@@ -20251,6 +20409,8 @@ snapshots:
       v8-to-istanbul: 9.3.0
       yargs: 17.7.2
       yargs-parser: 21.1.1
+
+  cac@6.7.14: {}
 
   cacache@19.0.1:
     dependencies:
@@ -22299,6 +22459,8 @@ snapshots:
 
   grapheme-splitter@1.0.4: {}
 
+  graphql@16.13.2: {}
+
   gray-matter@4.0.3:
     dependencies:
       js-yaml: 3.14.2
@@ -23122,6 +23284,8 @@ snapshots:
   js-tokens@10.0.0: {}
 
   js-tokens@4.0.0: {}
+
+  js-tokens@9.0.1: {}
 
   js-yaml@3.14.2:
     dependencies:
@@ -25637,6 +25801,11 @@ snapshots:
     dependencies:
       glob: 7.2.3
 
+  rimraf@6.0.1:
+    dependencies:
+      glob: 11.1.0
+      package-json-from-dist: 1.0.1
+
   rimraf@6.1.3:
     dependencies:
       glob: 13.0.6
@@ -26300,6 +26469,10 @@ snapshots:
 
   strip-json-comments@5.0.3: {}
 
+  strip-literal@3.1.0:
+    dependencies:
+      js-tokens: 9.0.1
+
   strnum@2.1.2: {}
 
   structured-source@4.0.0:
@@ -26541,6 +26714,8 @@ snapshots:
 
   tinybench@2.9.0: {}
 
+  tinyexec@0.3.2: {}
+
   tinyexec@1.0.2: {}
 
   tinyglobby@0.2.15:
@@ -26549,6 +26724,8 @@ snapshots:
       picomatch: 4.0.3
 
   tinylogic@2.0.0: {}
+
+  tinypool@1.1.1: {}
 
   tinyrainbow@2.0.0: {}
 
@@ -26829,6 +27006,8 @@ snapshots:
 
   undici-types@5.26.5: {}
 
+  undici-types@6.20.0: {}
+
   undici-types@7.18.2: {}
 
   undici@7.22.0: {}
@@ -27047,6 +27226,27 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
+  vite-node@3.2.4(@types/node@22.13.17)(tsx@4.21.0)(yaml@2.8.2):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3(supports-color@8.1.1)
+      es-module-lexer: 1.7.0
+      pathe: 2.0.3
+      vite: 7.3.1(@types/node@22.13.17)(tsx@4.21.0)(yaml@2.8.2)
+    transitivePeerDependencies:
+      - '@types/node'
+      - jiti
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
   vite-plugin-checker@0.12.0(eslint@10.0.2)(optionator@0.9.4)(typescript@5.9.3)(vite@7.3.1(@types/node@25.3.0)(tsx@4.21.0)(yaml@2.8.2)):
     dependencies:
       '@babel/code-frame': 7.29.0
@@ -27104,6 +27304,20 @@ snapshots:
       tsx: 4.21.0
       yaml: 2.8.2
 
+  vite@7.3.1(@types/node@22.13.17)(tsx@4.21.0)(yaml@2.8.2):
+    dependencies:
+      esbuild: 0.27.3
+      fdir: 6.5.0(picomatch@4.0.3)
+      picomatch: 4.0.3
+      postcss: 8.5.6
+      rollup: 4.49.0
+      tinyglobby: 0.2.15
+    optionalDependencies:
+      '@types/node': 22.13.17
+      fsevents: 2.3.3
+      tsx: 4.21.0
+      yaml: 2.8.2
+
   vite@7.3.1(@types/node@25.3.0)(tsx@4.21.0)(yaml@2.8.2):
     dependencies:
       esbuild: 0.27.3
@@ -27121,6 +27335,51 @@ snapshots:
   vitefu@1.1.2(vite@6.4.1(@types/node@25.3.0)(tsx@4.21.0)(yaml@2.8.2)):
     optionalDependencies:
       vite: 6.4.1(@types/node@25.3.0)(tsx@4.21.0)(yaml@2.8.2)
+
+  vitest@3.2.4(@types/debug@4.1.12)(@types/node@22.13.17)(@vitest/ui@4.0.18)(happy-dom@20.7.0)(jsdom@25.0.1)(tsx@4.21.0)(yaml@2.8.2):
+    dependencies:
+      '@types/chai': 5.2.3
+      '@vitest/expect': 3.2.4
+      '@vitest/mocker': 3.2.4(vite@7.3.1(@types/node@22.13.17)(tsx@4.21.0)(yaml@2.8.2))
+      '@vitest/pretty-format': 3.2.4
+      '@vitest/runner': 3.2.4
+      '@vitest/snapshot': 3.2.4
+      '@vitest/spy': 3.2.4
+      '@vitest/utils': 3.2.4
+      chai: 5.3.3
+      debug: 4.4.3(supports-color@8.1.1)
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      pathe: 2.0.3
+      picomatch: 4.0.3
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.15
+      tinypool: 1.1.1
+      tinyrainbow: 2.0.0
+      vite: 7.3.1(@types/node@22.13.17)(tsx@4.21.0)(yaml@2.8.2)
+      vite-node: 3.2.4(@types/node@22.13.17)(tsx@4.21.0)(yaml@2.8.2)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/debug': 4.1.12
+      '@types/node': 22.13.17
+      '@vitest/ui': 4.0.18(vitest@4.0.18)
+      happy-dom: 20.7.0
+      jsdom: 25.0.1
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
 
   vitest@4.0.18(@types/node@25.3.0)(@vitest/ui@4.0.18)(happy-dom@20.7.0)(jsdom@25.0.1)(tsx@4.21.0)(yaml@2.8.2):
     dependencies:


### PR DESCRIPTION
## Summary

- Adds Alloy build infrastructure (JSX config, `@alloy-js/graphql` dependency, Rollup plugin for vitest) as the foundation for the component-based emitter
- Introduces the context system: `GraphQLSchemaContext` (classified types, model variants, scalar specs) and `GraphQLTypeResolutionContext` (input/output mode tracking)
- Adds the core type analysis engine (`analyzeType`) that resolves TypeSpec types to GraphQL type information — base type name, nullability, and list wrapping — plus a `TypeAnalyzer` JSX component wrapper using render props
- Extends `scalar-mappings.ts` with `getGraphQLBuiltinName()` for identity-based builtin scalar resolution and a `GQL_BUILTIN_SCALARS` map

## Context

This lays the groundwork for the component-based emitter. The context providers supply schema-wide state (classified types, input/output mode) and the type analysis engine is the core logic that every field and type component will use to resolve TypeSpec types into GraphQL type information — base type name, nullability, and list wrapping.

## Test plan

- [x] Existing tests pass (129/129) — no new tests in this PR; type analysis is exercised by component and emitter tests in later PRs
