### PR TITLE
Fix nullable tracking: mark containers instead of shared type singletons

### DIFF
--- a/packages/graphql/src/lib.ts
+++ b/packages/graphql/src/lib.ts
@@ -177,7 +177,11 @@ export const libDef = {
     oneOf: { description: "State for tracking @oneOf input objects created from input unions." },
     nullable: {
       description:
-        "State for tracking types that were determined to be nullable from null-variant stripping.",
+        "State for tracking types and properties marked nullable after null-variant stripping by the mutation engine.",
+    },
+    nullableElements: {
+      description:
+        "State for tracking properties whose array element type was originally T | null before mutation.",
     },
   },
 } as const;

--- a/packages/graphql/src/lib/nullable.ts
+++ b/packages/graphql/src/lib/nullable.ts
@@ -1,47 +1,21 @@
 /**
  * Nullable tracking for the GraphQL mutation pipeline.
  *
- * ## Why state maps?
+ * The mutation engine strips `null` variants from unions before components
+ * render SDL, so structural nullability evidence is gone by render time.
+ * State maps bridge this gap: mutations record nullability, components query it.
  *
- * The GraphQL mutation engine strips `null` variants from unions before the
- * component layer renders SDL. By the time components see a type, the
- * structural evidence of nullability is gone — a `string | null` property's
- * type has already been replaced with the bare `string` scalar.
+ * ## `isNullable` — field/type nullability
  *
- * State maps bridge this gap: the mutation engine records nullability facts
- * during transformation, and components query them at render time.
+ * Marked on different targets depending on context:
+ * - **ModelProperty**: inline `T | null` (can't mark the shared scalar singleton)
+ * - **Operation**: return type `T | null`
+ * - **Union**: named unions like `Cat | Dog | null` (safe — new unique object)
  *
- * (This differs from the C# emitter, which has no mutation engine and detects
- * `T | null` unions structurally at render time. That approach doesn't work
- * here because our mutation engine rewrites the type graph first.)
+ * ## `hasNullableElements` — array element nullability
  *
- * ## Two tracking dimensions
- *
- * **Field nullability** (`isNullable`): The field/property itself is nullable.
- *
- *   Marked on different targets depending on the source:
- *   - *Property-level*: For inline `T | null` (e.g., `bio: string | null`),
- *     the union is replaced with the shared scalar singleton. Marking the
- *     singleton would poison every use of that scalar, so we mark the
- *     **ModelProperty** instead. Set by `GraphQLModelPropertyMutation`.
- *   - *Operation-level*: For `op getUser(): User | null`, the return type
- *     union is replaced with the inner type. We mark the **Operation**
- *     itself. Set by `GraphQLOperationMutation`.
- *   - *Type-level*: For named multi-variant unions with null (e.g.,
- *     `union Pet { Cat, Dog, null }`), the engine creates a new unique union
- *     object without the null variant. This new object is safe to mark
- *     directly. Set by `GraphQLUnionMutation`.
- *
- *   Components call `isNullable(program, property)`,
- *   `isNullable(program, operation)`, or `isNullable(program, type)` —
- *   all use the same state set.
- *
- * **Element nullability** (`hasNullableElements`): Array elements are nullable.
- *
- *   For `tags: (string | null)[]`, the mutation engine replaces the element
- *   union with the inner scalar but the array itself is non-null. We mark the
- *   **ModelProperty** so the component layer can emit `[String]` (nullable
- *   elements) instead of `[String!]`. Set by `GraphQLModelPropertyMutation`.
+ * For `(string | null)[]`, marks the ModelProperty so components emit
+ * `[String]` instead of `[String!]`.
  */
 
 import type { Program, Type } from "@typespec/compiler";
@@ -50,24 +24,12 @@ import { GraphQLKeys } from "../lib.js";
 
 const [getNullableState, setNullableState] = useStateSet<Type>(GraphQLKeys.nullable);
 
-/**
- * Check whether a type or property was marked nullable by the mutation engine.
- *
- * Works on both type-level targets (named unions with null stripped) and
- * property-level targets (inline `T | null` on a ModelProperty).
- */
+/** Check whether a type, property, or operation was marked nullable. */
 export function isNullable(program: Program, type: Type): boolean {
   return getNullableState(program, type);
 }
 
-/**
- * Mark a type or property as nullable. Called by the mutation engine when
- * null variants are stripped during processing.
- *
- * @see {@link GraphQLModelPropertyMutation} — marks ModelProperty for inline `T | null`
- * @see {@link GraphQLOperationMutation} — marks Operation for `op foo(): T | null`
- * @see {@link GraphQLUnionMutation} — marks the new union for named `Cat | Dog | null`
- */
+/** Mark a type, property, or operation as nullable. */
 export function setNullable(program: Program, type: Type): void {
   setNullableState(program, type);
 }
@@ -76,22 +38,12 @@ const [getNullableElementsState, setNullableElementsState] = useStateSet<Type>(
   GraphQLKeys.nullableElements,
 );
 
-/**
- * Check whether a property's array elements were originally `T | null`.
- *
- * For `tags: (string | null)[]`, the mutation engine replaces the element
- * type with the bare scalar, but the component layer still needs to know
- * that elements should be emitted without `!` (e.g., `[String]` not `[String!]`).
- */
+/** Check whether a property's array elements were originally `T | null`. */
 export function hasNullableElements(program: Program, type: Type): boolean {
   return getNullableElementsState(program, type);
 }
 
-/**
- * Mark a property as having nullable array elements.
- *
- * @see {@link GraphQLModelPropertyMutation} — detects `Array<T | null>` pattern
- */
+/** Mark a property as having nullable array elements. */
 export function setNullableElements(program: Program, type: Type): void {
   setNullableElementsState(program, type);
 }

--- a/packages/graphql/src/lib/nullable.ts
+++ b/packages/graphql/src/lib/nullable.ts
@@ -1,3 +1,49 @@
+/**
+ * Nullable tracking for the GraphQL mutation pipeline.
+ *
+ * ## Why state maps?
+ *
+ * The GraphQL mutation engine strips `null` variants from unions before the
+ * component layer renders SDL. By the time components see a type, the
+ * structural evidence of nullability is gone — a `string | null` property's
+ * type has already been replaced with the bare `string` scalar.
+ *
+ * State maps bridge this gap: the mutation engine records nullability facts
+ * during transformation, and components query them at render time.
+ *
+ * (This differs from the C# emitter, which has no mutation engine and detects
+ * `T | null` unions structurally at render time. That approach doesn't work
+ * here because our mutation engine rewrites the type graph first.)
+ *
+ * ## Two tracking dimensions
+ *
+ * **Field nullability** (`isNullable`): The field/property itself is nullable.
+ *
+ *   Marked on different targets depending on the source:
+ *   - *Property-level*: For inline `T | null` (e.g., `bio: string | null`),
+ *     the union is replaced with the shared scalar singleton. Marking the
+ *     singleton would poison every use of that scalar, so we mark the
+ *     **ModelProperty** instead. Set by `GraphQLModelPropertyMutation`.
+ *   - *Operation-level*: For `op getUser(): User | null`, the return type
+ *     union is replaced with the inner type. We mark the **Operation**
+ *     itself. Set by `GraphQLOperationMutation`.
+ *   - *Type-level*: For named multi-variant unions with null (e.g.,
+ *     `union Pet { Cat, Dog, null }`), the engine creates a new unique union
+ *     object without the null variant. This new object is safe to mark
+ *     directly. Set by `GraphQLUnionMutation`.
+ *
+ *   Components call `isNullable(program, property)`,
+ *   `isNullable(program, operation)`, or `isNullable(program, type)` —
+ *   all use the same state set.
+ *
+ * **Element nullability** (`hasNullableElements`): Array elements are nullable.
+ *
+ *   For `tags: (string | null)[]`, the mutation engine replaces the element
+ *   union with the inner scalar but the array itself is non-null. We mark the
+ *   **ModelProperty** so the component layer can emit `[String]` (nullable
+ *   elements) instead of `[String!]`. Set by `GraphQLModelPropertyMutation`.
+ */
+
 import type { Program, Type } from "@typespec/compiler";
 import { useStateSet } from "@typespec/compiler/utils";
 import { GraphQLKeys } from "../lib.js";
@@ -5,17 +51,47 @@ import { GraphQLKeys } from "../lib.js";
 const [getNullableState, setNullableState] = useStateSet<Type>(GraphQLKeys.nullable);
 
 /**
- * Check if a type has been marked as nullable due to null-variant stripping.
- * For example, `Cat | Dog | null` becomes `union CatDog` marked as nullable.
+ * Check whether a type or property was marked nullable by the mutation engine.
+ *
+ * Works on both type-level targets (named unions with null stripped) and
+ * property-level targets (inline `T | null` on a ModelProperty).
  */
 export function isNullable(program: Program, type: Type): boolean {
   return getNullableState(program, type);
 }
 
 /**
- * Mark a type as nullable. Called by the mutation engine when null variants
- * are stripped from a union during processing.
+ * Mark a type or property as nullable. Called by the mutation engine when
+ * null variants are stripped during processing.
+ *
+ * @see {@link GraphQLModelPropertyMutation} — marks ModelProperty for inline `T | null`
+ * @see {@link GraphQLOperationMutation} — marks Operation for `op foo(): T | null`
+ * @see {@link GraphQLUnionMutation} — marks the new union for named `Cat | Dog | null`
  */
 export function setNullable(program: Program, type: Type): void {
   setNullableState(program, type);
+}
+
+const [getNullableElementsState, setNullableElementsState] = useStateSet<Type>(
+  GraphQLKeys.nullableElements,
+);
+
+/**
+ * Check whether a property's array elements were originally `T | null`.
+ *
+ * For `tags: (string | null)[]`, the mutation engine replaces the element
+ * type with the bare scalar, but the component layer still needs to know
+ * that elements should be emitted without `!` (e.g., `[String]` not `[String!]`).
+ */
+export function hasNullableElements(program: Program, type: Type): boolean {
+  return getNullableElementsState(program, type);
+}
+
+/**
+ * Mark a property as having nullable array elements.
+ *
+ * @see {@link GraphQLModelPropertyMutation} — detects `Array<T | null>` pattern
+ */
+export function setNullableElements(program: Program, type: Type): void {
+  setNullableElementsState(program, type);
 }

--- a/packages/graphql/src/lib/nullable.ts
+++ b/packages/graphql/src/lib/nullable.ts
@@ -1,30 +1,17 @@
-/**
- * Nullable tracking for the GraphQL mutation pipeline.
- *
- * The mutation engine strips `null` variants from unions before components
- * render SDL, so structural nullability evidence is gone by render time.
- * State maps bridge this gap: mutations record nullability, components query it.
- *
- * ## `isNullable` — field/type nullability
- *
- * Marked on different targets depending on context:
- * - **ModelProperty**: inline `T | null` (can't mark the shared scalar singleton)
- * - **Operation**: return type `T | null`
- * - **Union**: named unions like `Cat | Dog | null` (safe — new unique object)
- *
- * ## `hasNullableElements` — array element nullability
- *
- * For `(string | null)[]`, marks the ModelProperty so components emit
- * `[String]` instead of `[String!]`.
- */
-
 import type { Program, Type } from "@typespec/compiler";
 import { useStateSet } from "@typespec/compiler/utils";
 import { GraphQLKeys } from "../lib.js";
 
 const [getNullableState, setNullableState] = useStateSet<Type>(GraphQLKeys.nullable);
 
-/** Check whether a type, property, or operation was marked nullable. */
+/**
+ * Check whether a type was marked nullable after null-variant stripping.
+ *
+ * Marked on different targets depending on context:
+ * - **ModelProperty**: inline `T | null` (can't mark the shared scalar singleton)
+ * - **Operation**: return type `T | null`
+ * - **Union**: named unions like `Cat | Dog | null` (safe — new unique object)
+ */
 export function isNullable(program: Program, type: Type): boolean {
   return getNullableState(program, type);
 }
@@ -38,7 +25,12 @@ const [getNullableElementsState, setNullableElementsState] = useStateSet<Type>(
   GraphQLKeys.nullableElements,
 );
 
-/** Check whether a property's array elements were originally `T | null`. */
+/**
+ * Check whether a property's array elements were originally `T | null`.
+ *
+ * For `(string | null)[]`, marks the ModelProperty so components emit
+ * `[String]` instead of `[String!]`.
+ */
 export function hasNullableElements(program: Program, type: Type): boolean {
   return getNullableElementsState(program, type);
 }

--- a/packages/graphql/src/lib/type-utils.ts
+++ b/packages/graphql/src/lib/type-utils.ts
@@ -49,6 +49,13 @@ export function unwrapNullableUnion(union: Union): Type | undefined {
 }
 
 /**
+ * Check whether a type is a `T | null` union (exactly two variants, one null).
+ */
+export function isNullableUnion(type: Type): boolean {
+  return type.kind === "Union" && unwrapNullableUnion(type) !== undefined;
+}
+
+/**
  * Strip null variants from a union, returning the remaining variants
  * and whether the union contained null.
  *

--- a/packages/graphql/src/mutation-engine/mutations/model-property.ts
+++ b/packages/graphql/src/mutation-engine/mutations/model-property.ts
@@ -1,4 +1,4 @@
-import type { MemberType, ModelProperty } from "@typespec/compiler";
+import { isArrayModelType, type MemberType, type ModelProperty } from "@typespec/compiler";
 import {
   SimpleModelPropertyMutation,
   type MutationInfo,
@@ -7,7 +7,11 @@ import {
   type SimpleMutations,
 } from "@typespec/mutator-framework";
 import { setNullable, setNullableElements } from "../../lib/nullable.js";
-import { isArray, unwrapNullableUnion, sanitizeNameForGraphQL } from "../../lib/type-utils.js";
+import {
+  isNullableUnion,
+  sanitizeNameForGraphQL,
+  unwrapNullableUnion,
+} from "../../lib/type-utils.js";
 
 /** GraphQL-specific ModelProperty mutation. */
 export class GraphQLModelPropertyMutation extends SimpleModelPropertyMutation<SimpleMutationOptions> {
@@ -32,14 +36,17 @@ export class GraphQLModelPropertyMutation extends SimpleModelPropertyMutation<Si
     // We mark the property (not the inner type) to avoid poisoning shared singletons.
     const originalType = this.sourceType.type;
 
-    const isInlineNullable =
-      originalType.kind === "Union" && unwrapNullableUnion(originalType) !== undefined;
+    const isInlineNullable = isNullableUnion(originalType);
+
+    // For element nullability, look through an outer `| null` wrapper to find the array.
+    // e.g. `(string | null)[] | null` → unwrap outer null → check array elements.
+    const innerType =
+      originalType.kind === "Union" ? (unwrapNullableUnion(originalType) ?? originalType) : originalType;
 
     const isArrayWithNullableElements =
-      originalType.kind === "Model" &&
-      isArray(originalType) &&
-      originalType.indexer.value.kind === "Union" &&
-      unwrapNullableUnion(originalType.indexer.value) !== undefined;
+      innerType.kind === "Model" &&
+      isArrayModelType(innerType) &&
+      isNullableUnion(innerType.indexer.value);
 
     this.mutationNode.mutate();
     super.mutate();

--- a/packages/graphql/src/mutation-engine/mutations/model-property.ts
+++ b/packages/graphql/src/mutation-engine/mutations/model-property.ts
@@ -6,7 +6,8 @@ import {
   type SimpleMutationOptions,
   type SimpleMutations,
 } from "@typespec/mutator-framework";
-import { sanitizeNameForGraphQL } from "../../lib/type-utils.js";
+import { setNullable, setNullableElements } from "../../lib/nullable.js";
+import { isArray, unwrapNullableUnion, sanitizeNameForGraphQL } from "../../lib/type-utils.js";
 
 /** GraphQL-specific ModelProperty mutation. */
 export class GraphQLModelPropertyMutation extends SimpleModelPropertyMutation<SimpleMutationOptions> {
@@ -29,8 +30,43 @@ export class GraphQLModelPropertyMutation extends SimpleModelPropertyMutation<Si
   }
 
   mutate() {
-    // Trigger mutation if not already mutated (whenMutated callback will run)
+    // Inspect the original property type BEFORE super.mutate() replaces it.
+    //
+    // After mutation, inline T | null unions are replaced with the inner type
+    // (a shared singleton like `string`). We can't mark the singleton as
+    // nullable — that would poison every use. Instead, we mark the property
+    // itself, which is unique per use-site. See nullable.ts for the full
+    // architectural explanation.
+    const originalType = this.sourceType.type;
+
+    // Case 1: Property type is directly T | null (e.g., `bio: string | null`)
+    const isInlineNullable =
+      originalType.kind === "Union" && unwrapNullableUnion(originalType) !== undefined;
+
+    // Case 2: Property type is Array<T | null> (e.g., `tags: (string | null)[]`)
+    // The array's element type (indexer value) is a T | null union.
+    const isArrayWithNullableElements =
+      originalType.kind === "Model" &&
+      isArray(originalType) &&
+      originalType.indexer.value.kind === "Union" &&
+      unwrapNullableUnion(originalType.indexer.value) !== undefined;
+
+    // Trigger mutation (whenMutated callback sanitizes the name)
     this.mutationNode.mutate();
     super.mutate();
+
+    // Mark the mutated *property* (not the type) as nullable.
+    // The component layer checks isNullable(program, property) to determine
+    // whether a field should omit the ! (non-null) wrapper.
+    if (isInlineNullable) {
+      setNullable(this.engine.$.program, this.mutatedType);
+    }
+
+    // Mark the property as having nullable array elements.
+    // The component layer checks hasNullableElements(program, property) to
+    // emit [String] instead of [String!].
+    if (isArrayWithNullableElements) {
+      setNullableElements(this.engine.$.program, this.mutatedType);
+    }
   }
 }

--- a/packages/graphql/src/mutation-engine/mutations/model-property.ts
+++ b/packages/graphql/src/mutation-engine/mutations/model-property.ts
@@ -19,9 +19,7 @@ export class GraphQLModelPropertyMutation extends SimpleModelPropertyMutation<Si
     info: MutationInfo,
   ) {
     super(engine, sourceType, referenceTypes, options, info);
-    // Register rename callback BEFORE any edge connections trigger mutation.
-    // whenMutated fires when the node is mutated (even via edge propagation),
-    // ensuring the name is sanitized before edge callbacks read it.
+    // Register rename callback before edge connections trigger mutation.
     this.mutationNode.whenMutated((property) => {
       if (property) {
         property.name = sanitizeNameForGraphQL(property.name);
@@ -30,41 +28,25 @@ export class GraphQLModelPropertyMutation extends SimpleModelPropertyMutation<Si
   }
 
   mutate() {
-    // Inspect the original property type BEFORE super.mutate() replaces it.
-    //
-    // After mutation, inline T | null unions are replaced with the inner type
-    // (a shared singleton like `string`). We can't mark the singleton as
-    // nullable — that would poison every use. Instead, we mark the property
-    // itself, which is unique per use-site. See nullable.ts for the full
-    // architectural explanation.
+    // Snapshot nullability from the original type BEFORE mutation replaces it.
+    // We mark the property (not the inner type) to avoid poisoning shared singletons.
     const originalType = this.sourceType.type;
 
-    // Case 1: Property type is directly T | null (e.g., `bio: string | null`)
     const isInlineNullable =
       originalType.kind === "Union" && unwrapNullableUnion(originalType) !== undefined;
 
-    // Case 2: Property type is Array<T | null> (e.g., `tags: (string | null)[]`)
-    // The array's element type (indexer value) is a T | null union.
     const isArrayWithNullableElements =
       originalType.kind === "Model" &&
       isArray(originalType) &&
       originalType.indexer.value.kind === "Union" &&
       unwrapNullableUnion(originalType.indexer.value) !== undefined;
 
-    // Trigger mutation (whenMutated callback sanitizes the name)
     this.mutationNode.mutate();
     super.mutate();
 
-    // Mark the mutated *property* (not the type) as nullable.
-    // The component layer checks isNullable(program, property) to determine
-    // whether a field should omit the ! (non-null) wrapper.
     if (isInlineNullable) {
       setNullable(this.engine.$.program, this.mutatedType);
     }
-
-    // Mark the property as having nullable array elements.
-    // The component layer checks hasNullableElements(program, property) to
-    // emit [String] instead of [String!].
     if (isArrayWithNullableElements) {
       setNullableElements(this.engine.$.program, this.mutatedType);
     }

--- a/packages/graphql/src/mutation-engine/mutations/operation.ts
+++ b/packages/graphql/src/mutation-engine/mutations/operation.ts
@@ -22,10 +22,7 @@ export class GraphQLOperationMutation extends SimpleOperationMutation<SimpleMuta
     super(engine, sourceType, referenceTypes, options, info);
   }
 
-  /**
-   * Override to mutate parameters with input context.
-   * Types reachable from operation parameters become GraphQL input types.
-   */
+  /** Mutate parameters with input context. */
   protected override mutateParameters() {
     const inputOptions = new GraphQLMutationOptions(GraphQLTypeContext.Input);
     this.parameters = this.engine.mutate(
@@ -35,10 +32,7 @@ export class GraphQLOperationMutation extends SimpleOperationMutation<SimpleMuta
     );
   }
 
-  /**
-   * Override to mutate return type with output context.
-   * Types reachable from operation return types become GraphQL object types.
-   */
+  /** Mutate return type with output context. */
   protected override mutateReturnType() {
     const outputOptions = new GraphQLMutationOptions(GraphQLTypeContext.Output);
     this.returnType = this.engine.mutate(
@@ -49,23 +43,17 @@ export class GraphQLOperationMutation extends SimpleOperationMutation<SimpleMuta
   }
 
   mutate() {
-    // Detect if the return type is inline T | null BEFORE super.mutate()
-    // replaces it. Same pattern as GraphQLModelPropertyMutation — see
-    // nullable.ts for the full architectural explanation.
+    // Snapshot return-type nullability before mutation replaces it.
     const originalReturnType = this.sourceType.returnType;
     const hasNullableReturn =
       originalReturnType.kind === "Union" &&
       unwrapNullableUnion(originalReturnType) !== undefined;
 
-    // Apply GraphQL name sanitization via callback
     this.mutationNode.mutate((operation) => {
       operation.name = sanitizeNameForGraphQL(operation.name);
     });
     super.mutate();
 
-    // Mark the mutated operation as having a nullable return type.
-    // The OperationField component checks isNullable(program, operation)
-    // to determine whether the return field should omit the ! wrapper.
     if (hasNullableReturn) {
       setNullable(this.engine.$.program, this.mutatedType);
     }

--- a/packages/graphql/src/mutation-engine/mutations/operation.ts
+++ b/packages/graphql/src/mutation-engine/mutations/operation.ts
@@ -7,7 +7,7 @@ import {
   type SimpleMutations,
 } from "@typespec/mutator-framework";
 import { setNullable } from "../../lib/nullable.js";
-import { unwrapNullableUnion, sanitizeNameForGraphQL } from "../../lib/type-utils.js";
+import { isNullableUnion, sanitizeNameForGraphQL } from "../../lib/type-utils.js";
 import { GraphQLMutationOptions, GraphQLTypeContext } from "../options.js";
 
 /** GraphQL-specific Operation mutation. */
@@ -44,10 +44,7 @@ export class GraphQLOperationMutation extends SimpleOperationMutation<SimpleMuta
 
   mutate() {
     // Snapshot return-type nullability before mutation replaces it.
-    const originalReturnType = this.sourceType.returnType;
-    const hasNullableReturn =
-      originalReturnType.kind === "Union" &&
-      unwrapNullableUnion(originalReturnType) !== undefined;
+    const hasNullableReturn = isNullableUnion(this.sourceType.returnType);
 
     this.mutationNode.mutate((operation) => {
       operation.name = sanitizeNameForGraphQL(operation.name);

--- a/packages/graphql/src/mutation-engine/mutations/operation.ts
+++ b/packages/graphql/src/mutation-engine/mutations/operation.ts
@@ -6,7 +6,8 @@ import {
   type SimpleMutationOptions,
   type SimpleMutations,
 } from "@typespec/mutator-framework";
-import { sanitizeNameForGraphQL } from "../../lib/type-utils.js";
+import { setNullable } from "../../lib/nullable.js";
+import { unwrapNullableUnion, sanitizeNameForGraphQL } from "../../lib/type-utils.js";
 import { GraphQLMutationOptions, GraphQLTypeContext } from "../options.js";
 
 /** GraphQL-specific Operation mutation. */
@@ -48,10 +49,25 @@ export class GraphQLOperationMutation extends SimpleOperationMutation<SimpleMuta
   }
 
   mutate() {
+    // Detect if the return type is inline T | null BEFORE super.mutate()
+    // replaces it. Same pattern as GraphQLModelPropertyMutation — see
+    // nullable.ts for the full architectural explanation.
+    const originalReturnType = this.sourceType.returnType;
+    const hasNullableReturn =
+      originalReturnType.kind === "Union" &&
+      unwrapNullableUnion(originalReturnType) !== undefined;
+
     // Apply GraphQL name sanitization via callback
     this.mutationNode.mutate((operation) => {
       operation.name = sanitizeNameForGraphQL(operation.name);
     });
     super.mutate();
+
+    // Mark the mutated operation as having a nullable return type.
+    // The OperationField component checks isNullable(program, operation)
+    // to determine whether the return field should omit the ! wrapper.
+    if (hasNullableReturn) {
+      setNullable(this.engine.$.program, this.mutatedType);
+    }
   }
 }

--- a/packages/graphql/src/mutation-engine/mutations/union.ts
+++ b/packages/graphql/src/mutation-engine/mutations/union.ts
@@ -21,10 +21,7 @@ import {
 } from "../../lib/type-utils.js";
 import { GraphQLMutationOptions, GraphQLTypeContext } from "../options.js";
 
-/**
- * Get the string name from a union variant name, which may be a string or symbol.
- * Symbols arise from anonymous/expression unions; we use their description as the name.
- */
+/** Convert a variant name (string or symbol) to a string. */
 function variantNameToString(name: string | symbol): string {
   return typeof name === "string" ? name : (name.description ?? "");
 }
@@ -32,13 +29,8 @@ function variantNameToString(name: string | symbol): string {
 /**
  * GraphQL-specific Union mutation.
  *
- * In output context: flattens nested unions, deduplicates variants,
- * and creates synthetic wrapper models for scalar variants since GraphQL unions
- * can only contain object types.
- *
- * In input context: creates a synthetic @oneOf input object, because GraphQL unions
- * are output-only. Each variant becomes a nullable field on the input object, and
- * exactly one field must be provided (oneOf semantics).
+ * Output context: flattens nested unions, deduplicates, wraps scalar variants.
+ * Input context: replaces with @oneOf input object (GraphQL unions are output-only).
  */
 export class GraphQLUnionMutation extends UnionMutation<MutationOptions, any, MutationEngine<any>> {
   #mutationNode: UnionMutationNode;
@@ -59,11 +51,7 @@ export class GraphQLUnionMutation extends UnionMutation<MutationOptions, any, Mu
     }) as UnionMutationNode;
   }
 
-  /**
-   * The input/output context this union was mutated with.
-   * Undefined when the options are not GraphQLMutationOptions (e.g. via
-   * SimpleMutationOptions edge propagation).
-   */
+  /** The input/output context, or undefined if options aren't GraphQLMutationOptions. */
   get typeContext(): GraphQLTypeContext | undefined {
     return this.options instanceof GraphQLMutationOptions
       ? this.options.typeContext
@@ -83,18 +71,12 @@ export class GraphQLUnionMutation extends UnionMutation<MutationOptions, any, Mu
     return this.#flattenedUnion || this.#mutationNode.mutatedType;
   }
 
-  /**
-   * Synthetic wrapper models created for scalar union variants.
-   * These are collected by the emitter and emitted as separate GraphQL object types.
-   */
+  /** Synthetic wrapper models for scalar union variants. */
   get wrapperModels() {
     return this.#wrapperModels;
   }
 
-  /**
-   * Creates a MutationHalfEdge that wraps the node-level edge.
-   * This ensures proper bidirectional updates when variants are mutated.
-   */
+  /** Creates a half-edge for bidirectional variant mutation updates. */
   protected startVariantEdge(): MutationHalfEdge<
     GraphQLUnionMutation,
     SimpleUnionVariantMutation<MutationOptions>
@@ -105,32 +87,17 @@ export class GraphQLUnionMutation extends UnionMutation<MutationOptions, any, Mu
   }
 
   mutate() {
-    // A nullable wrapper (e.g. `string | null`) is not a real union —
-    // it's just TypeSpec's way of spelling "nullable T". Replace the union
-    // with the inner type so downstream code sees the unwrapped type.
-    // Nullability is tracked via the state map.
+    // T | null is not a real union — replace with the inner type.
+    // Don't mark the replacement as nullable here; it's a shared singleton.
+    // Nullability is tracked by the container (ModelProperty or Operation).
     const innerType = unwrapNullableUnion(this.sourceType);
     if (innerType) {
       this.#mutationNode.replace(innerType);
-      // NOTE: We intentionally do NOT call setNullable() on the replacement type here.
-      // For inline T | null unions (e.g., `bio: string | null`), the replacement type
-      // is a shared scalar singleton — marking it would poison all uses of that scalar.
-      // Instead, nullability for inline T | null is tracked at the container level:
-      // - Model properties: by GraphQLModelPropertyMutation
-      // - Operation return types: by GraphQLOperationMutation
-      // For named multi-variant unions (Cat | Dog | null), setNullable is called in
-      // mutateAsOutputUnion() below on the newly-created union object, which is safe
-      // because that object is unique.
-      //
-      // Don't call super.mutate() — replace() swaps the union out of the
-      // graph, so there are no variants to iterate.
       return;
     }
 
     if (this.typeContext === GraphQLTypeContext.Input) {
       this.mutateAsOneOfInput();
-      // Don't call super.mutate() — the union node has been replaced with a
-      // Model, so iterating union variants is not needed
       return;
     }
 
@@ -138,16 +105,11 @@ export class GraphQLUnionMutation extends UnionMutation<MutationOptions, any, Mu
     super.mutate();
   }
 
-  /**
-   * Mutate as an output union: flatten nested unions, deduplicate, and
-   * wrap scalar variants in synthetic models.
-   */
+  /** Flatten nested unions, deduplicate, and wrap scalar variants in synthetic models. */
   private mutateAsOutputUnion() {
     const tk = this.engine.$;
     const program = tk.program;
 
-    // Strip null variants before processing — null is not a valid GraphQL union member.
-    // Nullability is tracked separately via the state map.
     const { variants: sourceVariants, isNullable: hasNull } = stripNullVariants(this.sourceType);
 
     const flattenedVariants = this.deduplicateVariants(
@@ -162,8 +124,6 @@ export class GraphQLUnionMutation extends UnionMutation<MutationOptions, any, Mu
     const needsFlattening = flattenedVariants.length !== sourceVariants.length;
 
     if (needsFlattening || hasNull) {
-      // Create a new union using TypeKit
-      // Convert symbol names to strings — GraphQL identifiers must be strings
       const variantArray = flattenedVariants.map((variant) => {
         return tk.unionVariant.create({
           name: variantNameToString(variant.name),
@@ -185,7 +145,7 @@ export class GraphQLUnionMutation extends UnionMutation<MutationOptions, any, Mu
       setNullable(program, this.mutatedType);
     }
 
-    // Wrap scalar variants in synthetic models (GraphQL unions can only contain object types)
+    // GraphQL unions can only contain object types — wrap scalars in synthetic models
     for (const variant of flattenedVariants) {
       const isScalar = variant.type.kind === "Scalar" || variant.type.kind === "Intrinsic";
 
@@ -211,17 +171,13 @@ export class GraphQLUnionMutation extends UnionMutation<MutationOptions, any, Mu
   }
 
   /**
-   * Mutate as a @oneOf input object. GraphQL unions are output-only, so when
-   * a union appears in input context it becomes a oneOf Input Object where
-   * each variant is a nullable field and exactly one must be provided.
-   *
+   * Replace with a @oneOf input object (GraphQL unions are output-only).
    * @see https://spec.graphql.org/September2025/#sec-OneOf-Input-Objects
    */
   private mutateAsOneOfInput() {
     const tk = this.engine.$;
     const program = tk.program;
 
-    // Strip null variants before processing
     const { variants: sourceVariants, isNullable: hasNull } = stripNullVariants(this.sourceType);
 
     const flattenedVariants = this.deduplicateVariants(
@@ -233,16 +189,13 @@ export class GraphQLUnionMutation extends UnionMutation<MutationOptions, any, Mu
       return;
     }
 
-    // Create one nullable field per variant
     const properties: Record<string, ReturnType<typeof tk.modelProperty.create>> = {};
     for (const variant of flattenedVariants) {
       const fieldName = sanitizeNameForGraphQL(variantNameToString(variant.name));
       properties[fieldName] = tk.modelProperty.create({
         name: fieldName,
         type: variant.type,
-        // All fields are optional — oneOf semantics mean exactly one must be provided,
-        // but from the schema perspective each individual field is nullable
-        optional: true,
+        optional: true, // oneOf: exactly one must be provided
       });
     }
 
@@ -254,26 +207,16 @@ export class GraphQLUnionMutation extends UnionMutation<MutationOptions, any, Mu
       properties,
     });
 
-    // Mark as @oneOf so the emitter can emit the directive
     setOneOf(program, oneOfModel);
 
     if (hasNull) {
       setNullable(program, oneOfModel);
     }
 
-    // Replace the union node with the model in the type graph.
-    // This notifies all parent edges (ModelProperty, UnionVariant) via onTailReplaced,
-    // so their mutatedType.type automatically points to the oneOf Model.
     this.#mutationNode.replace(oneOfModel);
   }
 
-  /**
-   * Recursively flatten nested unions into a single list of variants.
-   * GraphQL doesn't support nested unions, so union Pet { cat: Cat, animal: Animal }
-   * where Animal is itself a union becomes union Pet { Cat | Bear | Lion }.
-   *
-   * Null variants are stripped at each level — nested unions may also contain null.
-   */
+  /** Recursively flatten nested unions (GraphQL doesn't support nesting). */
   private flattenVariants(
     variants: readonly { name: string | symbol; type: Type }[],
     seen: Set<Union> = new Set(),
@@ -286,7 +229,6 @@ export class GraphQLUnionMutation extends UnionMutation<MutationOptions, any, Mu
         if (seen.has(nestedUnion)) continue;
         seen.add(nestedUnion);
 
-        // Strip null from nested unions too
         const { variants: nestedVariants } = stripNullVariants(nestedUnion);
         flattened.push(...this.flattenVariants(nestedVariants, seen));
       } else {
@@ -297,10 +239,7 @@ export class GraphQLUnionMutation extends UnionMutation<MutationOptions, any, Mu
     return flattened;
   }
 
-  /**
-   * Remove duplicate variants by type identity. If two variants reference the
-   * same type, the first occurrence wins and a diagnostic is emitted.
-   */
+  /** Deduplicate variants by type identity; first occurrence wins. */
   private deduplicateVariants(
     variants: Array<{ name: string | symbol; type: Type }>,
   ): Array<{ name: string | symbol; type: Type }> {

--- a/packages/graphql/src/mutation-engine/mutations/union.ts
+++ b/packages/graphql/src/mutation-engine/mutations/union.ts
@@ -112,7 +112,16 @@ export class GraphQLUnionMutation extends UnionMutation<MutationOptions, any, Mu
     const innerType = unwrapNullableUnion(this.sourceType);
     if (innerType) {
       this.#mutationNode.replace(innerType);
-      setNullable(this.engine.$.program, this.mutatedType);
+      // NOTE: We intentionally do NOT call setNullable() on the replacement type here.
+      // For inline T | null unions (e.g., `bio: string | null`), the replacement type
+      // is a shared scalar singleton — marking it would poison all uses of that scalar.
+      // Instead, nullability for inline T | null is tracked at the container level:
+      // - Model properties: by GraphQLModelPropertyMutation
+      // - Operation return types: by GraphQLOperationMutation
+      // For named multi-variant unions (Cat | Dog | null), setNullable is called in
+      // mutateAsOutputUnion() below on the newly-created union object, which is safe
+      // because that object is unique.
+      //
       // Don't call super.mutate() — replace() swaps the union out of the
       // graph, so there are no variants to iterate.
       return;

--- a/packages/graphql/test/mutation-engine/graphql-mutation-engine.test.ts
+++ b/packages/graphql/test/mutation-engine/graphql-mutation-engine.test.ts
@@ -1,7 +1,7 @@
 import type { EnumMember, Model, Union } from "@typespec/compiler";
 import { t } from "@typespec/compiler/testing";
 import { beforeEach, describe, expect, it } from "vitest";
-import { isNullable } from "../../src/lib/nullable.js";
+import { hasNullableElements, isNullable } from "../../src/lib/nullable.js";
 import { isOneOf } from "../../src/lib/one-of.js";
 import { getSpecifiedBy } from "../../src/lib/specified-by.js";
 import {
@@ -649,6 +649,65 @@ describe("GraphQL Mutation Engine - Unions", () => {
     // The shared scalar singleton must NOT be marked nullable (would poison all uses).
     expect(isNullable(tester.program, nameProp!.type)).toBe(false);
     expect(isNullable(tester.program, nameProp!)).toBe(true);
+  });
+
+  it("does not mark non-nullable array property as nullable or nullableElements", async () => {
+    const { Foo } = await tester.compile(
+      t.code`model ${t.model("Foo")} { tags: string[]; }`,
+    );
+
+    const engine = createTestEngine(tester.program);
+    const mutation = engine.mutateModel(Foo, GraphQLTypeContext.Output);
+
+    const tagsProp = mutation.mutatedType.properties.get("tags");
+    expect(tagsProp).toBeDefined();
+    expect(isNullable(tester.program, tagsProp!)).toBe(false);
+    expect(hasNullableElements(tester.program, tagsProp!)).toBe(false);
+  });
+
+  it("marks (T | null)[] property as nullableElements only", async () => {
+    const { Foo } = await tester.compile(
+      t.code`model ${t.model("Foo")} { tags: (string | null)[]; }`,
+    );
+
+    const engine = createTestEngine(tester.program);
+    const mutation = engine.mutateModel(Foo, GraphQLTypeContext.Output);
+
+    const tagsProp = mutation.mutatedType.properties.get("tags");
+    expect(tagsProp).toBeDefined();
+    expect(isNullable(tester.program, tagsProp!)).toBe(false);
+    expect(hasNullableElements(tester.program, tagsProp!)).toBe(true);
+  });
+
+  it("marks T[] | null property as nullable only", async () => {
+    const { Foo } = await tester.compile(
+      t.code`model ${t.model("Foo")} { tags: string[] | null; }`,
+    );
+
+    const engine = createTestEngine(tester.program);
+    const mutation = engine.mutateModel(Foo, GraphQLTypeContext.Output);
+
+    const tagsProp = mutation.mutatedType.properties.get("tags");
+    expect(tagsProp).toBeDefined();
+    expect(isNullable(tester.program, tagsProp!)).toBe(true);
+    expect(hasNullableElements(tester.program, tagsProp!)).toBe(false);
+  });
+
+  it("marks (T | null)[] | null property as both nullable and hasNullableElements", async () => {
+    const { Foo } = await tester.compile(
+      t.code`model ${t.model("Foo")} { tags: (string | null)[] | null; }`,
+    );
+
+    const engine = createTestEngine(tester.program);
+    const mutation = engine.mutateModel(Foo, GraphQLTypeContext.Output);
+
+    const tagsProp = mutation.mutatedType.properties.get("tags");
+    expect(tagsProp).toBeDefined();
+
+    // The outer `| null` marks the property as nullable
+    expect(isNullable(tester.program, tagsProp!)).toBe(true);
+    // The inner `(T | null)` marks the property as having nullable elements
+    expect(hasNullableElements(tester.program, tagsProp!)).toBe(true);
   });
 });
 

--- a/packages/graphql/test/mutation-engine/graphql-mutation-engine.test.ts
+++ b/packages/graphql/test/mutation-engine/graphql-mutation-engine.test.ts
@@ -201,6 +201,38 @@ describe("GraphQL Mutation Engine - Operations", () => {
 
     expect(mutation.mutatedType.name).toBe("get_data");
   });
+
+  it("marks operation as nullable when return type is T | null", async () => {
+    const { getUser } = await tester.compile(
+      t.code`
+        model ${t.model("User")} { name: string; }
+        op ${t.op("getUser")}(): User | null;
+      `,
+    );
+
+    const engine = createTestEngine(tester.program);
+    const mutation = engine.mutateOperation(getUser);
+
+    // The return type should be unwrapped to the inner type
+    expect(mutation.mutatedType.returnType.kind).toBe("Model");
+    // The operation itself should be marked nullable
+    expect(isNullable(tester.program, mutation.mutatedType)).toBe(true);
+  });
+
+  it("does not mark operation as nullable when return type is non-null", async () => {
+    const { getUser } = await tester.compile(
+      t.code`
+        model ${t.model("User")} { name: string; }
+        op ${t.op("getUser")}(): User;
+      `,
+    );
+
+    const engine = createTestEngine(tester.program);
+    const mutation = engine.mutateOperation(getUser);
+
+    expect(mutation.mutatedType.returnType.kind).toBe("Model");
+    expect(isNullable(tester.program, mutation.mutatedType)).toBe(false);
+  });
 });
 
 describe("GraphQL Mutation Engine - Scalars", () => {
@@ -499,7 +531,9 @@ describe("GraphQL Mutation Engine - Unions", () => {
     // T | null is replaced with the inner type (string scalar)
     expect(mutation.mutatedType.kind).toBe("Scalar");
     expect(mutation.wrapperModels).toHaveLength(0);
-    expect(isNullable(tester.program, mutation.mutatedType)).toBe(true);
+    // The replacement type is NOT marked nullable — nullability for inline T | null
+    // is tracked on the model property, not the shared scalar singleton.
+    expect(isNullable(tester.program, mutation.mutatedType)).toBe(false);
   });
 
   it("replaces nullable model union with inner type", async () => {
@@ -516,7 +550,9 @@ describe("GraphQL Mutation Engine - Unions", () => {
     // Dog | null is replaced with the inner type (Dog model)
     expect(mutation.mutatedType.kind).toBe("Model");
     expect(mutation.wrapperModels).toHaveLength(0);
-    expect(isNullable(tester.program, mutation.mutatedType)).toBe(true);
+    // The replacement type is NOT marked nullable — nullability for inline T | null
+    // is tracked on the model property, not the shared type.
+    expect(isNullable(tester.program, mutation.mutatedType)).toBe(false);
   });
 
   it("creates wrapper models for scalar variants", async () => {
@@ -596,7 +632,7 @@ describe("GraphQL Mutation Engine - Unions", () => {
     expect(mutation.mutatedType.name).toBe("ValidUnion");
   });
 
-  it("strips T | null on model property to inner type and marks nullable", async () => {
+  it("strips T | null on model property to inner type and marks property nullable", async () => {
     const { Foo } = await tester.compile(
       t.code`model ${t.model("Foo")} { name: string | null; }`,
     );
@@ -609,8 +645,10 @@ describe("GraphQL Mutation Engine - Unions", () => {
     expect(nameProp).toBeDefined();
     expect(nameProp!.type.kind).toBe("Scalar");
 
-    // The inner type should be marked as nullable
-    expect(isNullable(tester.program, nameProp!.type)).toBe(true);
+    // Nullability is tracked on the property, not the inner type.
+    // The shared scalar singleton must NOT be marked nullable (would poison all uses).
+    expect(isNullable(tester.program, nameProp!.type)).toBe(false);
+    expect(isNullable(tester.program, nameProp!)).toBe(true);
   });
 });
 


### PR DESCRIPTION
## Problem

When the mutation engine encounters `T | null` (e.g., `string | null` on a model property), it strips the null variant and calls `setNullable()` on the replacement type. But `replace()` returns shared singletons — there's only one `string` scalar in the type graph. Marking it nullable poisons every use of `string` across the entire schema.

## Solution

Move nullable marking to the **container** that holds the type rather than the type itself:

- **ModelProperty**: For inline `T | null`, mark the mutated property (not the inner scalar).
- **Operation**: For return type `T | null`, mark the mutated operation.
- **Union**: For named unions like `Cat | Dog | null`, marking the flattened union is safe (it's a new unique object), so that stays as-is. For `T | null` wrappers, stop marking the replacement — the container handles it.

Also adds `hasNullableElements` tracking for `(T | null)[]` arrays, where the ModelProperty is marked so components can emit `[String]` instead of `[String!]`.

### Changes

- `nullable.ts` — Add `hasNullableElements` / `setNullableElements` API; document the three marking sites.
- `model-property.ts` — Snapshot nullability from the original type before mutation, then mark the property.
- `operation.ts` — Snapshot return-type nullability before mutation, then mark the operation.
- `union.ts` — Remove `setNullable` from the `T | null` early-return path (container handles it).
- `lib.ts` — Add `nullableElements` state key.
- Tests — Update assertions to verify the property (not the scalar) is marked; add operation nullable/non-nullable coverage.
