### PR TITLE
Add simple type components (Enum, Scalar, Union) and input model splitting

### DIFF
--- a/packages/graphql/src/components/types/enum-type.tsx
+++ b/packages/graphql/src/components/types/enum-type.tsx
@@ -1,0 +1,25 @@
+import { type Enum, getDoc, getDeprecationDetails } from "@typespec/compiler";
+import * as gql from "@alloy-js/graphql";
+import { useTsp } from "@typespec/emitter-framework";
+
+export interface EnumTypeProps {
+  type: Enum;
+}
+
+export function EnumType(props: EnumTypeProps) {
+  const { program } = useTsp();
+  const doc = getDoc(program, props.type);
+  const members = [...props.type.members.values()];
+
+  return (
+    <gql.EnumType name={props.type.name} description={doc}>
+      {members.map((member) => (
+        <gql.EnumValue
+          name={member.name}
+          description={getDoc(program, member)}
+          deprecated={getDeprecationDetails(program, member)?.message}
+        />
+      ))}
+    </gql.EnumType>
+  );
+}

--- a/packages/graphql/src/components/types/index.ts
+++ b/packages/graphql/src/components/types/index.ts
@@ -1,0 +1,3 @@
+export { EnumType, type EnumTypeProps } from "./enum-type.js";
+export { ScalarType, type ScalarTypeProps } from "./scalar-type.js";
+export { UnionType, type UnionTypeProps } from "./union-type.js";

--- a/packages/graphql/src/components/types/index.ts
+++ b/packages/graphql/src/components/types/index.ts
@@ -1,3 +1,3 @@
 export { EnumType, type EnumTypeProps } from "./enum-type.js";
 export { ScalarType, type ScalarTypeProps } from "./scalar-type.js";
-export { UnionType, type UnionTypeProps } from "./union-type.js";
+export { UnionType, type UnionTypeProps, type GraphQLUnion } from "./union-type.js";

--- a/packages/graphql/src/components/types/scalar-type.tsx
+++ b/packages/graphql/src/components/types/scalar-type.tsx
@@ -1,0 +1,21 @@
+import { type Scalar, getDoc } from "@typespec/compiler";
+import * as gql from "@alloy-js/graphql";
+import { useTsp } from "@typespec/emitter-framework";
+
+export interface ScalarTypeProps {
+  type: Scalar;
+  specificationUrl?: string;
+}
+
+export function ScalarType(props: ScalarTypeProps) {
+  const { program } = useTsp();
+  const doc = getDoc(program, props.type);
+
+  return (
+    <gql.ScalarType
+      name={props.type.name}
+      description={doc}
+      specifiedByUrl={props.specificationUrl}
+    />
+  );
+}

--- a/packages/graphql/src/components/types/union-type.tsx
+++ b/packages/graphql/src/components/types/union-type.tsx
@@ -1,0 +1,16 @@
+import { type Union, getDoc } from "@typespec/compiler";
+import * as gql from "@alloy-js/graphql";
+import { useTsp } from "@typespec/emitter-framework";
+
+export interface UnionTypeProps {
+  type: Union;
+}
+
+export function UnionType(props: UnionTypeProps) {
+  const { program } = useTsp();
+  const doc = getDoc(program, props.type);
+  const variants = [...props.type.variants.values()];
+  const members = variants.map((v) => (v.type as { name: string }).name);
+
+  return <gql.UnionType name={props.type.name!} description={doc} members={members} />;
+}

--- a/packages/graphql/src/components/types/union-type.tsx
+++ b/packages/graphql/src/components/types/union-type.tsx
@@ -1,16 +1,24 @@
-import { type Union, getDoc } from "@typespec/compiler";
+import { type Model, type Union, getDoc } from "@typespec/compiler";
 import * as gql from "@alloy-js/graphql";
 import { useTsp } from "@typespec/emitter-framework";
 
+/**
+ * A Union guaranteed to have a name after mutation.
+ * The mutation engine ensures this: anonymous unions get derived names.
+ */
+export interface GraphQLUnion extends Union {
+  name: string;
+}
+
 export interface UnionTypeProps {
-  type: Union;
+  type: GraphQLUnion;
 }
 
 export function UnionType(props: UnionTypeProps) {
   const { program } = useTsp();
   const doc = getDoc(program, props.type);
   const variants = [...props.type.variants.values()];
-  const members = variants.map((v) => (v.type as { name: string }).name);
+  const members = variants.map((v) => (v.type as Model).name);
 
-  return <gql.UnionType name={props.type.name!} description={doc} members={members} />;
+  return <gql.UnionType name={props.type.name} description={doc} members={members} />;
 }

--- a/packages/graphql/src/lib.ts
+++ b/packages/graphql/src/lib.ts
@@ -162,6 +162,12 @@ export const libDef = {
         default: paramMessage`Scalar "${"name"}" collides with GraphQL built-in type "${"builtinName"}". This may cause unexpected behavior. Consider renaming the scalar.`,
       },
     },
+    "type-name-collision": {
+      severity: "error",
+      messages: {
+        default: paramMessage`Type "${"name"}" collides with another type of the same name in the GraphQL schema. Consider renaming one of the types.`,
+      },
+    },
     "empty-schema": {
       severity: "warning",
       messages: {

--- a/packages/graphql/src/mutation-engine/mutations/union.ts
+++ b/packages/graphql/src/mutation-engine/mutations/union.ts
@@ -193,10 +193,14 @@ export class GraphQLUnionMutation extends UnionMutation<MutationOptions, any, Mu
         });
       });
 
-      const flattenedUnion = tk.union.create({
-        name: unionName,
-        variants: variantArray,
-      });
+      const flattenedUnion = tk.type.clone(this.sourceType);
+      flattenedUnion.name = unionName;
+      flattenedUnion.variants.clear();
+      for (const variant of variantArray) {
+        flattenedUnion.variants.set(variant.name, variant);
+        variant.union = flattenedUnion;
+      }
+      tk.type.finishType(flattenedUnion);
 
       this.#flattenedUnion = flattenedUnion;
     } else {

--- a/packages/graphql/src/mutation-engine/mutations/union.ts
+++ b/packages/graphql/src/mutation-engine/mutations/union.ts
@@ -159,7 +159,33 @@ export class GraphQLUnionMutation extends UnionMutation<MutationOptions, any, Mu
       type: resolveType(this.engine.mutate(variant.type, this.options)),
     }));
 
-    if (needsFlattening || hasNull) {
+    // GraphQL unions can only contain object types — wrap scalars in synthetic models
+    // and substitute the wrapper into the variant so the union is self-contained.
+    for (const variant of mutatedVariants) {
+      const isScalar = variant.type.kind === "Scalar" || variant.type.kind === "Intrinsic";
+
+      if (isScalar) {
+        const variantName = variantNameToString(variant.name);
+        const wrapperName =
+          applyBaseNamePipeline(unionName) + applyBaseNamePipeline(variantName) + "UnionVariant";
+
+        const valueProp = tk.modelProperty.create({
+          name: "value",
+          type: variant.type,
+          optional: false,
+        });
+
+        const wrapperModel = tk.model.create({
+          name: wrapperName,
+          properties: { value: valueProp },
+        });
+
+        this.#wrapperModels.push(wrapperModel);
+        variant.type = wrapperModel;
+      }
+    }
+
+    if (needsFlattening || hasNull || this.#wrapperModels.length > 0) {
       const variantArray = mutatedVariants.map((variant) => {
         return tk.unionVariant.create({
           name: variantNameToString(variant.name),
@@ -181,30 +207,6 @@ export class GraphQLUnionMutation extends UnionMutation<MutationOptions, any, Mu
 
     if (hasNull) {
       setNullable(this.mutatedType);
-    }
-
-    // GraphQL unions can only contain object types — wrap scalars in synthetic models
-    for (const variant of mutatedVariants) {
-      const isScalar = variant.type.kind === "Scalar" || variant.type.kind === "Intrinsic";
-
-      if (isScalar) {
-        const variantName = variantNameToString(variant.name);
-        const wrapperName =
-          applyBaseNamePipeline(unionName) + applyBaseNamePipeline(variantName) + "UnionVariant";
-
-        const valueProp = tk.modelProperty.create({
-          name: "value",
-          type: variant.type,
-          optional: false,
-        });
-
-        const wrapperModel = tk.model.create({
-          name: wrapperName,
-          properties: { value: valueProp },
-        });
-
-        this.#wrapperModels.push(wrapperModel);
-      }
     }
   }
 

--- a/packages/graphql/src/mutation-engine/schema-mutator.ts
+++ b/packages/graphql/src/mutation-engine/schema-mutator.ts
@@ -34,19 +34,23 @@ export function mutateSchema(
 ): TypeGraph {
   const tk = $(program);
   const mutatedTypes: Type[] = [];
-  const modelsToInputMutate: Model[] = [];
 
   navigateTypesInNamespace(schema, {
     model: (node: Model) => {
       if (isArrayModelType(node)) return;
       if (typeUsage.isUnreachable(node)) return;
 
-      const mutation = engine.mutateModel(node, GraphQLTypeContext.Output);
-      mutatedTypes.push(mutation.mutatedType);
-
       const usage = typeUsage.getUsage(node);
-      if (usage?.has(GraphQLTypeUsage.Input)) {
-        modelsToInputMutate.push(node);
+      const usedAsOutput = usage?.has(GraphQLTypeUsage.Output) ?? false;
+      const usedAsInput = usage?.has(GraphQLTypeUsage.Input) ?? false;
+
+      if (usedAsOutput || !usage) {
+        const mutation = engine.mutateModel(node, GraphQLTypeContext.Output);
+        mutatedTypes.push(mutation.mutatedType);
+      }
+      if (usedAsInput) {
+        const mutation = engine.mutateModel(node, GraphQLTypeContext.Input);
+        mutatedTypes.push(mutation.mutatedType);
       }
     },
     enum: (node: Enum) => {
@@ -74,11 +78,6 @@ export function mutateSchema(
       mutatedTypes.push(mutation.mutatedType);
     },
   });
-
-  for (const model of modelsToInputMutate) {
-    const mutation = engine.mutateModel(model, GraphQLTypeContext.Input);
-    mutatedTypes.push(mutation.mutatedType);
-  }
 
   return buildTypeGraph(program, tk, mutatedTypes);
 }

--- a/packages/graphql/src/mutation-engine/schema-mutator.ts
+++ b/packages/graphql/src/mutation-engine/schema-mutator.ts
@@ -11,7 +11,7 @@ import {
   type Union,
 } from "@typespec/compiler";
 import { $ } from "@typespec/compiler/typekit";
-import type { TypeUsageResolver } from "../type-usage.js";
+import { GraphQLTypeUsage, type TypeUsageResolver } from "../type-usage.js";
 import type { GraphQLMutationEngine } from "./engine.js";
 import { GraphQLTypeContext } from "./options.js";
 import { buildTypeGraph, type TypeGraph } from "./type-graph.js";
@@ -22,6 +22,9 @@ import { buildTypeGraph, type TypeGraph } from "./type-graph.js";
  *
  * Filtering (unreachable types, array models, nullable unions) happens here
  * so the engine only processes types that belong in the schema.
+ *
+ * Models used as both input and output get two mutations (Output and Input),
+ * producing separate entries in the TypeGraph (e.g., `Book` and `BookInput`).
  */
 export function mutateSchema(
   program: Program,
@@ -31,6 +34,7 @@ export function mutateSchema(
 ): TypeGraph {
   const tk = $(program);
   const mutatedTypes: Type[] = [];
+  const modelsToInputMutate: Model[] = [];
 
   navigateTypesInNamespace(schema, {
     model: (node: Model) => {
@@ -39,6 +43,11 @@ export function mutateSchema(
 
       const mutation = engine.mutateModel(node, GraphQLTypeContext.Output);
       mutatedTypes.push(mutation.mutatedType);
+
+      const usage = typeUsage.getUsage(node);
+      if (usage?.has(GraphQLTypeUsage.Input)) {
+        modelsToInputMutate.push(node);
+      }
     },
     enum: (node: Enum) => {
       if (typeUsage.isUnreachable(node)) return;
@@ -65,6 +74,11 @@ export function mutateSchema(
       mutatedTypes.push(mutation.mutatedType);
     },
   });
+
+  for (const model of modelsToInputMutate) {
+    const mutation = engine.mutateModel(model, GraphQLTypeContext.Input);
+    mutatedTypes.push(mutation.mutatedType);
+  }
 
   return buildTypeGraph(program, tk, mutatedTypes);
 }

--- a/packages/graphql/src/mutation-engine/schema-mutator.ts
+++ b/packages/graphql/src/mutation-engine/schema-mutator.ts
@@ -11,6 +11,7 @@ import {
   type Union,
 } from "@typespec/compiler";
 import { $ } from "@typespec/compiler/typekit";
+import { reportDiagnostic } from "../lib.js";
 import { GraphQLTypeUsage, type TypeUsageResolver } from "../type-usage.js";
 import type { GraphQLMutationEngine } from "./engine.js";
 import { GraphQLTypeContext } from "./options.js";
@@ -78,6 +79,21 @@ export function mutateSchema(
       mutatedTypes.push(mutation.mutatedType);
     },
   });
+
+  const seen = new Map<string, Type>();
+  for (const type of mutatedTypes) {
+    if (!("name" in type) || !type.name) continue;
+    const name = type.name as string;
+    if (seen.has(name)) {
+      reportDiagnostic(program, {
+        code: "type-name-collision",
+        format: { name },
+        target: type,
+      });
+    } else {
+      seen.set(name, type);
+    }
+  }
 
   return buildTypeGraph(program, tk, mutatedTypes);
 }

--- a/packages/graphql/test/components/enum-type.test.tsx
+++ b/packages/graphql/test/components/enum-type.test.tsx
@@ -1,0 +1,102 @@
+import { t } from "@typespec/compiler/testing";
+import { beforeEach, describe, expect, it } from "vitest";
+import { EnumType } from "../../src/components/types/index.js";
+import { createGraphQLMutationEngine } from "../../src/mutation-engine/index.js";
+import { Tester } from "../test-host.js";
+import { renderToSDL } from "./test-utils.js";
+
+describe("EnumType component", () => {
+  let tester: Awaited<ReturnType<typeof Tester.createInstance>>;
+  beforeEach(async () => {
+    tester = await Tester.createInstance();
+  });
+
+  it("renders a basic enum", async () => {
+    const { Color } = await tester.compile(
+      t.code`enum ${t.enum("Color")} { Red, Green, Blue }`,
+    );
+
+    const engine = createGraphQLMutationEngine(tester.program);
+    const mutated = engine.mutateEnum(Color).mutatedType;
+
+    const sdl = renderToSDL(tester.program, <EnumType type={mutated} />);
+
+    expect(sdl).toContain("enum Color");
+    expect(sdl).toContain("RED");
+    expect(sdl).toContain("GREEN");
+    expect(sdl).toContain("BLUE");
+  });
+
+  it("renders enum with doc comment as description", async () => {
+    const { Role } = await tester.compile(
+      t.code`
+        /** The role a user can have */
+        enum ${t.enum("Role")} { Admin, User }
+      `,
+    );
+
+    const engine = createGraphQLMutationEngine(tester.program);
+    const mutated = engine.mutateEnum(Role).mutatedType;
+
+    const sdl = renderToSDL(tester.program, <EnumType type={mutated} />);
+
+    expect(sdl).toContain('"The role a user can have"');
+    expect(sdl).toContain("enum Role");
+  });
+
+  it("renders enum with member descriptions", async () => {
+    const { Status } = await tester.compile(
+      t.code`
+        enum ${t.enum("Status")} {
+          /** Currently active */
+          Active,
+          /** No longer active */
+          Inactive,
+        }
+      `,
+    );
+
+    const engine = createGraphQLMutationEngine(tester.program);
+    const mutated = engine.mutateEnum(Status).mutatedType;
+
+    const sdl = renderToSDL(tester.program, <EnumType type={mutated} />);
+
+    expect(sdl).toContain('"Currently active"');
+    expect(sdl).toContain('"No longer active"');
+  });
+
+  it("renders enum with deprecated members", async () => {
+    const { Status } = await tester.compile(
+      t.code`
+        enum ${t.enum("Status")} {
+          Active,
+          #deprecated "use Active instead"
+          Legacy,
+        }
+      `,
+    );
+
+    const engine = createGraphQLMutationEngine(tester.program);
+    const mutated = engine.mutateEnum(Status).mutatedType;
+
+    const sdl = renderToSDL(tester.program, <EnumType type={mutated} />);
+
+    expect(sdl).toContain("@deprecated");
+    expect(sdl).toContain("use Active instead");
+  });
+
+  it("renders enum with mutation-engine-sanitized member names", async () => {
+    const { E } = await tester.compile(
+      t.code`enum ${t.enum("E")} { \`$val1$\`, \`val-2\` }`,
+    );
+
+    const engine = createGraphQLMutationEngine(tester.program);
+    const mutated = engine.mutateEnum(E).mutatedType;
+
+    const sdl = renderToSDL(tester.program, <EnumType type={mutated} />);
+
+    // Mutation engine: sanitize → CONSTANT_CASE
+    expect(sdl).toContain("_VAL_1");
+    expect(sdl).toContain("VAL_2");
+  });
+});

--- a/packages/graphql/test/components/scalar-type.test.tsx
+++ b/packages/graphql/test/components/scalar-type.test.tsx
@@ -1,0 +1,79 @@
+import { t } from "@typespec/compiler/testing";
+import { beforeEach, describe, expect, it } from "vitest";
+import { ScalarType } from "../../src/components/types/index.js";
+import { createGraphQLMutationEngine } from "../../src/mutation-engine/index.js";
+import { getSpecifiedBy } from "../../src/lib/specified-by.js";
+import { Tester } from "../test-host.js";
+import { renderToSDL } from "./test-utils.js";
+
+describe("ScalarType component", () => {
+  let tester: Awaited<ReturnType<typeof Tester.createInstance>>;
+  beforeEach(async () => {
+    tester = await Tester.createInstance();
+  });
+
+  it("renders a custom scalar", async () => {
+    const { DateTime } = await tester.compile(
+      t.code`scalar ${t.scalar("DateTime")} extends string;`,
+    );
+
+    const engine = createGraphQLMutationEngine(tester.program);
+    const mutated = engine.mutateScalar(DateTime).mutatedType;
+
+    const sdl = renderToSDL(tester.program, <ScalarType type={mutated} />);
+
+    expect(sdl).toContain("scalar DateTime");
+  });
+
+  it("renders a scalar with doc comment description", async () => {
+    const { JSON } = await tester.compile(
+      t.code`
+        /** Arbitrary JSON blob */
+        scalar ${t.scalar("JSON")} extends string;
+      `,
+    );
+
+    const engine = createGraphQLMutationEngine(tester.program);
+    const mutated = engine.mutateScalar(JSON).mutatedType;
+
+    const sdl = renderToSDL(tester.program, <ScalarType type={mutated} />);
+
+    expect(sdl).toContain('"Arbitrary JSON blob"');
+    expect(sdl).toContain("scalar JSON");
+  });
+
+  it("renders a scalar with @specifiedBy", async () => {
+    const { MyScalar } = await tester.compile(
+      t.code`
+        @specifiedBy("https://example.com/spec")
+        scalar ${t.scalar("MyScalar")} extends string;
+      `,
+    );
+
+    const engine = createGraphQLMutationEngine(tester.program);
+    const mutated = engine.mutateScalar(MyScalar).mutatedType;
+    const specUrl = getSpecifiedBy(tester.program, mutated);
+
+    const sdl = renderToSDL(
+      tester.program,
+      <ScalarType type={mutated} specificationUrl={specUrl} />,
+    );
+
+    expect(sdl).toContain("@specifiedBy");
+    expect(sdl).toContain("https://example.com/spec");
+  });
+
+  it("renders a scalar without @specifiedBy when not present", async () => {
+    const { MyScalar } = await tester.compile(
+      t.code`scalar ${t.scalar("MyScalar")} extends string;`,
+    );
+
+    const engine = createGraphQLMutationEngine(tester.program);
+    const mutated = engine.mutateScalar(MyScalar).mutatedType;
+
+    const sdl = renderToSDL(tester.program, <ScalarType type={mutated} />);
+
+    expect(sdl).toContain("scalar MyScalar");
+    expect(sdl).not.toContain("@specifiedBy");
+  });
+});

--- a/packages/graphql/test/components/test-utils.tsx
+++ b/packages/graphql/test/components/test-utils.tsx
@@ -1,0 +1,35 @@
+import { type Children } from "@alloy-js/core";
+import * as gql from "@alloy-js/graphql";
+import { renderSchema } from "@alloy-js/graphql";
+import { printSchema } from "graphql";
+import type { Program } from "@typespec/compiler";
+import { TspContext } from "@typespec/emitter-framework";
+import { GraphQLSchemaContext } from "../../src/context/index.js";
+import type { TypeGraph } from "../../src/mutation-engine/type-graph.js";
+
+/**
+ * Render GraphQL components in isolation and return SDL string.
+ * Wraps children in required context providers and adds a placeholder Query
+ * (graphql-js requires at least one query field).
+ */
+export function renderToSDL(program: Program, children: Children): string {
+  const typeGraph: TypeGraph = {
+    globalNamespace: program.getGlobalNamespaceType(),
+  };
+
+  const schema = renderSchema(
+    <TspContext.Provider value={{ program }}>
+      <GraphQLSchemaContext.Provider value={{ typeGraph }}>
+        {children}
+        <gql.Query>
+          <gql.Field name="_placeholder" type={gql.Boolean} nonNull={false} />
+        </gql.Query>
+      </GraphQLSchemaContext.Provider>
+    </TspContext.Provider>,
+    { namePolicy: null },
+  );
+
+  // Cast needed: alloy uses graphql@17-alpha internally, our package uses graphql@16.
+  // At runtime both are deduped via vitest config; the type mismatch is superficial.
+  return printSchema(schema as any);
+}

--- a/packages/graphql/test/components/union-type.test.tsx
+++ b/packages/graphql/test/components/union-type.test.tsx
@@ -1,0 +1,141 @@
+import { type Union } from "@typespec/compiler";
+import { t } from "@typespec/compiler/testing";
+import * as gql from "@alloy-js/graphql";
+import { beforeEach, describe, expect, it } from "vitest";
+import { UnionType } from "../../src/components/types/index.js";
+import {
+  createGraphQLMutationEngine,
+  GraphQLTypeContext,
+} from "../../src/mutation-engine/index.js";
+import { Tester } from "../test-host.js";
+import { renderToSDL } from "./test-utils.js";
+
+describe("UnionType component", () => {
+  let tester: Awaited<ReturnType<typeof Tester.createInstance>>;
+  beforeEach(async () => {
+    tester = await Tester.createInstance();
+  });
+
+  it("renders a union of model types", async () => {
+    const { Pet } = await tester.compile(
+      t.code`
+        model ${t.model("Cat")} { name: string; }
+        model ${t.model("Dog")} { breed: string; }
+        union ${t.union("Pet")} { cat: Cat; dog: Dog; }
+      `,
+    );
+
+    const engine = createGraphQLMutationEngine(tester.program);
+    const mutation = engine.mutateUnion(Pet, GraphQLTypeContext.Output);
+    const mutatedUnion = mutation.mutatedType as Union;
+
+    // Union members must be registered for graphql-js to validate the schema
+    const sdl = renderToSDL(
+      tester.program,
+      <>
+        <gql.ObjectType name="Cat">
+          <gql.Field name="name" type={gql.String} nonNull />
+        </gql.ObjectType>
+        <gql.ObjectType name="Dog">
+          <gql.Field name="breed" type={gql.String} nonNull />
+        </gql.ObjectType>
+        <UnionType type={mutatedUnion} />
+      </>,
+    );
+
+    expect(sdl).toContain("union Pet = Cat | Dog");
+  });
+
+  it("renders a union with doc comment description", async () => {
+    const { Result } = await tester.compile(
+      t.code`
+        model ${t.model("Success")} { value: string; }
+        model ${t.model("Failure")} { message: string; }
+        /** The result of an operation */
+        union ${t.union("Result")} { success: Success; failure: Failure; }
+      `,
+    );
+
+    const engine = createGraphQLMutationEngine(tester.program);
+    const mutation = engine.mutateUnion(Result, GraphQLTypeContext.Output);
+    const mutatedUnion = mutation.mutatedType as Union;
+
+    const sdl = renderToSDL(
+      tester.program,
+      <>
+        <gql.ObjectType name="Success">
+          <gql.Field name="value" type={gql.String} nonNull />
+        </gql.ObjectType>
+        <gql.ObjectType name="Failure">
+          <gql.Field name="message" type={gql.String} nonNull />
+        </gql.ObjectType>
+        <UnionType type={mutatedUnion} />
+      </>,
+    );
+
+    expect(sdl).toContain('"The result of an operation"');
+    expect(sdl).toContain("union Result = Success | Failure");
+  });
+
+  it("references wrapper model names for scalar variants", async () => {
+    const { Mixed } = await tester.compile(
+      t.code`
+        model ${t.model("Cat")} { name: string; }
+        union ${t.union("Mixed")} { cat: Cat; text: string; }
+      `,
+    );
+
+    const engine = createGraphQLMutationEngine(tester.program);
+    const mutation = engine.mutateUnion(Mixed, GraphQLTypeContext.Output);
+    const mutatedUnion = mutation.mutatedType as Union;
+
+    // Register the wrapper model and Cat so graphql-js can validate
+    const sdl = renderToSDL(
+      tester.program,
+      <>
+        <gql.ObjectType name="Cat">
+          <gql.Field name="name" type={gql.String} nonNull />
+        </gql.ObjectType>
+        <gql.ObjectType name="MixedTextUnionVariant">
+          <gql.Field name="value" type={gql.String} nonNull />
+        </gql.ObjectType>
+        <UnionType type={mutatedUnion} />
+      </>,
+    );
+
+    expect(sdl).toContain("union Mixed = Cat | MixedTextUnionVariant");
+  });
+
+  it("renders a union with three model members", async () => {
+    const { Shape } = await tester.compile(
+      t.code`
+        model ${t.model("Circle")} { radius: float32; }
+        model ${t.model("Square")} { side: float32; }
+        model ${t.model("Triangle")} { base: float32; }
+        union ${t.union("Shape")} { circle: Circle; square: Square; triangle: Triangle; }
+      `,
+    );
+
+    const engine = createGraphQLMutationEngine(tester.program);
+    const mutation = engine.mutateUnion(Shape, GraphQLTypeContext.Output);
+    const mutatedUnion = mutation.mutatedType as Union;
+
+    const sdl = renderToSDL(
+      tester.program,
+      <>
+        <gql.ObjectType name="Circle">
+          <gql.Field name="radius" type={gql.Float} nonNull />
+        </gql.ObjectType>
+        <gql.ObjectType name="Square">
+          <gql.Field name="side" type={gql.Float} nonNull />
+        </gql.ObjectType>
+        <gql.ObjectType name="Triangle">
+          <gql.Field name="base" type={gql.Float} nonNull />
+        </gql.ObjectType>
+        <UnionType type={mutatedUnion} />
+      </>,
+    );
+
+    expect(sdl).toContain("union Shape = Circle | Square | Triangle");
+  });
+});

--- a/packages/graphql/test/components/union-type.test.tsx
+++ b/packages/graphql/test/components/union-type.test.tsx
@@ -1,8 +1,7 @@
-import { type Union } from "@typespec/compiler";
 import { t } from "@typespec/compiler/testing";
 import * as gql from "@alloy-js/graphql";
 import { beforeEach, describe, expect, it } from "vitest";
-import { UnionType } from "../../src/components/types/index.js";
+import { UnionType, type GraphQLUnion } from "../../src/components/types/index.js";
 import {
   createGraphQLMutationEngine,
   GraphQLTypeContext,
@@ -27,7 +26,7 @@ describe("UnionType component", () => {
 
     const engine = createGraphQLMutationEngine(tester.program);
     const mutation = engine.mutateUnion(Pet, GraphQLTypeContext.Output);
-    const mutatedUnion = mutation.mutatedType as Union;
+    const mutatedUnion = mutation.mutatedType as GraphQLUnion;
 
     // Union members must be registered for graphql-js to validate the schema
     const sdl = renderToSDL(
@@ -58,7 +57,7 @@ describe("UnionType component", () => {
 
     const engine = createGraphQLMutationEngine(tester.program);
     const mutation = engine.mutateUnion(Result, GraphQLTypeContext.Output);
-    const mutatedUnion = mutation.mutatedType as Union;
+    const mutatedUnion = mutation.mutatedType as GraphQLUnion;
 
     const sdl = renderToSDL(
       tester.program,
@@ -87,7 +86,7 @@ describe("UnionType component", () => {
 
     const engine = createGraphQLMutationEngine(tester.program);
     const mutation = engine.mutateUnion(Mixed, GraphQLTypeContext.Output);
-    const mutatedUnion = mutation.mutatedType as Union;
+    const mutatedUnion = mutation.mutatedType as GraphQLUnion;
 
     // Register the wrapper model and Cat so graphql-js can validate
     const sdl = renderToSDL(
@@ -118,7 +117,7 @@ describe("UnionType component", () => {
 
     const engine = createGraphQLMutationEngine(tester.program);
     const mutation = engine.mutateUnion(Shape, GraphQLTypeContext.Output);
-    const mutatedUnion = mutation.mutatedType as Union;
+    const mutatedUnion = mutation.mutatedType as GraphQLUnion;
 
     const sdl = renderToSDL(
       tester.program,

--- a/packages/graphql/test/mutation-engine/schema-mutator.test.ts
+++ b/packages/graphql/test/mutation-engine/schema-mutator.test.ts
@@ -208,6 +208,30 @@ describe("mutateSchema", () => {
     expect(typeGraph.globalNamespace.models.has("Payload")).toBe(false);
   });
 
+  it("reports diagnostic when two types produce the same GraphQL name", async () => {
+    const [_, diagnostics] = await tester.compileAndDiagnose(
+      t.code`
+        model ${t.model("BookInput")} { x: int32; }
+        model ${t.model("Book")} { title: string; }
+        op ${t.op("getBooks")}(): Book[];
+        op ${t.op("createBook")}(input: Book): Book;
+      `,
+    );
+
+    // Book used as input → Input mutation → "BookInput"
+    // BookInput declared explicitly → Output mutation → "BookInput"
+    // This should produce a collision diagnostic
+    const ns = tester.program.getGlobalNamespaceType();
+    const typeUsage = resolveTypeUsage(ns, false);
+    const engine = createGraphQLMutationEngine(tester.program);
+    mutateSchema(tester.program, engine, ns, typeUsage);
+
+    const collisions = tester.program.diagnostics.filter(
+      (d) => d.code === "@typespec/graphql/type-name-collision",
+    );
+    expect(collisions.length).toBeGreaterThan(0);
+  });
+
   it("skips array models (they are list types, not object types)", async () => {
     await tester.compile(
       t.code`

--- a/packages/graphql/test/mutation-engine/schema-mutator.test.ts
+++ b/packages/graphql/test/mutation-engine/schema-mutator.test.ts
@@ -187,6 +187,27 @@ describe("mutateSchema", () => {
     expect(typeGraph.globalNamespace.models.has("BookInput")).toBe(false);
   });
 
+  it("does not produce Output variant for input-only models", async () => {
+    await tester.compile(
+      t.code`
+        model ${t.model("Book")} { title: string; }
+        model ${t.model("Payload")} { title: string; }
+        op ${t.op("getBooks")}(): Book[];
+        op ${t.op("createBook")}(input: Payload): Book;
+      `,
+    );
+
+    const ns = tester.program.getGlobalNamespaceType();
+    const typeUsage = resolveTypeUsage(ns, true);
+    const engine = createGraphQLMutationEngine(tester.program);
+    const typeGraph = mutateSchema(tester.program, engine, ns, typeUsage);
+
+    // Payload is only used as input — should only appear as Input variant (PayloadInput)
+    expect(typeGraph.globalNamespace.models.has("PayloadInput")).toBe(true);
+    // Should NOT have an Output variant
+    expect(typeGraph.globalNamespace.models.has("Payload")).toBe(false);
+  });
+
   it("skips array models (they are list types, not object types)", async () => {
     await tester.compile(
       t.code`

--- a/packages/graphql/test/mutation-engine/schema-mutator.test.ts
+++ b/packages/graphql/test/mutation-engine/schema-mutator.test.ts
@@ -150,6 +150,43 @@ describe("mutateSchema", () => {
     expect(typeGraph.globalNamespace.models.has("MixedNumUnionVariant")).toBe(true);
   });
 
+  it("produces Input variant for models used as operation parameters", async () => {
+    await tester.compile(
+      t.code`
+        model ${t.model("Book")} { title: string; }
+        op ${t.op("getBooks")}(): Book[];
+        op ${t.op("createBook")}(input: Book): Book;
+      `,
+    );
+
+    const ns = tester.program.getGlobalNamespaceType();
+    const typeUsage = resolveTypeUsage(ns, false);
+    const engine = createGraphQLMutationEngine(tester.program);
+    const typeGraph = mutateSchema(tester.program, engine, ns, typeUsage);
+
+    // Book is used as both output (return) and input (parameter),
+    // so both variants should appear in the TypeGraph
+    expect(typeGraph.globalNamespace.models.has("Book")).toBe(true);
+    expect(typeGraph.globalNamespace.models.has("BookInput")).toBe(true);
+  });
+
+  it("does not produce Input variant for output-only models", async () => {
+    await tester.compile(
+      t.code`
+        model ${t.model("Book")} { title: string; }
+        op ${t.op("getBooks")}(): Book[];
+      `,
+    );
+
+    const ns = tester.program.getGlobalNamespaceType();
+    const typeUsage = resolveTypeUsage(ns, false);
+    const engine = createGraphQLMutationEngine(tester.program);
+    const typeGraph = mutateSchema(tester.program, engine, ns, typeUsage);
+
+    expect(typeGraph.globalNamespace.models.has("Book")).toBe(true);
+    expect(typeGraph.globalNamespace.models.has("BookInput")).toBe(false);
+  });
+
   it("skips array models (they are list types, not object types)", async () => {
     await tester.compile(
       t.code`

--- a/packages/graphql/test/mutation-engine/unions.test.ts
+++ b/packages/graphql/test/mutation-engine/unions.test.ts
@@ -71,6 +71,32 @@ describe("GraphQL Mutation Engine - Unions", () => {
     expect(mutation.wrapperModels[0].name).toBe("MixedTextUnionVariant");
   });
 
+  it("substitutes wrapper models into union variant types", async () => {
+    const { Mixed } = await tester.compile(
+      t.code`
+        model ${t.model("Cat")} { name: string; }
+        union ${t.union("Mixed")} { cat: Cat; text: string; }
+      `,
+    );
+
+    const engine = createTestEngine(tester.program);
+    const mutation = engine.mutateUnion(Mixed, GraphQLTypeContext.Output);
+    const mutatedUnion = mutation.mutatedType as Union;
+
+    const variants = [...mutatedUnion.variants.values()];
+    expect(variants).toHaveLength(2);
+
+    // Model variant points to the mutated model
+    const catVariant = variants.find((v) => v.name === "cat")!;
+    expect(catVariant.type.kind).toBe("Model");
+    expect((catVariant.type as Model).name).toBe("Cat");
+
+    // Scalar variant points to the wrapper model, not the raw scalar
+    const textVariant = variants.find((v) => v.name === "text")!;
+    expect(textVariant.type.kind).toBe("Model");
+    expect((textVariant.type as Model).name).toBe("MixedTextUnionVariant");
+  });
+
   it("does not create wrappers for model-only unions", async () => {
     const { Pet } = await tester.compile(
       t.code`
@@ -111,6 +137,13 @@ describe("GraphQL Mutation Engine - Unions", () => {
     expect(mutation.wrapperModels).toHaveLength(2);
     const names = mutation.wrapperModels.map((m) => m.name).sort();
     expect(names).toEqual(["MixedCountUnionVariant", "MixedTextUnionVariant"]);
+
+    // All union variants point to Models (originals or wrappers)
+    const mutatedUnion = mutation.mutatedType as Union;
+    const variants = [...mutatedUnion.variants.values()];
+    for (const variant of variants) {
+      expect(variant.type.kind).toBe("Model");
+    }
   });
 
   it("names anonymous return type union as OperationUnion", async () => {

--- a/packages/graphql/test/mutation-engine/unions.test.ts
+++ b/packages/graphql/test/mutation-engine/unions.test.ts
@@ -1,4 +1,4 @@
-import type { Model, Union } from "@typespec/compiler";
+import { getDoc, type Model, type Union } from "@typespec/compiler";
 import { t } from "@typespec/compiler/testing";
 import { beforeEach, describe, expect, it } from "vitest";
 import { isNullable } from "../../src/lib/nullable.js";
@@ -216,6 +216,22 @@ describe("GraphQL Mutation Engine - Unions", () => {
       .map((v) => ("name" in v.type ? v.type.name : v.type.kind))
       .sort();
     expect(variantNames).toEqual(["AdAccount", "Board"]);
+  });
+
+  it("preserves decorator state (e.g. @doc) on flattened unions", async () => {
+    const { MaybePet } = await tester.compile(
+      t.code`
+        model ${t.model("Cat")} { name: string; }
+        model ${t.model("Dog")} { breed: string; }
+        /** A pet or nothing */
+        union ${t.union("MaybePet")} { cat: Cat; dog: Dog; null; }
+      `,
+    );
+
+    const engine = createTestEngine(tester.program);
+    const mutation = engine.mutateUnion(MaybePet, GraphQLTypeContext.Output);
+
+    expect(getDoc(tester.program, mutation.mutatedType)).toBe("A pet or nothing");
   });
 
   it("T | null replacement gets its mutation pipeline applied", async () => {

--- a/packages/graphql/vitest.config.ts
+++ b/packages/graphql/vitest.config.ts
@@ -10,5 +10,9 @@ export default mergeConfig(
       sourcemap: "both",
     },
     plugins: [alloyPlugin()],
+    resolve: {
+      conditions: ["development"],
+      dedupe: ["@alloy-js/core", "graphql"],
+    },
   }),
 );


### PR DESCRIPTION
## Summary

- Add thin rendering components (`EnumType`, `ScalarType`, `UnionType`) that consume mutated types from the TypeGraph and delegate to `@alloy-js/graphql`
- Fix union mutation to substitute wrapper models into variant types (self-contained unions)
- Add input/output model splitting in `schema-mutator.ts` — models used as operation parameters get a second mutation pass with `GraphQLTypeContext.Input`
- Add component test infrastructure (`renderToSDL` helper, vitest config for alloy/graphql deduping)

## Architecture decisions applied

- No `GraphQLTypeExpression` component — use `resolveGraphQLTypeName()` directly
- No render-time name logic — all names come from `type.name` (set by mutation engine)
- Components are thin wrappers around `@alloy-js/graphql`

## Test plan

- [x] 13 component tests (EnumType: 5, ScalarType: 4, UnionType: 4)
- [x] 2 schema-mutator tests for input model splitting
- [x] 1 union mutation test for wrapper model substitution
- [x] All 226 tests pass
- [x] `tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)