### PR TITLE
Replace state maps with decorators for mutation engine metadata

### DIFF
--- a/packages/graphql/lib/main.tsp
+++ b/packages/graphql/lib/main.tsp
@@ -1,4 +1,6 @@
 import "./interface.tsp";
+import "./nullable.tsp";
+import "./one-of.tsp";
 import "./operation-fields.tsp";
 import "./operation-kind.tsp";
 import "./scalars.tsp";

--- a/packages/graphql/lib/nullable.tsp
+++ b/packages/graphql/lib/nullable.tsp
@@ -1,0 +1,22 @@
+import "../dist/src/lib/nullable.js";
+
+using TypeSpec.Reflection;
+
+namespace TypeSpec.GraphQL;
+
+/**
+ * Mark a field, operation, or type as nullable in the emitted GraphQL schema.
+ *
+ * Applied automatically by the mutation engine when it strips `| null` from
+ * union types. The decorator's presence on the type's `decorators` array is
+ * the signal — the implementation is a no-op.
+ */
+extern dec nullable(target: ModelProperty | Operation | Union | Model);
+
+/**
+ * Mark a field or operation as having nullable array elements in the emitted GraphQL schema.
+ *
+ * Applied automatically by the mutation engine when it detects `Array<T | null>`
+ * patterns. Causes the emitter to emit `[T]` instead of `[T!]`.
+ */
+extern dec nullableElements(target: ModelProperty | Operation);

--- a/packages/graphql/lib/one-of.tsp
+++ b/packages/graphql/lib/one-of.tsp
@@ -1,0 +1,16 @@
+import "../dist/src/lib/one-of.js";
+
+using TypeSpec.Reflection;
+
+namespace TypeSpec.GraphQL;
+
+/**
+ * Mark a model as a `@oneOf` input object in the emitted GraphQL schema.
+ *
+ * This decorator is applied automatically by the mutation engine when it converts
+ * a union type in input context to a synthetic input object (since GraphQL unions
+ * are output-only). The emitter uses this to emit the `@oneOf` directive.
+ *
+ * @see https://spec.graphql.org/September2025/#sec-OneOf-Input-Objects
+ */
+extern dec oneOf(target: Model);

--- a/packages/graphql/src/lib.ts
+++ b/packages/graphql/src/lib.ts
@@ -174,15 +174,6 @@ export const libDef = {
     interface: { description: "State for the @Interface decorator." },
     schema: { description: "State for the @schema decorator." },
     specifiedBy: { description: "State for the @specifiedBy decorator." },
-    oneOf: { description: "State for tracking @oneOf input objects created from input unions." },
-    nullable: {
-      description:
-        "State for tracking types and properties marked nullable after null-variant stripping by the mutation engine.",
-    },
-    nullableElements: {
-      description:
-        "State for tracking properties whose array element type was originally T | null before mutation.",
-    },
   },
 } as const;
 

--- a/packages/graphql/src/lib/nullable.ts
+++ b/packages/graphql/src/lib/nullable.ts
@@ -1,8 +1,38 @@
-import type { Program, Type } from "@typespec/compiler";
-import { useStateSet } from "@typespec/compiler/utils";
-import { GraphQLKeys } from "../lib.js";
+import type {
+  DecoratedType,
+  DecoratorContext,
+  DecoratorFunction,
+  Model,
+  ModelProperty,
+  Operation,
+  Type,
+  Union,
+} from "@typespec/compiler";
+import { NAMESPACE } from "../lib.js";
 
-const [getNullableState, setNullableState] = useStateSet<Type>(GraphQLKeys.nullable);
+// This will set the namespace for decorators implemented in this file
+export const namespace = NAMESPACE;
+
+/**
+ * Decorator implementation for `@nullable`.
+ *
+ * No-op — the decorator's presence on the type's `decorators` array is the
+ * signal. No additional state storage is needed.
+ */
+export const $nullable: DecoratorFunction = (
+  _context: DecoratorContext,
+  _target: ModelProperty | Operation | Union | Model,
+) => {};
+
+/**
+ * Decorator implementation for `@nullableElements`.
+ *
+ * No-op — presence on the decorators array is the signal.
+ */
+export const $nullableElements: DecoratorFunction = (
+  _context: DecoratorContext,
+  _target: ModelProperty | Operation,
+) => {};
 
 /**
  * Check whether a type was marked nullable after null-variant stripping.
@@ -12,18 +42,20 @@ const [getNullableState, setNullableState] = useStateSet<Type>(GraphQLKeys.nulla
  * - **Operation**: return type `T | null`
  * - **Union**: named unions like `Cat | Dog | null` (safe — new unique object)
  */
-export function isNullable(program: Program, type: Type): boolean {
-  return getNullableState(program, type);
+export function isNullable(type: Type): boolean {
+  if (!isDecoratedType(type)) return false;
+  return type.decorators.some((d) => d.decorator === $nullable);
 }
 
-/** Mark a type, property, or operation as nullable. */
-export function setNullable(program: Program, type: Type): void {
-  setNullableState(program, type);
+/**
+ * Mark a type, property, or operation as nullable.
+ * Called by the mutation engine when null variants are stripped.
+ */
+export function setNullable(type: Type): void {
+  if (!isDecoratedType(type)) return;
+  if (type.decorators.some((d) => d.decorator === $nullable)) return;
+  type.decorators.push({ decorator: $nullable, args: [] });
 }
-
-const [getNullableElementsState, setNullableElementsState] = useStateSet<Type>(
-  GraphQLKeys.nullableElements,
-);
 
 /**
  * Check whether a property's array elements were originally `T | null`.
@@ -31,11 +63,18 @@ const [getNullableElementsState, setNullableElementsState] = useStateSet<Type>(
  * For `(string | null)[]`, marks the ModelProperty so components emit
  * `[String]` instead of `[String!]`.
  */
-export function hasNullableElements(program: Program, type: Type): boolean {
-  return getNullableElementsState(program, type);
+export function hasNullableElements(type: Type): boolean {
+  if (!isDecoratedType(type)) return false;
+  return type.decorators.some((d) => d.decorator === $nullableElements);
 }
 
 /** Mark a property as having nullable array elements. */
-export function setNullableElements(program: Program, type: Type): void {
-  setNullableElementsState(program, type);
+export function setNullableElements(type: Type): void {
+  if (!isDecoratedType(type)) return;
+  if (type.decorators.some((d) => d.decorator === $nullableElements)) return;
+  type.decorators.push({ decorator: $nullableElements, args: [] });
+}
+
+function isDecoratedType(type: Type): type is Type & DecoratedType {
+  return "decorators" in type;
 }

--- a/packages/graphql/src/lib/one-of.ts
+++ b/packages/graphql/src/lib/one-of.ts
@@ -1,8 +1,19 @@
-import type { Model, Program } from "@typespec/compiler";
-import { useStateSet } from "@typespec/compiler/utils";
-import { GraphQLKeys } from "../lib.js";
+import type { DecoratorContext, DecoratorFunction, Model } from "@typespec/compiler";
+import { NAMESPACE } from "../lib.js";
 
-const [getOneOfState, setOneOfState] = useStateSet<Model>(GraphQLKeys.oneOf);
+// This will set the namespace for decorators implemented in this file
+export const namespace = NAMESPACE;
+
+/**
+ * Decorator implementation for `@oneOf`.
+ *
+ * No-op — the decorator's presence on the type's `decorators` array is the
+ * signal. No additional state storage is needed.
+ */
+export const $oneOf: DecoratorFunction = (
+  _context: DecoratorContext,
+  _target: Model,
+) => {};
 
 /**
  * Check if a model has been marked as a @oneOf input object.
@@ -10,13 +21,14 @@ const [getOneOfState, setOneOfState] = useStateSet<Model>(GraphQLKeys.oneOf);
  * is used in input context — GraphQL unions are output-only, so input
  * unions become @oneOf input objects.
  */
-export function isOneOf(program: Program, model: Model): boolean {
-  return getOneOfState(program, model);
+export function isOneOf(model: Model): boolean {
+  return model.decorators.some((d) => d.decorator === $oneOf);
 }
 
 /**
  * Mark a model as a @oneOf input object.
  */
-export function setOneOf(program: Program, model: Model): void {
-  setOneOfState(program, model);
+export function setOneOf(model: Model): void {
+  if (model.decorators.some((d) => d.decorator === $oneOf)) return;
+  model.decorators.push({ decorator: $oneOf, args: [] });
 }

--- a/packages/graphql/src/mutation-engine/mutations/model-property.ts
+++ b/packages/graphql/src/mutation-engine/mutations/model-property.ts
@@ -52,10 +52,10 @@ export class GraphQLModelPropertyMutation extends SimpleModelPropertyMutation<Si
     super.mutate();
 
     if (isInlineNullable) {
-      setNullable(this.engine.$.program, this.mutatedType);
+      setNullable(this.mutatedType);
     }
     if (isArrayWithNullableElements) {
-      setNullableElements(this.engine.$.program, this.mutatedType);
+      setNullableElements(this.mutatedType);
     }
   }
 }

--- a/packages/graphql/src/mutation-engine/mutations/operation.ts
+++ b/packages/graphql/src/mutation-engine/mutations/operation.ts
@@ -1,4 +1,4 @@
-import type { MemberType, Operation } from "@typespec/compiler";
+import { isArrayModelType, type MemberType, type Operation } from "@typespec/compiler";
 import {
   SimpleOperationMutation,
   type MutationInfo,
@@ -6,8 +6,12 @@ import {
   type SimpleMutationOptions,
   type SimpleMutations,
 } from "@typespec/mutator-framework";
-import { setNullable } from "../../lib/nullable.js";
-import { isNullableUnion, sanitizeNameForGraphQL } from "../../lib/type-utils.js";
+import { setNullable, setNullableElements } from "../../lib/nullable.js";
+import {
+  isNullableUnion,
+  sanitizeNameForGraphQL,
+  unwrapNullableUnion,
+} from "../../lib/type-utils.js";
 import { GraphQLMutationOptions, GraphQLTypeContext } from "../options.js";
 
 /** GraphQL-specific Operation mutation. */
@@ -44,7 +48,18 @@ export class GraphQLOperationMutation extends SimpleOperationMutation<SimpleMuta
 
   mutate() {
     // Snapshot return-type nullability before mutation replaces it.
-    const hasNullableReturn = isNullableUnion(this.sourceType.returnType);
+    const returnType = this.sourceType.returnType;
+    const hasNullableReturn = isNullableUnion(returnType);
+
+    // For element nullability, look through an outer `| null` wrapper to find the array.
+    // e.g. `(string | null)[] | null` → unwrap outer null → check array elements.
+    const innerReturnType =
+      returnType.kind === "Union" ? (unwrapNullableUnion(returnType) ?? returnType) : returnType;
+
+    const hasNullableElements =
+      innerReturnType.kind === "Model" &&
+      isArrayModelType(innerReturnType) &&
+      isNullableUnion(innerReturnType.indexer.value);
 
     this.mutationNode.mutate((operation) => {
       operation.name = sanitizeNameForGraphQL(operation.name);
@@ -52,7 +67,10 @@ export class GraphQLOperationMutation extends SimpleOperationMutation<SimpleMuta
     super.mutate();
 
     if (hasNullableReturn) {
-      setNullable(this.engine.$.program, this.mutatedType);
+      setNullable(this.mutatedType);
+    }
+    if (hasNullableElements) {
+      setNullableElements(this.mutatedType);
     }
   }
 }

--- a/packages/graphql/src/mutation-engine/mutations/union.ts
+++ b/packages/graphql/src/mutation-engine/mutations/union.ts
@@ -142,7 +142,7 @@ export class GraphQLUnionMutation extends UnionMutation<MutationOptions, any, Mu
     }
 
     if (hasNull) {
-      setNullable(program, this.mutatedType);
+      setNullable(this.mutatedType);
     }
 
     // GraphQL unions can only contain object types — wrap scalars in synthetic models
@@ -207,10 +207,10 @@ export class GraphQLUnionMutation extends UnionMutation<MutationOptions, any, Mu
       properties,
     });
 
-    setOneOf(program, oneOfModel);
+    setOneOf(oneOfModel);
 
     if (hasNull) {
-      setNullable(program, oneOfModel);
+      setNullable(oneOfModel);
     }
 
     this.#mutationNode.replace(oneOfModel);

--- a/packages/graphql/test/mutation-engine/graphql-mutation-engine.test.ts
+++ b/packages/graphql/test/mutation-engine/graphql-mutation-engine.test.ts
@@ -216,7 +216,7 @@ describe("GraphQL Mutation Engine - Operations", () => {
     // The return type should be unwrapped to the inner type
     expect(mutation.mutatedType.returnType.kind).toBe("Model");
     // The operation itself should be marked nullable
-    expect(isNullable(tester.program, mutation.mutatedType)).toBe(true);
+    expect(isNullable(mutation.mutatedType)).toBe(true);
   });
 
   it("does not mark operation as nullable when return type is non-null", async () => {
@@ -231,7 +231,55 @@ describe("GraphQL Mutation Engine - Operations", () => {
     const mutation = engine.mutateOperation(getUser);
 
     expect(mutation.mutatedType.returnType.kind).toBe("Model");
-    expect(isNullable(tester.program, mutation.mutatedType)).toBe(false);
+    expect(isNullable(mutation.mutatedType)).toBe(false);
+  });
+
+  it("does not mark operation as nullableElements when return type is plain array", async () => {
+    const { getTags } = await tester.compile(
+      t.code`op ${t.op("getTags")}(): string[];`,
+    );
+
+    const engine = createTestEngine(tester.program);
+    const mutation = engine.mutateOperation(getTags);
+
+    expect(isNullable(mutation.mutatedType)).toBe(false);
+    expect(hasNullableElements(mutation.mutatedType)).toBe(false);
+  });
+
+  it("marks operation as nullableElements when return type is (T | null)[]", async () => {
+    const { getTags } = await tester.compile(
+      t.code`op ${t.op("getTags")}(): (string | null)[];`,
+    );
+
+    const engine = createTestEngine(tester.program);
+    const mutation = engine.mutateOperation(getTags);
+
+    expect(isNullable(mutation.mutatedType)).toBe(false);
+    expect(hasNullableElements(mutation.mutatedType)).toBe(true);
+  });
+
+  it("marks operation as nullable only when return type is T[] | null", async () => {
+    const { getTags } = await tester.compile(
+      t.code`op ${t.op("getTags")}(): string[] | null;`,
+    );
+
+    const engine = createTestEngine(tester.program);
+    const mutation = engine.mutateOperation(getTags);
+
+    expect(isNullable(mutation.mutatedType)).toBe(true);
+    expect(hasNullableElements(mutation.mutatedType)).toBe(false);
+  });
+
+  it("marks operation as both nullable and nullableElements when return type is (T | null)[] | null", async () => {
+    const { getTags } = await tester.compile(
+      t.code`op ${t.op("getTags")}(): (string | null)[] | null;`,
+    );
+
+    const engine = createTestEngine(tester.program);
+    const mutation = engine.mutateOperation(getTags);
+
+    expect(isNullable(mutation.mutatedType)).toBe(true);
+    expect(hasNullableElements(mutation.mutatedType)).toBe(true);
   });
 });
 
@@ -533,7 +581,7 @@ describe("GraphQL Mutation Engine - Unions", () => {
     expect(mutation.wrapperModels).toHaveLength(0);
     // The replacement type is NOT marked nullable — nullability for inline T | null
     // is tracked on the model property, not the shared scalar singleton.
-    expect(isNullable(tester.program, mutation.mutatedType)).toBe(false);
+    expect(isNullable(mutation.mutatedType)).toBe(false);
   });
 
   it("replaces nullable model union with inner type", async () => {
@@ -552,7 +600,7 @@ describe("GraphQL Mutation Engine - Unions", () => {
     expect(mutation.wrapperModels).toHaveLength(0);
     // The replacement type is NOT marked nullable — nullability for inline T | null
     // is tracked on the model property, not the shared type.
-    expect(isNullable(tester.program, mutation.mutatedType)).toBe(false);
+    expect(isNullable(mutation.mutatedType)).toBe(false);
   });
 
   it("creates wrapper models for scalar variants", async () => {
@@ -647,8 +695,8 @@ describe("GraphQL Mutation Engine - Unions", () => {
 
     // Nullability is tracked on the property, not the inner type.
     // The shared scalar singleton must NOT be marked nullable (would poison all uses).
-    expect(isNullable(tester.program, nameProp!.type)).toBe(false);
-    expect(isNullable(tester.program, nameProp!)).toBe(true);
+    expect(isNullable(nameProp!.type)).toBe(false);
+    expect(isNullable(nameProp!)).toBe(true);
   });
 
   it("does not mark non-nullable array property as nullable or nullableElements", async () => {
@@ -661,8 +709,8 @@ describe("GraphQL Mutation Engine - Unions", () => {
 
     const tagsProp = mutation.mutatedType.properties.get("tags");
     expect(tagsProp).toBeDefined();
-    expect(isNullable(tester.program, tagsProp!)).toBe(false);
-    expect(hasNullableElements(tester.program, tagsProp!)).toBe(false);
+    expect(isNullable(tagsProp!)).toBe(false);
+    expect(hasNullableElements(tagsProp!)).toBe(false);
   });
 
   it("marks (T | null)[] property as nullableElements only", async () => {
@@ -675,8 +723,8 @@ describe("GraphQL Mutation Engine - Unions", () => {
 
     const tagsProp = mutation.mutatedType.properties.get("tags");
     expect(tagsProp).toBeDefined();
-    expect(isNullable(tester.program, tagsProp!)).toBe(false);
-    expect(hasNullableElements(tester.program, tagsProp!)).toBe(true);
+    expect(isNullable(tagsProp!)).toBe(false);
+    expect(hasNullableElements(tagsProp!)).toBe(true);
   });
 
   it("marks T[] | null property as nullable only", async () => {
@@ -689,8 +737,8 @@ describe("GraphQL Mutation Engine - Unions", () => {
 
     const tagsProp = mutation.mutatedType.properties.get("tags");
     expect(tagsProp).toBeDefined();
-    expect(isNullable(tester.program, tagsProp!)).toBe(true);
-    expect(hasNullableElements(tester.program, tagsProp!)).toBe(false);
+    expect(isNullable(tagsProp!)).toBe(true);
+    expect(hasNullableElements(tagsProp!)).toBe(false);
   });
 
   it("marks (T | null)[] | null property as both nullable and hasNullableElements", async () => {
@@ -705,9 +753,9 @@ describe("GraphQL Mutation Engine - Unions", () => {
     expect(tagsProp).toBeDefined();
 
     // The outer `| null` marks the property as nullable
-    expect(isNullable(tester.program, tagsProp!)).toBe(true);
+    expect(isNullable(tagsProp!)).toBe(true);
     // The inner `(T | null)` marks the property as having nullable elements
-    expect(hasNullableElements(tester.program, tagsProp!)).toBe(true);
+    expect(hasNullableElements(tagsProp!)).toBe(true);
   });
 });
 
@@ -867,7 +915,7 @@ describe("GraphQL Mutation Engine - Operation Context Propagation", () => {
     const unionMutation = engine.mutateUnion(Pet, GraphQLTypeContext.Input);
     expect(unionMutation.mutatedType.kind).toBe("Model");
     expect(unionMutation.mutatedType.name).toBe("PetInput");
-    expect(isOneOf(tester.program, unionMutation.mutatedType as Model)).toBe(true);
+    expect(isOneOf(unionMutation.mutatedType as Model)).toBe(true);
   });
 
   it("keeps union return type as union via operation mutation", async () => {
@@ -910,7 +958,7 @@ describe("GraphQL Mutation Engine - oneOf Input Objects", () => {
     // Union is replaced with a Model in the type graph
     expect(mutation.mutatedType.kind).toBe("Model");
     expect(mutation.mutatedType.name).toBe("PetInput");
-    expect(isOneOf(tester.program, mutation.mutatedType as Model)).toBe(true);
+    expect(isOneOf(mutation.mutatedType as Model)).toBe(true);
   });
 
   it("oneOf model has one field per variant, all optional", async () => {
@@ -1011,7 +1059,7 @@ describe("GraphQL Mutation Engine - oneOf Input Objects", () => {
     expect(mutatedUnion.variants.size).toBe(2);
 
     // The result should be marked as nullable
-    expect(isNullable(tester.program, mutatedUnion)).toBe(true);
+    expect(isNullable(mutatedUnion)).toBe(true);
   });
 
   it("strips null from multi-variant union in input context", async () => {
@@ -1034,8 +1082,8 @@ describe("GraphQL Mutation Engine - oneOf Input Objects", () => {
     expect(model.properties.has("dog")).toBe(true);
 
     // Should be marked as both @oneOf and nullable
-    expect(isOneOf(tester.program, model)).toBe(true);
-    expect(isNullable(tester.program, model)).toBe(true);
+    expect(isOneOf(model)).toBe(true);
+    expect(isNullable(model)).toBe(true);
   });
 
   it("non-nullable union is not marked as nullable", async () => {
@@ -1050,7 +1098,7 @@ describe("GraphQL Mutation Engine - oneOf Input Objects", () => {
     const engine = createTestEngine(tester.program);
     const mutation = engine.mutateUnion(Pet, GraphQLTypeContext.Output);
 
-    expect(isNullable(tester.program, mutation.mutatedType)).toBe(false);
+    expect(isNullable(mutation.mutatedType)).toBe(false);
   });
 
   it("exposes typeContext on union mutation", async () => {
@@ -1067,5 +1115,25 @@ describe("GraphQL Mutation Engine - oneOf Input Objects", () => {
 
     expect(inputMutation.typeContext).toBe(GraphQLTypeContext.Input);
     expect(outputMutation.typeContext).toBe(GraphQLTypeContext.Output);
+  });
+
+  it("nullable decorator survives type cloning", async () => {
+    const { Pet } = await tester.compile(
+      t.code`
+        model ${t.model("Cat")} { name: string; }
+        model ${t.model("Dog")} { breed: string; }
+        union ${t.union("Pet")} { cat: Cat; dog: Dog; null; }
+      `,
+    );
+
+    const engine = createTestEngine(tester.program);
+    const mutation = engine.mutateUnion(Pet, GraphQLTypeContext.Output);
+
+    // Multi-variant union with null: null is stripped, result marked nullable
+    expect(isNullable(mutation.mutatedType)).toBe(true);
+
+    // Simulate a downstream mutation stage cloning the type
+    const clone = tester.program.checker.cloneType(mutation.mutatedType);
+    expect(isNullable(clone)).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

- Replace `useStateSet` state maps (`nullable`, `nullableElements`, `oneOf`) with decorator-based tracking that pushes `DecoratorApplication` objects directly onto mutated types
- Remove the unused `program` parameter from all accessor functions (`isNullable`, `setNullable`, `hasNullableElements`, `setNullableElements`, `isOneOf`, `setOneOf`)
- Add `.tsp` declarations for `@nullable`, `@nullableElements`, and `@oneOf` decorators

## Motivation

State maps are keyed on object identity. When a downstream mutation engine clones a type (via `checker.cloneType()`), the clone is a new JS object and the state map entry still points to the old one — the metadata is lost. In a multi-stage pipeline where each stage's output feeds the next, this breaks nullability and oneOf tracking.

Decorators live on the type's `decorators` array, which the mutator framework shallow-copies during cloning. By pushing decorator entries instead of writing to a side-channel state map, metadata survives across pipeline stages without any special handling.

## Approach

The `set*` functions now push a `DecoratorApplication` onto `type.decorators` (with an idempotency guard). The `is*`/`has*` functions check for the decorator's presence via identity comparison (`d.decorator === $nullable`). The decorator implementations themselves are no-ops — their presence is the signal.

The `program` parameter was only needed by `useStateSet` and is now unused, so it's removed from all 6 function signatures and all call sites.

## Test plan

- [x] Existing mutation engine tests pass (61 tests on this branch)
- [x] New test: "nullable decorator survives type cloning" — verifies `isNullable` returns true on a `cloneType()` copy
