### PR TITLE
Add structural transforms: union naming, collapsing, record-to-scalar

### DIFF
--- a/packages/graphql/lib/main.tsp
+++ b/packages/graphql/lib/main.tsp
@@ -1,4 +1,6 @@
 import "./interface.tsp";
+import "./nullable.tsp";
+import "./one-of.tsp";
 import "./operation-fields.tsp";
 import "./operation-kind.tsp";
 import "./scalars.tsp";

--- a/packages/graphql/lib/nullable.tsp
+++ b/packages/graphql/lib/nullable.tsp
@@ -1,0 +1,22 @@
+import "../dist/src/lib/nullable.js";
+
+using TypeSpec.Reflection;
+
+namespace TypeSpec.GraphQL;
+
+/**
+ * Mark a field, operation, or type as nullable in the emitted GraphQL schema.
+ *
+ * Applied automatically by the mutation engine when it strips `| null` from
+ * union types. The decorator's presence on the type's `decorators` array is
+ * the signal — the implementation is a no-op.
+ */
+extern dec nullable(target: ModelProperty | Operation | Union | Model);
+
+/**
+ * Mark a field or operation as having nullable array elements in the emitted GraphQL schema.
+ *
+ * Applied automatically by the mutation engine when it detects `Array<T | null>`
+ * patterns. Causes the emitter to emit `[T]` instead of `[T!]`.
+ */
+extern dec nullableElements(target: ModelProperty | Operation);

--- a/packages/graphql/lib/one-of.tsp
+++ b/packages/graphql/lib/one-of.tsp
@@ -1,0 +1,16 @@
+import "../dist/src/lib/one-of.js";
+
+using TypeSpec.Reflection;
+
+namespace TypeSpec.GraphQL;
+
+/**
+ * Mark a model as a `@oneOf` input object in the emitted GraphQL schema.
+ *
+ * This decorator is applied automatically by the mutation engine when it converts
+ * a union type in input context to a synthetic input object (since GraphQL unions
+ * are output-only). The emitter uses this to emit the `@oneOf` directive.
+ *
+ * @see https://spec.graphql.org/September2025/#sec-OneOf-Input-Objects
+ */
+extern dec oneOf(target: Model);

--- a/packages/graphql/src/lib.ts
+++ b/packages/graphql/src/lib.ts
@@ -176,15 +176,6 @@ export const libDef = {
     interface: { description: "State for the @Interface decorator." },
     schema: { description: "State for the @schema decorator." },
     specifiedBy: { description: "State for the @specifiedBy decorator." },
-    oneOf: { description: "State for tracking @oneOf input objects created from input unions." },
-    nullable: {
-      description:
-        "State for tracking types and properties marked nullable after null-variant stripping by the mutation engine.",
-    },
-    nullableElements: {
-      description:
-        "State for tracking properties whose array element type was originally T | null before mutation.",
-    },
   },
 } as const;
 

--- a/packages/graphql/src/lib/graphql-type-name.ts
+++ b/packages/graphql/src/lib/graphql-type-name.ts
@@ -1,0 +1,30 @@
+import type { Type } from "@typespec/compiler";
+
+const SCALAR_TO_GRAPHQL: Record<string, string> = {
+  string: "String",
+  boolean: "Boolean",
+  int32: "Int",
+  float32: "Float",
+  float64: "Float",
+};
+
+/**
+ * Resolve the GraphQL type name for a mutated TypeSpec type.
+ *
+ * For std scalars, maps to GraphQL built-in names (string → String, int32 → Int).
+ * For all other types, returns type.name directly (mutation pipeline already set it).
+ */
+export function resolveGraphQLTypeName(type: Type): string {
+  switch (type.kind) {
+    case "Scalar":
+      return SCALAR_TO_GRAPHQL[type.name] ?? type.name;
+    case "Model":
+      return type.name;
+    case "Enum":
+      return type.name;
+    case "Union":
+      return type.name ?? "Union";
+    default:
+      return type.kind;
+  }
+}

--- a/packages/graphql/src/lib/nullable.ts
+++ b/packages/graphql/src/lib/nullable.ts
@@ -1,8 +1,38 @@
-import type { Program, Type } from "@typespec/compiler";
-import { useStateSet } from "@typespec/compiler/utils";
-import { GraphQLKeys } from "../lib.js";
+import type {
+  DecoratedType,
+  DecoratorContext,
+  DecoratorFunction,
+  Model,
+  ModelProperty,
+  Operation,
+  Type,
+  Union,
+} from "@typespec/compiler";
+import { NAMESPACE } from "../lib.js";
 
-const [getNullableState, setNullableState] = useStateSet<Type>(GraphQLKeys.nullable);
+// This will set the namespace for decorators implemented in this file
+export const namespace = NAMESPACE;
+
+/**
+ * Decorator implementation for `@nullable`.
+ *
+ * No-op — the decorator's presence on the type's `decorators` array is the
+ * signal. No additional state storage is needed.
+ */
+export const $nullable: DecoratorFunction = (
+  _context: DecoratorContext,
+  _target: ModelProperty | Operation | Union | Model,
+) => {};
+
+/**
+ * Decorator implementation for `@nullableElements`.
+ *
+ * No-op — presence on the decorators array is the signal.
+ */
+export const $nullableElements: DecoratorFunction = (
+  _context: DecoratorContext,
+  _target: ModelProperty | Operation,
+) => {};
 
 /**
  * Check whether a type was marked nullable after null-variant stripping.
@@ -12,18 +42,20 @@ const [getNullableState, setNullableState] = useStateSet<Type>(GraphQLKeys.nulla
  * - **Operation**: return type `T | null`
  * - **Union**: named unions like `Cat | Dog | null` (safe — new unique object)
  */
-export function isNullable(program: Program, type: Type): boolean {
-  return getNullableState(program, type);
+export function isNullable(type: Type): boolean {
+  if (!isDecoratedType(type)) return false;
+  return type.decorators.some((d) => d.decorator === $nullable);
 }
 
-/** Mark a type, property, or operation as nullable. */
-export function setNullable(program: Program, type: Type): void {
-  setNullableState(program, type);
+/**
+ * Mark a type, property, or operation as nullable.
+ * Called by the mutation engine when null variants are stripped.
+ */
+export function setNullable(type: Type): void {
+  if (!isDecoratedType(type)) return;
+  if (type.decorators.some((d) => d.decorator === $nullable)) return;
+  type.decorators.push({ decorator: $nullable, args: [] });
 }
-
-const [getNullableElementsState, setNullableElementsState] = useStateSet<Type>(
-  GraphQLKeys.nullableElements,
-);
 
 /**
  * Check whether a property's array elements were originally `T | null`.
@@ -31,11 +63,18 @@ const [getNullableElementsState, setNullableElementsState] = useStateSet<Type>(
  * For `(string | null)[]`, marks the ModelProperty so components emit
  * `[String]` instead of `[String!]`.
  */
-export function hasNullableElements(program: Program, type: Type): boolean {
-  return getNullableElementsState(program, type);
+export function hasNullableElements(type: Type): boolean {
+  if (!isDecoratedType(type)) return false;
+  return type.decorators.some((d) => d.decorator === $nullableElements);
 }
 
 /** Mark a property as having nullable array elements. */
-export function setNullableElements(program: Program, type: Type): void {
-  setNullableElementsState(program, type);
+export function setNullableElements(type: Type): void {
+  if (!isDecoratedType(type)) return;
+  if (type.decorators.some((d) => d.decorator === $nullableElements)) return;
+  type.decorators.push({ decorator: $nullableElements, args: [] });
+}
+
+function isDecoratedType(type: Type): type is Type & DecoratedType {
+  return "decorators" in type;
 }

--- a/packages/graphql/src/lib/one-of.ts
+++ b/packages/graphql/src/lib/one-of.ts
@@ -1,8 +1,19 @@
-import type { Model, Program } from "@typespec/compiler";
-import { useStateSet } from "@typespec/compiler/utils";
-import { GraphQLKeys } from "../lib.js";
+import type { DecoratorContext, DecoratorFunction, Model } from "@typespec/compiler";
+import { NAMESPACE } from "../lib.js";
 
-const [getOneOfState, setOneOfState] = useStateSet<Model>(GraphQLKeys.oneOf);
+// This will set the namespace for decorators implemented in this file
+export const namespace = NAMESPACE;
+
+/**
+ * Decorator implementation for `@oneOf`.
+ *
+ * No-op — the decorator's presence on the type's `decorators` array is the
+ * signal. No additional state storage is needed.
+ */
+export const $oneOf: DecoratorFunction = (
+  _context: DecoratorContext,
+  _target: Model,
+) => {};
 
 /**
  * Check if a model has been marked as a @oneOf input object.
@@ -10,13 +21,14 @@ const [getOneOfState, setOneOfState] = useStateSet<Model>(GraphQLKeys.oneOf);
  * is used in input context — GraphQL unions are output-only, so input
  * unions become @oneOf input objects.
  */
-export function isOneOf(program: Program, model: Model): boolean {
-  return getOneOfState(program, model);
+export function isOneOf(model: Model): boolean {
+  return model.decorators.some((d) => d.decorator === $oneOf);
 }
 
 /**
  * Mark a model as a @oneOf input object.
  */
-export function setOneOf(program: Program, model: Model): void {
-  setOneOfState(program, model);
+export function setOneOf(model: Model): void {
+  if (model.decorators.some((d) => d.decorator === $oneOf)) return;
+  model.decorators.push({ decorator: $oneOf, args: [] });
 }

--- a/packages/graphql/src/mutation-engine/mutations/model-property.ts
+++ b/packages/graphql/src/mutation-engine/mutations/model-property.ts
@@ -51,10 +51,10 @@ export class GraphQLModelPropertyMutation extends SimpleModelPropertyMutation<Si
     super.mutate();
 
     if (isInlineNullable) {
-      setNullable(this.engine.$.program, this.mutatedType);
+      setNullable(this.mutatedType);
     }
     if (isArrayWithNullableElements) {
-      setNullableElements(this.engine.$.program, this.mutatedType);
+      setNullableElements(this.mutatedType);
     }
   }
 }

--- a/packages/graphql/src/mutation-engine/mutations/model.ts
+++ b/packages/graphql/src/mutation-engine/mutations/model.ts
@@ -1,4 +1,10 @@
-import { isTemplateInstance, type MemberType, type Model } from "@typespec/compiler";
+import {
+  isTemplateInstance,
+  walkPropertiesInherited,
+  type MemberType,
+  type Model,
+  type Scalar,
+} from "@typespec/compiler";
 import {
   SimpleModelMutation,
   type MutationInfo,
@@ -9,6 +15,7 @@ import {
 import { isInterface } from "../../lib/interface.js";
 import { applyTypeNamePipeline } from "../../lib/naming.js";
 import { composeTemplateName } from "../../lib/template-composition.js";
+import { isRecordType } from "../../lib/type-utils.js";
 import { GraphQLMutationOptions, GraphQLTypeContext } from "../options.js";
 
 /**
@@ -33,9 +40,37 @@ export class GraphQLModelMutation extends SimpleModelMutation<SimpleMutationOpti
     return this.options instanceof GraphQLMutationOptions ? this.options.typeContext : undefined;
   }
 
+  get resolvedType(): Model | Scalar {
+    if (this.mutationNode.isReplaced && this.mutationNode.replacementNode) {
+      return this.mutationNode.replacementNode.mutatedType as unknown as Scalar;
+    }
+    return this.mutationNode.mutatedType;
+  }
+
   mutate() {
-    const program = this.engine.$.program;
+    const tk = this.engine.$;
+    const program = tk.program;
     const isInputContext = this.typeContext === GraphQLTypeContext.Input;
+
+    if (isRecordType(this.sourceType) && walkPropertiesInherited(this.sourceType).next().done) {
+      const rawName = isTemplateInstance(this.sourceType)
+        ? composeTemplateName(this.sourceType)
+        : this.sourceType.name;
+      const scalarName = applyTypeNamePipeline(rawName, {
+        isInput: isInputContext,
+        isInterface: false,
+      });
+      const scalar = program.checker.createType({
+        kind: "Scalar",
+        name: scalarName,
+        decorators: [],
+        derivedScalars: [],
+        constructors: new Map(),
+      });
+      this.mutationNode.replace(scalar);
+      return;
+    }
+
     const isInterfaceModel = isInterface(program, this.sourceType);
     const rawName = isTemplateInstance(this.sourceType)
       ? composeTemplateName(this.sourceType)

--- a/packages/graphql/src/mutation-engine/mutations/model.ts
+++ b/packages/graphql/src/mutation-engine/mutations/model.ts
@@ -3,7 +3,6 @@ import {
   walkPropertiesInherited,
   type MemberType,
   type Model,
-  type Scalar,
 } from "@typespec/compiler";
 import {
   SimpleModelMutation,
@@ -38,13 +37,6 @@ export class GraphQLModelMutation extends SimpleModelMutation<SimpleMutationOpti
    */
   get typeContext(): GraphQLTypeContext | undefined {
     return this.options instanceof GraphQLMutationOptions ? this.options.typeContext : undefined;
-  }
-
-  get resolvedType(): Model | Scalar {
-    if (this.mutationNode.isReplaced && this.mutationNode.replacementNode) {
-      return this.mutationNode.replacementNode.mutatedType as unknown as Scalar;
-    }
-    return this.mutationNode.mutatedType;
   }
 
   mutate() {

--- a/packages/graphql/src/mutation-engine/mutations/operation.ts
+++ b/packages/graphql/src/mutation-engine/mutations/operation.ts
@@ -1,4 +1,4 @@
-import type { MemberType, Operation } from "@typespec/compiler";
+import { isArrayModelType, type MemberType, type Operation } from "@typespec/compiler";
 import {
   SimpleOperationMutation,
   type MutationInfo,
@@ -7,8 +7,8 @@ import {
   type SimpleMutations,
 } from "@typespec/mutator-framework";
 import { applyFieldNamePipeline } from "../../lib/naming.js";
-import { setNullable } from "../../lib/nullable.js";
-import { isNullableUnion } from "../../lib/type-utils.js";
+import { setNullable, setNullableElements } from "../../lib/nullable.js";
+import { isNullableUnion, unwrapNullableUnion } from "../../lib/type-utils.js";
 import { GraphQLMutationOptions, GraphQLTypeContext } from "../options.js";
 
 /** GraphQL-specific Operation mutation. */
@@ -45,7 +45,18 @@ export class GraphQLOperationMutation extends SimpleOperationMutation<SimpleMuta
 
   mutate() {
     // Snapshot return-type nullability before mutation replaces it.
-    const hasNullableReturn = isNullableUnion(this.sourceType.returnType);
+    const returnType = this.sourceType.returnType;
+    const hasNullableReturn = isNullableUnion(returnType);
+
+    // For element nullability, look through an outer `| null` wrapper to find the array.
+    // e.g. `(string | null)[] | null` → unwrap outer null → check array elements.
+    const innerReturnType =
+      returnType.kind === "Union" ? (unwrapNullableUnion(returnType) ?? returnType) : returnType;
+
+    const hasNullableElements =
+      innerReturnType.kind === "Model" &&
+      isArrayModelType(innerReturnType) &&
+      isNullableUnion(innerReturnType.indexer.value);
 
     this.mutationNode.mutate((operation) => {
       operation.name = applyFieldNamePipeline(operation.name);
@@ -53,7 +64,10 @@ export class GraphQLOperationMutation extends SimpleOperationMutation<SimpleMuta
     super.mutate();
 
     if (hasNullableReturn) {
-      setNullable(this.engine.$.program, this.mutatedType);
+      setNullable(this.mutatedType);
+    }
+    if (hasNullableElements) {
+      setNullableElements(this.mutatedType);
     }
   }
 }

--- a/packages/graphql/src/mutation-engine/mutations/union.ts
+++ b/packages/graphql/src/mutation-engine/mutations/union.ts
@@ -146,7 +146,7 @@ export class GraphQLUnionMutation extends UnionMutation<MutationOptions, any, Mu
       const innerMutation = this.engine.mutate(flattenedVariants[0].type, this.options);
       this.#mutationNode.replace(resolveType(innerMutation));
       if (hasNull) {
-        setNullable(program, this.mutatedType);
+        setNullable(this.mutatedType);
       }
       return;
     }
@@ -180,7 +180,7 @@ export class GraphQLUnionMutation extends UnionMutation<MutationOptions, any, Mu
     }
 
     if (hasNull) {
-      setNullable(program, this.mutatedType);
+      setNullable(this.mutatedType);
     }
 
     // GraphQL unions can only contain object types — wrap scalars in synthetic models
@@ -244,10 +244,10 @@ export class GraphQLUnionMutation extends UnionMutation<MutationOptions, any, Mu
       properties,
     });
 
-    setOneOf(program, oneOfModel);
+    setOneOf(oneOfModel);
 
     if (hasNull) {
-      setNullable(program, oneOfModel);
+      setNullable(oneOfModel);
     }
 
     this.#mutationNode.replace(oneOfModel);

--- a/packages/graphql/src/mutation-engine/mutations/union.ts
+++ b/packages/graphql/src/mutation-engine/mutations/union.ts
@@ -32,6 +32,22 @@ function variantNameToString(name: string | symbol): string {
 }
 
 /**
+ * Resolve the actual mutated type from a mutation result.
+ * Handles the case where mutationNode.replace() was called — the inherited
+ * mutatedType getter doesn't reflect replacements, so we check the node directly.
+ */
+function resolveType(mutation: {
+  mutationNode: { isReplaced: boolean; replacementNode: any };
+  mutatedType: Type;
+}): Type {
+  const node = mutation.mutationNode;
+  if (node.isReplaced && node.replacementNode) {
+    return node.replacementNode.mutatedType;
+  }
+  return mutation.mutatedType;
+}
+
+/**
  * GraphQL-specific Union mutation.
  *
  * Output context: flattens nested unions, deduplicates, wraps scalar variants.
@@ -95,7 +111,8 @@ export class GraphQLUnionMutation extends UnionMutation<MutationOptions, any, Mu
     // Nullability is tracked by the container (ModelProperty or Operation).
     const innerType = unwrapNullableUnion(this.sourceType);
     if (innerType) {
-      this.#mutationNode.replace(innerType);
+      const innerMutation = this.engine.mutate(innerType, this.options);
+      this.#mutationNode.replace(resolveType(innerMutation));
       return;
     }
 
@@ -113,6 +130,9 @@ export class GraphQLUnionMutation extends UnionMutation<MutationOptions, any, Mu
     const tk = this.engine.$;
     const program = tk.program;
 
+    const rawName = getUnionName(this.sourceType, program);
+    const unionName = applyTypeNamePipeline(rawName, { isInput: false, isInterface: false });
+
     const { variants: sourceVariants, isNullable: hasNull } = stripNullVariants(this.sourceType);
 
     const flattenedVariants = this.deduplicateVariants(this.flattenVariants(sourceVariants));
@@ -122,10 +142,25 @@ export class GraphQLUnionMutation extends UnionMutation<MutationOptions, any, Mu
       return;
     }
 
+    if (flattenedVariants.length === 1) {
+      const innerMutation = this.engine.mutate(flattenedVariants[0].type, this.options);
+      this.#mutationNode.replace(resolveType(innerMutation));
+      if (hasNull) {
+        setNullable(program, this.mutatedType);
+      }
+      return;
+    }
+
     const needsFlattening = flattenedVariants.length !== sourceVariants.length;
 
+    // Mutate each variant's type so it goes through the full pipeline
+    const mutatedVariants = flattenedVariants.map((variant) => ({
+      name: variant.name,
+      type: resolveType(this.engine.mutate(variant.type, this.options)),
+    }));
+
     if (needsFlattening || hasNull) {
-      const variantArray = flattenedVariants.map((variant) => {
+      const variantArray = mutatedVariants.map((variant) => {
         return tk.unionVariant.create({
           name: variantNameToString(variant.name),
           type: variant.type,
@@ -133,13 +168,15 @@ export class GraphQLUnionMutation extends UnionMutation<MutationOptions, any, Mu
       });
 
       const flattenedUnion = tk.union.create({
-        name: this.sourceType.name,
+        name: unionName,
         variants: variantArray,
       });
 
       this.#flattenedUnion = flattenedUnion;
     } else {
-      this.#mutationNode.mutate();
+      this.#mutationNode.mutate((union) => {
+        union.name = unionName;
+      });
     }
 
     if (hasNull) {
@@ -147,12 +184,11 @@ export class GraphQLUnionMutation extends UnionMutation<MutationOptions, any, Mu
     }
 
     // GraphQL unions can only contain object types — wrap scalars in synthetic models
-    for (const variant of flattenedVariants) {
+    for (const variant of mutatedVariants) {
       const isScalar = variant.type.kind === "Scalar" || variant.type.kind === "Intrinsic";
 
       if (isScalar) {
         const variantName = variantNameToString(variant.name);
-        const unionName = this.sourceType.name ?? "";
         const wrapperName =
           applyBaseNamePipeline(unionName) + applyBaseNamePipeline(variantName) + "UnionVariant";
 
@@ -192,9 +228,10 @@ export class GraphQLUnionMutation extends UnionMutation<MutationOptions, any, Mu
     const properties: Record<string, ReturnType<typeof tk.modelProperty.create>> = {};
     for (const variant of flattenedVariants) {
       const fieldName = applyFieldNamePipeline(variantNameToString(variant.name));
+      const mutatedType = resolveType(this.engine.mutate(variant.type, this.options));
       properties[fieldName] = tk.modelProperty.create({
         name: fieldName,
-        type: variant.type,
+        type: mutatedType,
         optional: true, // oneOf: exactly one must be provided
       });
     }

--- a/packages/graphql/src/mutation-engine/print-type.ts
+++ b/packages/graphql/src/mutation-engine/print-type.ts
@@ -1,6 +1,5 @@
 import { isArrayModelType, type ModelProperty, type Program, type Type } from "@typespec/compiler";
 import { hasNullableElements, isNullable } from "../lib/nullable.js";
-import { unwrapNullableUnion } from "../lib/type-utils.js";
 
 const SCALAR_TO_GRAPHQL: Record<string, string> = {
   string: "String",
@@ -28,12 +27,7 @@ export function printMutatedType(program: Program, prop: ModelProperty): string 
   const type = prop.type;
 
   if (type.kind === "Model" && isArrayModelType(type)) {
-    // Workaround: the mutation engine marks hasNullableElements on the property but
-    // doesn't replace the inner T | null union with T (to avoid poisoning shared type
-    // singletons). PR B will fix this by cloning array element types during mutation.
-    const rawElement = type.indexer.value;
-    const elementType =
-      rawElement.kind === "Union" ? (unwrapNullableUnion(rawElement) ?? rawElement) : rawElement;
+    const elementType = type.indexer.value;
     const elementName = resolveTypeName(elementType);
     const inner = elementsNullable ? elementName : `${elementName}!`;
     const list = `[${inner}]`;

--- a/packages/graphql/src/mutation-engine/print-type.ts
+++ b/packages/graphql/src/mutation-engine/print-type.ts
@@ -1,4 +1,4 @@
-import { isArrayModelType, type ModelProperty, type Program } from "@typespec/compiler";
+import { isArrayModelType, type ModelProperty } from "@typespec/compiler";
 import { resolveGraphQLTypeName } from "../lib/graphql-type-name.js";
 import { hasNullableElements, isNullable } from "../lib/nullable.js";
 
@@ -13,9 +13,9 @@ import { hasNullableElements, isNullable } from "../lib/nullable.js";
  *   required string[] property   → "[String!]!"
  *   optional (string | null)[]   → "[String]"
  */
-export function printMutatedType(program: Program, prop: ModelProperty): string {
-  const propNullable = isNullable(program, prop) || prop.optional;
-  const elementsNullable = hasNullableElements(program, prop);
+export function printMutatedType(prop: ModelProperty): string {
+  const propNullable = isNullable(prop) || prop.optional;
+  const elementsNullable = hasNullableElements(prop);
 
   const type = prop.type;
 

--- a/packages/graphql/src/mutation-engine/print-type.ts
+++ b/packages/graphql/src/mutation-engine/print-type.ts
@@ -1,13 +1,6 @@
-import { isArrayModelType, type ModelProperty, type Program, type Type } from "@typespec/compiler";
+import { isArrayModelType, type ModelProperty, type Program } from "@typespec/compiler";
+import { resolveGraphQLTypeName } from "../lib/graphql-type-name.js";
 import { hasNullableElements, isNullable } from "../lib/nullable.js";
-
-const SCALAR_TO_GRAPHQL: Record<string, string> = {
-  string: "String",
-  boolean: "Boolean",
-  int32: "Int",
-  float32: "Float",
-  float64: "Float",
-};
 
 /**
  * Print a mutated type as its GraphQL type string representation.
@@ -28,27 +21,12 @@ export function printMutatedType(program: Program, prop: ModelProperty): string 
 
   if (type.kind === "Model" && isArrayModelType(type)) {
     const elementType = type.indexer.value;
-    const elementName = resolveTypeName(elementType);
+    const elementName = resolveGraphQLTypeName(elementType);
     const inner = elementsNullable ? elementName : `${elementName}!`;
     const list = `[${inner}]`;
     return propNullable ? list : `${list}!`;
   }
 
-  const name = resolveTypeName(type);
+  const name = resolveGraphQLTypeName(type);
   return propNullable ? name : `${name}!`;
-}
-
-function resolveTypeName(type: Type): string {
-  switch (type.kind) {
-    case "Scalar":
-      return SCALAR_TO_GRAPHQL[type.name] ?? type.name;
-    case "Model":
-      return type.name;
-    case "Enum":
-      return type.name;
-    case "Union":
-      return type.name ?? "Union";
-    default:
-      return type.kind;
-  }
 }

--- a/packages/graphql/test/mutation-engine/context.test.ts
+++ b/packages/graphql/test/mutation-engine/context.test.ts
@@ -161,7 +161,7 @@ describe("GraphQL Mutation Engine - Operation Context Propagation", () => {
     const unionMutation = engine.mutateUnion(Pet, GraphQLTypeContext.Input);
     expect(unionMutation.mutatedType.kind).toBe("Model");
     expect(unionMutation.mutatedType.name).toBe("PetInput");
-    expect(isOneOf(tester.program, unionMutation.mutatedType as Model)).toBe(true);
+    expect(isOneOf(unionMutation.mutatedType as Model)).toBe(true);
   });
 
   it("keeps union return type as union via operation mutation", async () => {

--- a/packages/graphql/test/mutation-engine/models.test.ts
+++ b/packages/graphql/test/mutation-engine/models.test.ts
@@ -48,6 +48,77 @@ describe("GraphQL Mutation Engine - Models", () => {
   });
 });
 
+describe("GraphQL Mutation Engine - Record-to-Scalar", () => {
+  let tester: Awaited<ReturnType<typeof Tester.createInstance>>;
+  beforeEach(async () => {
+    tester = await Tester.createInstance();
+  });
+
+  it("replaces named Record model with a scalar", async () => {
+    const { Metadata } = await tester.compile(
+      t.code`model ${t.model("Metadata")} is Record<string>;`,
+    );
+
+    const engine = createTestEngine(tester.program);
+    const mutation = engine.mutateModel(Metadata, GraphQLTypeContext.Output);
+
+    expect(mutation.resolvedType.kind).toBe("Scalar");
+    expect(mutation.resolvedType.name).toBe("Metadata");
+  });
+
+  it("replaces Record model with scalar even through T | null unwrap", async () => {
+    const { Foo } = await tester.compile(
+      t.code`
+        model ${t.model("Metadata")} is Record<string>;
+        model ${t.model("Foo")} { data: Metadata | null; }
+      `,
+    );
+
+    const engine = createTestEngine(tester.program);
+    const mutation = engine.mutateModel(Foo, GraphQLTypeContext.Output);
+
+    const dataProp = mutation.mutatedType.properties.get("data")!;
+    // After T|null unwrap + Record mutation, should be a Scalar
+    expect(dataProp.type.kind).toBe("Scalar");
+    expect((dataProp.type as { name: string }).name).toBe("Metadata");
+  });
+
+  it("does not replace Record model that has named properties", async () => {
+    const { Config } = await tester.compile(
+      t.code`model ${t.model("Config")} { debug: boolean; ...Record<string>; }`,
+    );
+
+    const engine = createTestEngine(tester.program);
+    const mutation = engine.mutateModel(Config, GraphQLTypeContext.Output);
+
+    expect(mutation.resolvedType.kind).toBe("Model");
+    expect(mutation.resolvedType.name).toBe("Config");
+  });
+});
+
+describe("GraphQL Mutation Engine - Inner Nullable Array Fix", () => {
+  let tester: Awaited<ReturnType<typeof Tester.createInstance>>;
+  beforeEach(async () => {
+    tester = await Tester.createInstance();
+  });
+
+  it("unwraps inner nullable union in array element for (T | null)[] | null", async () => {
+    const { Foo } = await tester.compile(
+      t.code`model ${t.model("Foo")} { tags: (string | null)[] | null; }`,
+    );
+
+    const engine = createTestEngine(tester.program);
+    const mutation = engine.mutateModel(Foo, GraphQLTypeContext.Output);
+
+    const tagsProp = mutation.mutatedType.properties.get("tags")!;
+    const arrayType = tagsProp.type;
+    expect(arrayType.kind).toBe("Model");
+    // The array's indexer value should be the unwrapped scalar, not a T | null union
+    const elementType = (arrayType as any).indexer.value;
+    expect(elementType.kind).toBe("Scalar");
+  });
+});
+
 describe("GraphQL Mutation Engine - Model Properties", () => {
   let tester: Awaited<ReturnType<typeof Tester.createInstance>>;
   beforeEach(async () => {

--- a/packages/graphql/test/mutation-engine/models.test.ts
+++ b/packages/graphql/test/mutation-engine/models.test.ts
@@ -1,3 +1,4 @@
+import { isArrayModelType, type Model } from "@typespec/compiler";
 import { t } from "@typespec/compiler/testing";
 import { beforeEach, describe, expect, it } from "vitest";
 import {
@@ -62,8 +63,10 @@ describe("GraphQL Mutation Engine - Record-to-Scalar", () => {
     const engine = createTestEngine(tester.program);
     const mutation = engine.mutateModel(Metadata, GraphQLTypeContext.Output);
 
-    expect(mutation.resolvedType.kind).toBe("Scalar");
-    expect(mutation.resolvedType.name).toBe("Metadata");
+    expect(mutation.mutationNode.isReplaced).toBe(true);
+    const resolved = mutation.mutationNode.replacementNode!.mutatedType;
+    expect(resolved).toHaveProperty("kind", "Scalar");
+    expect(resolved).toHaveProperty("name", "Metadata");
   });
 
   it("replaces Record model with scalar even through T | null unwrap", async () => {
@@ -79,8 +82,8 @@ describe("GraphQL Mutation Engine - Record-to-Scalar", () => {
 
     const dataProp = mutation.mutatedType.properties.get("data")!;
     // After T|null unwrap + Record mutation, should be a Scalar
-    expect(dataProp.type.kind).toBe("Scalar");
-    expect((dataProp.type as { name: string }).name).toBe("Metadata");
+    expect(dataProp.type).toHaveProperty("kind", "Scalar");
+    expect(dataProp.type).toHaveProperty("name", "Metadata");
   });
 
   it("does not replace Record model that has named properties", async () => {
@@ -91,8 +94,9 @@ describe("GraphQL Mutation Engine - Record-to-Scalar", () => {
     const engine = createTestEngine(tester.program);
     const mutation = engine.mutateModel(Config, GraphQLTypeContext.Output);
 
-    expect(mutation.resolvedType.kind).toBe("Model");
-    expect(mutation.resolvedType.name).toBe("Config");
+    expect(mutation.mutationNode.isReplaced).toBe(false);
+    expect(mutation.mutatedType.kind).toBe("Model");
+    expect(mutation.mutatedType.name).toBe("Config");
   });
 });
 
@@ -111,11 +115,11 @@ describe("GraphQL Mutation Engine - Inner Nullable Array Fix", () => {
     const mutation = engine.mutateModel(Foo, GraphQLTypeContext.Output);
 
     const tagsProp = mutation.mutatedType.properties.get("tags")!;
-    const arrayType = tagsProp.type;
-    expect(arrayType.kind).toBe("Model");
+    expect(tagsProp.type.kind).toBe("Model");
     // The array's indexer value should be the unwrapped scalar, not a T | null union
-    const elementType = (arrayType as any).indexer.value;
-    expect(elementType.kind).toBe("Scalar");
+    const arrayModel = tagsProp.type as Model;
+    expect(isArrayModelType(arrayModel)).toBe(true);
+    expect(arrayModel.indexer!.value.kind).toBe("Scalar");
   });
 });
 

--- a/packages/graphql/test/mutation-engine/operations.test.ts
+++ b/packages/graphql/test/mutation-engine/operations.test.ts
@@ -57,7 +57,7 @@ describe("GraphQL Mutation Engine - Operations", () => {
     // The return type should be unwrapped to the inner type
     expect(mutation.mutatedType.returnType.kind).toBe("Model");
     // The operation itself should be marked nullable
-    expect(isNullable(tester.program, mutation.mutatedType)).toBe(true);
+    expect(isNullable(mutation.mutatedType)).toBe(true);
   });
 
   it("does not mark operation as nullable when return type is non-null", async () => {
@@ -72,6 +72,6 @@ describe("GraphQL Mutation Engine - Operations", () => {
     const mutation = engine.mutateOperation(getUser);
 
     expect(mutation.mutatedType.returnType.kind).toBe("Model");
-    expect(isNullable(tester.program, mutation.mutatedType)).toBe(false);
+    expect(isNullable(mutation.mutatedType)).toBe(false);
   });
 });

--- a/packages/graphql/test/mutation-engine/print-type.test.ts
+++ b/packages/graphql/test/mutation-engine/print-type.test.ts
@@ -19,7 +19,7 @@ describe("printMutatedType", () => {
     const engine = createGraphQLMutationEngine(tester.program);
     const mutated = engine.mutateModel(Foo, GraphQLTypeContext.Output);
     const prop = mutated.mutatedType.properties.get("name")!;
-    expect(printMutatedType(tester.program, prop)).toBe("String!");
+    expect(printMutatedType(prop)).toBe("String!");
   });
 
   it("optional string → String", async () => {
@@ -27,7 +27,7 @@ describe("printMutatedType", () => {
     const engine = createGraphQLMutationEngine(tester.program);
     const mutated = engine.mutateModel(Foo, GraphQLTypeContext.Output);
     const prop = mutated.mutatedType.properties.get("name")!;
-    expect(printMutatedType(tester.program, prop)).toBe("String");
+    expect(printMutatedType(prop)).toBe("String");
   });
 
   it("string | null → String", async () => {
@@ -35,7 +35,7 @@ describe("printMutatedType", () => {
     const engine = createGraphQLMutationEngine(tester.program);
     const mutated = engine.mutateModel(Foo, GraphQLTypeContext.Output);
     const prop = mutated.mutatedType.properties.get("name")!;
-    expect(printMutatedType(tester.program, prop)).toBe("String");
+    expect(printMutatedType(prop)).toBe("String");
   });
 
   it("required string[] → [String!]!", async () => {
@@ -43,7 +43,7 @@ describe("printMutatedType", () => {
     const engine = createGraphQLMutationEngine(tester.program);
     const mutated = engine.mutateModel(Foo, GraphQLTypeContext.Output);
     const prop = mutated.mutatedType.properties.get("tags")!;
-    expect(printMutatedType(tester.program, prop)).toBe("[String!]!");
+    expect(printMutatedType(prop)).toBe("[String!]!");
   });
 
   it("optional string[] → [String!]", async () => {
@@ -51,7 +51,7 @@ describe("printMutatedType", () => {
     const engine = createGraphQLMutationEngine(tester.program);
     const mutated = engine.mutateModel(Foo, GraphQLTypeContext.Output);
     const prop = mutated.mutatedType.properties.get("tags")!;
-    expect(printMutatedType(tester.program, prop)).toBe("[String!]");
+    expect(printMutatedType(prop)).toBe("[String!]");
   });
 
   it("(string | null)[] → [String]!", async () => {
@@ -61,7 +61,7 @@ describe("printMutatedType", () => {
     const engine = createGraphQLMutationEngine(tester.program);
     const mutated = engine.mutateModel(Foo, GraphQLTypeContext.Output);
     const prop = mutated.mutatedType.properties.get("tags")!;
-    expect(printMutatedType(tester.program, prop)).toBe("[String]!");
+    expect(printMutatedType(prop)).toBe("[String]!");
   });
 
   it("string[] | null → [String!]", async () => {
@@ -71,7 +71,7 @@ describe("printMutatedType", () => {
     const engine = createGraphQLMutationEngine(tester.program);
     const mutated = engine.mutateModel(Foo, GraphQLTypeContext.Output);
     const prop = mutated.mutatedType.properties.get("tags")!;
-    expect(printMutatedType(tester.program, prop)).toBe("[String!]");
+    expect(printMutatedType(prop)).toBe("[String!]");
   });
 
   it("(string | null)[] | null → [String]", async () => {
@@ -81,7 +81,7 @@ describe("printMutatedType", () => {
     const engine = createGraphQLMutationEngine(tester.program);
     const mutated = engine.mutateModel(Foo, GraphQLTypeContext.Output);
     const prop = mutated.mutatedType.properties.get("tags")!;
-    expect(printMutatedType(tester.program, prop)).toBe("[String]");
+    expect(printMutatedType(prop)).toBe("[String]");
   });
 
   it("required model type → ModelName!", async () => {
@@ -94,7 +94,7 @@ describe("printMutatedType", () => {
     const engine = createGraphQLMutationEngine(tester.program);
     const mutated = engine.mutateModel(Foo, GraphQLTypeContext.Output);
     const prop = mutated.mutatedType.properties.get("bar")!;
-    expect(printMutatedType(tester.program, prop)).toBe("Bar!");
+    expect(printMutatedType(prop)).toBe("Bar!");
   });
 
   it("required int32 → Int!", async () => {
@@ -102,6 +102,6 @@ describe("printMutatedType", () => {
     const engine = createGraphQLMutationEngine(tester.program);
     const mutated = engine.mutateModel(Foo, GraphQLTypeContext.Output);
     const prop = mutated.mutatedType.properties.get("count")!;
-    expect(printMutatedType(tester.program, prop)).toBe("Int!");
+    expect(printMutatedType(prop)).toBe("Int!");
   });
 });

--- a/packages/graphql/test/mutation-engine/unions.test.ts
+++ b/packages/graphql/test/mutation-engine/unions.test.ts
@@ -33,7 +33,7 @@ describe("GraphQL Mutation Engine - Unions", () => {
     expect(mutation.wrapperModels).toHaveLength(0);
     // The replacement type is NOT marked nullable — nullability for inline T | null
     // is tracked on the model property, not the shared scalar singleton.
-    expect(isNullable(tester.program, mutation.mutatedType)).toBe(false);
+    expect(isNullable(mutation.mutatedType)).toBe(false);
   });
 
   it("replaces nullable model union with inner type", async () => {
@@ -52,7 +52,7 @@ describe("GraphQL Mutation Engine - Unions", () => {
     expect(mutation.wrapperModels).toHaveLength(0);
     // The replacement type is NOT marked nullable — nullability for inline T | null
     // is tracked on the model property, not the shared type.
-    expect(isNullable(tester.program, mutation.mutatedType)).toBe(false);
+    expect(isNullable(mutation.mutatedType)).toBe(false);
   });
 
   it("creates wrapper models for scalar variants", async () => {
@@ -234,7 +234,7 @@ describe("GraphQL Mutation Engine - Unions", () => {
     // Strip null → Cat, Cat → dedup → 1 variant → collapse
     expect(mutation.mutatedType.kind).toBe("Model");
     expect(mutation.mutatedType.name).toBe("Cat");
-    expect(isNullable(tester.program, mutation.mutatedType)).toBe(true);
+    expect(isNullable(mutation.mutatedType)).toBe(true);
   });
 
   it("handles circular type references without infinite recursion", async () => {
@@ -276,7 +276,7 @@ describe("GraphQL Mutation Engine - Unions", () => {
 
     const nameProp = mutation.mutatedType.properties.get("name")!;
     expect(nameProp.type.kind).toBe("Scalar");
-    expect(printMutatedType(tester.program, nameProp)).toBe("String");
+    expect(printMutatedType(nameProp)).toBe("String");
   });
 
   it("string[] property → [String!]!", async () => {
@@ -286,7 +286,7 @@ describe("GraphQL Mutation Engine - Unions", () => {
     const mutation = engine.mutateModel(Foo, GraphQLTypeContext.Output);
 
     const tagsProp = mutation.mutatedType.properties.get("tags")!;
-    expect(printMutatedType(tester.program, tagsProp)).toBe("[String!]!");
+    expect(printMutatedType(tagsProp)).toBe("[String!]!");
   });
 
   it("(string | null)[] property → [String]!", async () => {
@@ -298,7 +298,7 @@ describe("GraphQL Mutation Engine - Unions", () => {
     const mutation = engine.mutateModel(Foo, GraphQLTypeContext.Output);
 
     const tagsProp = mutation.mutatedType.properties.get("tags")!;
-    expect(printMutatedType(tester.program, tagsProp)).toBe("[String]!");
+    expect(printMutatedType(tagsProp)).toBe("[String]!");
   });
 
   it("string[] | null property → [String!]", async () => {
@@ -310,7 +310,7 @@ describe("GraphQL Mutation Engine - Unions", () => {
     const mutation = engine.mutateModel(Foo, GraphQLTypeContext.Output);
 
     const tagsProp = mutation.mutatedType.properties.get("tags")!;
-    expect(printMutatedType(tester.program, tagsProp)).toBe("[String!]");
+    expect(printMutatedType(tagsProp)).toBe("[String!]");
   });
 
   it("(string | null)[] | null property → [String]", async () => {
@@ -322,7 +322,7 @@ describe("GraphQL Mutation Engine - Unions", () => {
     const mutation = engine.mutateModel(Foo, GraphQLTypeContext.Output);
 
     const tagsProp = mutation.mutatedType.properties.get("tags")!;
-    expect(printMutatedType(tester.program, tagsProp)).toBe("[String]");
+    expect(printMutatedType(tagsProp)).toBe("[String]");
   });
 });
 
@@ -347,7 +347,7 @@ describe("GraphQL Mutation Engine - oneOf Input Objects", () => {
     // Union is replaced with a Model in the type graph
     expect(mutation.mutatedType.kind).toBe("Model");
     expect(mutation.mutatedType.name).toBe("PetInput");
-    expect(isOneOf(tester.program, mutation.mutatedType as Model)).toBe(true);
+    expect(isOneOf(mutation.mutatedType as Model)).toBe(true);
   });
 
   it("PascalCases oneOf model name for snake_case unions", async () => {
@@ -483,7 +483,7 @@ describe("GraphQL Mutation Engine - oneOf Input Objects", () => {
     expect(mutatedUnion.variants.size).toBe(2);
 
     // The result should be marked as nullable
-    expect(isNullable(tester.program, mutatedUnion)).toBe(true);
+    expect(isNullable(mutatedUnion)).toBe(true);
   });
 
   it("strips null from multi-variant union in input context", async () => {
@@ -506,8 +506,8 @@ describe("GraphQL Mutation Engine - oneOf Input Objects", () => {
     expect(model.properties.has("dog")).toBe(true);
 
     // Should be marked as both @oneOf and nullable
-    expect(isOneOf(tester.program, model)).toBe(true);
-    expect(isNullable(tester.program, model)).toBe(true);
+    expect(isOneOf(model)).toBe(true);
+    expect(isNullable(model)).toBe(true);
   });
 
   it("non-nullable union is not marked as nullable", async () => {
@@ -522,7 +522,7 @@ describe("GraphQL Mutation Engine - oneOf Input Objects", () => {
     const engine = createTestEngine(tester.program);
     const mutation = engine.mutateUnion(Pet, GraphQLTypeContext.Output);
 
-    expect(isNullable(tester.program, mutation.mutatedType)).toBe(false);
+    expect(isNullable(mutation.mutatedType)).toBe(false);
   });
 
   it("exposes typeContext on union mutation", async () => {

--- a/packages/graphql/test/mutation-engine/unions.test.ts
+++ b/packages/graphql/test/mutation-engine/unions.test.ts
@@ -86,17 +86,15 @@ describe("GraphQL Mutation Engine - Unions", () => {
     expect(mutation.wrapperModels).toHaveLength(0);
   });
 
-  it("wrapper model has value property with the scalar type", async () => {
+  it("collapses single-scalar-variant union to the scalar type", async () => {
     const { Data } = await tester.compile(t.code`union ${t.union("Data")} { text: string; }`);
 
     const engine = createTestEngine(tester.program);
     const mutation = engine.mutateUnion(Data, GraphQLTypeContext.Output);
 
-    expect(mutation.wrapperModels).toHaveLength(1);
-    const wrapper = mutation.wrapperModels[0];
-    const valueProp = wrapper.properties.get("value");
-    expect(valueProp).toBeDefined();
-    expect(valueProp!.optional).toBe(false);
+    // Single variant → collapsed to the scalar directly (no union or wrapper)
+    expect(mutation.mutatedType.kind).toBe("Scalar");
+    expect(mutation.wrapperModels).toHaveLength(0);
   });
 
   it("creates wrappers for multiple scalar variants", async () => {
@@ -113,6 +111,145 @@ describe("GraphQL Mutation Engine - Unions", () => {
     expect(mutation.wrapperModels).toHaveLength(2);
     const names = mutation.wrapperModels.map((m) => m.name).sort();
     expect(names).toEqual(["MixedCountUnionVariant", "MixedTextUnionVariant"]);
+  });
+
+  it("names anonymous return type union as OperationUnion", async () => {
+    await tester.compile(
+      t.code`
+        model ${t.model("Foo")} { x: int32; }
+        model ${t.model("Bar")} { y: string; }
+        op ${t.op("getBaz")}(): Foo | Bar;
+      `,
+    );
+
+    const getBaz = tester.program.getGlobalNamespaceType().operations.get("getBaz")!;
+    const engine = createTestEngine(tester.program);
+    const mutation = engine.mutateUnion(getBaz.returnType as Union, GraphQLTypeContext.Output);
+
+    expect(mutation.mutatedType.kind).toBe("Union");
+    expect((mutation.mutatedType as Union).name).toBe("GetBazUnion");
+  });
+
+  it("names anonymous union on model property as ModelPropertyUnion", async () => {
+    const { Foo } = await tester.compile(
+      t.code`
+        model ${t.model("Cat")} { name: string; }
+        model ${t.model("Dog")} { breed: string; }
+        model ${t.model("Foo")} { pet: Cat | Dog; }
+      `,
+    );
+
+    const engine = createTestEngine(tester.program);
+    const mutation = engine.mutateModel(Foo, GraphQLTypeContext.Output);
+
+    const petProp = mutation.mutatedType.properties.get("pet")!;
+    expect(petProp.type.kind).toBe("Union");
+    expect((petProp.type as Union).name).toBe("FooPetUnion");
+  });
+
+  it("collapses union to single type after flattening deduplicates to one variant", async () => {
+    const { Outer } = await tester.compile(
+      t.code`
+        model ${t.model("Cat")} { name: string; }
+        union ${t.union("Inner")} { a: Cat; }
+        union ${t.union("Outer")} { inner: Inner; cat: Cat; }
+      `,
+    );
+
+    const engine = createTestEngine(tester.program);
+    const mutation = engine.mutateUnion(Outer, GraphQLTypeContext.Output);
+
+    // Inner flattens to Cat, Outer's cat is also Cat → dedup → 1 variant → collapse
+    expect(mutation.mutatedType.kind).toBe("Model");
+    expect(mutation.mutatedType.name).toBe("Cat");
+  });
+
+  it("flattened union variant types get their mutation pipeline applied", async () => {
+    await tester.compile(
+      t.code`
+        model ${t.model("ad_account")} { id: int32; }
+        model ${t.model("board")} { title: string; }
+        union ${t.union("Mixed")} { a: ad_account; b: board; null; }
+      `,
+    );
+
+    const Mixed = tester.program.getGlobalNamespaceType().unions.get("Mixed")!;
+    const engine = createTestEngine(tester.program);
+    const mutation = engine.mutateUnion(Mixed, GraphQLTypeContext.Output);
+
+    // After null-strip + flattening, variants should have mutated names
+    const mutatedUnion = mutation.mutatedType as Union;
+    const variantTypes = [...mutatedUnion.variants.values()].map((v) => v.type);
+    const names = variantTypes.map((t) => (t as any).name).sort();
+    expect(names).toEqual(["AdAccount", "Board"]);
+  });
+
+  it("T | null replacement gets its mutation pipeline applied", async () => {
+    await tester.compile(
+      t.code`
+        model ${t.model("ad_account")} { id: int32; }
+        union ${t.union("MaybeAccount")} { ad_account, null }
+      `,
+    );
+
+    const MaybeAccount = tester.program.getGlobalNamespaceType().unions.get("MaybeAccount")!;
+    const engine = createTestEngine(tester.program);
+    const mutation = engine.mutateUnion(MaybeAccount, GraphQLTypeContext.Output);
+
+    // T | null unwraps to ad_account → mutation renames to AdAccount
+    expect(mutation.mutatedType.kind).toBe("Model");
+    expect(mutation.mutatedType.name).toBe("AdAccount");
+  });
+
+  it("collapsed type gets its mutation pipeline applied (e.g. naming)", async () => {
+    await tester.compile(
+      t.code`
+        model ${t.model("ad_account")} { id: int32; }
+        union ${t.union("Inner")} { a: ad_account; }
+        union ${t.union("Outer")} { inner: Inner; dup: ad_account; }
+      `,
+    );
+
+    const Outer = tester.program.getGlobalNamespaceType().unions.get("Outer")!;
+    const engine = createTestEngine(tester.program);
+    const mutation = engine.mutateUnion(Outer, GraphQLTypeContext.Output);
+
+    // Flattens to one unique type (ad_account) → collapses → mutation renames to AdAccount
+    expect(mutation.mutatedType.kind).toBe("Model");
+    expect(mutation.mutatedType.name).toBe("AdAccount");
+  });
+
+  it("collapses nullable multi-variant union when only one variant remains after null strip", async () => {
+    const { Things } = await tester.compile(
+      t.code`
+        model ${t.model("Cat")} { name: string; }
+        union ${t.union("Things")} { cat: Cat; dup: Cat; null; }
+      `,
+    );
+
+    const engine = createTestEngine(tester.program);
+    const mutation = engine.mutateUnion(Things, GraphQLTypeContext.Output);
+
+    // Strip null → Cat, Cat → dedup → 1 variant → collapse
+    expect(mutation.mutatedType.kind).toBe("Model");
+    expect(mutation.mutatedType.name).toBe("Cat");
+    expect(isNullable(tester.program, mutation.mutatedType)).toBe(true);
+  });
+
+  it("handles circular type references without infinite recursion", async () => {
+    const { Tree } = await tester.compile(
+      t.code`
+        model ${t.model("Leaf")} { value: int32; }
+        model ${t.model("Tree")} { children: Tree | Leaf | null; }
+      `,
+    );
+
+    const engine = createTestEngine(tester.program);
+    // Should complete without stack overflow
+    const mutation = engine.mutateModel(Tree, GraphQLTypeContext.Output);
+
+    expect(mutation.mutatedType.kind).toBe("Model");
+    expect(mutation.mutatedType.name).toBe("Tree");
   });
 
   it("sanitizes union name in mutated type", async () => {

--- a/packages/graphql/test/mutation-engine/unions.test.ts
+++ b/packages/graphql/test/mutation-engine/unions.test.ts
@@ -179,9 +179,10 @@ describe("GraphQL Mutation Engine - Unions", () => {
 
     // After null-strip + flattening, variants should have mutated names
     const mutatedUnion = mutation.mutatedType as Union;
-    const variantTypes = [...mutatedUnion.variants.values()].map((v) => v.type);
-    const names = variantTypes.map((t) => (t as any).name).sort();
-    expect(names).toEqual(["AdAccount", "Board"]);
+    const variantNames = [...mutatedUnion.variants.values()]
+      .map((v) => ("name" in v.type ? v.type.name : v.type.kind))
+      .sort();
+    expect(variantNames).toEqual(["AdAccount", "Board"]);
   });
 
   it("T | null replacement gets its mutation pipeline applied", async () => {


### PR DESCRIPTION
## Summary

- **Anonymous union naming**: Inline unions (e.g., `Foo | Bar` on a property or return type) now get named via `getUnionName()` + naming pipeline (e.g., `FooPetUnion`, `GetBazUnion`)
- **Union collapsing**: Single-variant unions after flattening/dedup/null-strip collapse to the inner type (avoids degenerate `union Foo = Bar`)
- **Record-to-scalar**: `Record<T>` models with no named properties are replaced with custom scalars named after the model/template
- **Inner nullable fix**: `T | null` unwrap now mutates the inner type before replacing, ensuring the full pipeline runs (naming, nested array elements, etc.)
- **Mutation pipeline invariant**: All variant types in flattened unions pass through `engine.mutate()` + `resolveType()` before entering the mutated graph — prevents raw source types from leaking through

Stacked on PR #88 (naming pipelines).

## Key design decision

Discovered that `mutationNode.replace()` doesn't update the inherited `mutatedType` getter on `SimpleModelMutation`. Added `resolveType()` helper that checks `mutationNode.isReplaced` and returns the replacement's mutated type. This is needed everywhere we call `engine.mutate(x).mutatedType` — if the mutation replaced the type (e.g., Record→Scalar), the getter returns stale data without the helper.

## Test plan

- [x] Anonymous union naming: operation return type, model property (2 tests)
- [x] Union collapsing: flatten-to-one, null-strip-to-one, scalar-variant (3 tests)
- [x] Mutation pipeline through collapse/unwrap: snake_case models get PascalCased (3 tests)
- [x] Record-to-scalar: named Record, Record with properties (stays Model), Record through T|null (3 tests)
- [x] Inner nullable array: `(T|null)[] | null` element unwrapped correctly (1 test)
- [x] Circular types: no infinite recursion with self-referencing models (1 test)
- [x] 201 tests total, all passing
- [x] Type check clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)