### PR TITLE
  Add Object, Interface, and Input type components for rendering GraphQL type declarations.

### DIFF
--- a/packages/graphql/src/components/types/index.ts
+++ b/packages/graphql/src/components/types/index.ts
@@ -1,3 +1,6 @@
 export { EnumType, type EnumTypeProps } from "./enum-type.js";
 export { ScalarType, type ScalarTypeProps } from "./scalar-type.js";
 export { UnionType, type UnionTypeProps, type GraphQLUnion } from "./union-type.js";
+export { InterfaceType, type InterfaceTypeProps } from "./interface-type.js";
+export { ObjectType, type ObjectTypeProps } from "./object-type.js";
+export { InputType, type InputTypeProps } from "./input-type.js";

--- a/packages/graphql/src/components/types/input-type.tsx
+++ b/packages/graphql/src/components/types/input-type.tsx
@@ -1,0 +1,36 @@
+import { type Model, getDoc } from "@typespec/compiler";
+import * as gql from "@alloy-js/graphql";
+import { useTsp } from "@typespec/emitter-framework";
+import { useGraphQLSchema } from "../../context/index.js";
+import { Field } from "../fields/index.js";
+
+export interface InputTypeProps {
+  /** The input type to render */
+  type: Model;
+}
+
+/**
+ * Renders a GraphQL input type declaration
+ *
+ * Determines the correct input type name:
+ * - If the model is also an output type, appends "Input"
+ * - Otherwise, uses the name as-is
+ */
+export function InputType(props: InputTypeProps) {
+  const { program } = useTsp();
+  const { modelVariants } = useGraphQLSchema();
+  const doc = getDoc(program, props.type);
+  const properties = Array.from(props.type.properties.values());
+
+  // If there's an output variant with the same name, add Input suffix
+  const hasOutputVariant = modelVariants.outputModels.has(props.type.name);
+  const inputTypeName = hasOutputVariant ? `${props.type.name}Input` : props.type.name;
+
+  return (
+    <gql.InputObjectType name={inputTypeName} description={doc}>
+      {properties.map((prop) => (
+        <Field property={prop} isInput={true} />
+      ))}
+    </gql.InputObjectType>
+  );
+}

--- a/packages/graphql/src/components/types/input-type.tsx
+++ b/packages/graphql/src/components/types/input-type.tsx
@@ -1,4 +1,4 @@
-import { type Model, getDoc } from "@typespec/compiler";
+import type { Model } from "@typespec/compiler";
 import * as gql from "@alloy-js/graphql";
 import { useTsp } from "@typespec/emitter-framework";
 import { useGraphQLSchema } from "../../context/index.js";
@@ -17,9 +17,9 @@ export interface InputTypeProps {
  * - Otherwise, uses the name as-is
  */
 export function InputType(props: InputTypeProps) {
-  const { program } = useTsp();
+  const { $ } = useTsp();
   const { modelVariants } = useGraphQLSchema();
-  const doc = getDoc(program, props.type);
+  const doc = $.type.getDoc(props.type);
   const properties = Array.from(props.type.properties.values());
 
   // If there's an output variant with the same name, add Input suffix

--- a/packages/graphql/src/components/types/input-type.tsx
+++ b/packages/graphql/src/components/types/input-type.tsx
@@ -9,10 +9,7 @@ export interface InputTypeProps {
 }
 
 /**
- * Renders a GraphQL input type declaration
- *
- * The mutation engine handles naming: input models are already suffixed
- * with "Input" when they need to be distinguished from output types.
+ * Renders a GraphQL input type declaration.
  */
 export function InputType(props: InputTypeProps) {
   const { $ } = useTsp();

--- a/packages/graphql/src/components/types/input-type.tsx
+++ b/packages/graphql/src/components/types/input-type.tsx
@@ -1,7 +1,6 @@
 import type { Model } from "@typespec/compiler";
 import * as gql from "@alloy-js/graphql";
 import { useTsp } from "@typespec/emitter-framework";
-import { useGraphQLSchema } from "../../context/index.js";
 import { Field } from "../fields/index.js";
 
 export interface InputTypeProps {
@@ -12,22 +11,16 @@ export interface InputTypeProps {
 /**
  * Renders a GraphQL input type declaration
  *
- * Determines the correct input type name:
- * - If the model is also an output type, appends "Input"
- * - Otherwise, uses the name as-is
+ * The mutation engine handles naming: input models are already suffixed
+ * with "Input" when they need to be distinguished from output types.
  */
 export function InputType(props: InputTypeProps) {
   const { $ } = useTsp();
-  const { modelVariants } = useGraphQLSchema();
   const doc = $.type.getDoc(props.type);
   const properties = Array.from(props.type.properties.values());
 
-  // If there's an output variant with the same name, add Input suffix
-  const hasOutputVariant = modelVariants.outputModels.has(props.type.name);
-  const inputTypeName = hasOutputVariant ? `${props.type.name}Input` : props.type.name;
-
   return (
-    <gql.InputObjectType name={inputTypeName} description={doc}>
+    <gql.InputObjectType name={props.type.name} description={doc}>
       {properties.map((prop) => (
         <Field property={prop} isInput={true} />
       ))}

--- a/packages/graphql/src/components/types/interface-type.tsx
+++ b/packages/graphql/src/components/types/interface-type.tsx
@@ -1,0 +1,28 @@
+import { type Model, getDoc } from "@typespec/compiler";
+import * as gql from "@alloy-js/graphql";
+import { useTsp } from "@typespec/emitter-framework";
+import { Field } from "../fields/index.js";
+
+export interface InterfaceTypeProps {
+  /** The interface type to render */
+  type: Model;
+}
+
+/**
+ * Renders a GraphQL interface type declaration
+ *
+ * Interfaces are marked with @Interface decorator in TypeSpec
+ */
+export function InterfaceType(props: InterfaceTypeProps) {
+  const { program } = useTsp();
+  const doc = getDoc(program, props.type);
+  const properties = Array.from(props.type.properties.values());
+
+  return (
+    <gql.InterfaceType name={props.type.name} description={doc}>
+      {properties.map((prop) => (
+        <Field property={prop} isInput={false} />
+      ))}
+    </gql.InterfaceType>
+  );
+}

--- a/packages/graphql/src/components/types/interface-type.tsx
+++ b/packages/graphql/src/components/types/interface-type.tsx
@@ -1,4 +1,4 @@
-import { type Model, getDoc } from "@typespec/compiler";
+import type { Model } from "@typespec/compiler";
 import * as gql from "@alloy-js/graphql";
 import { useTsp } from "@typespec/emitter-framework";
 import { Field } from "../fields/index.js";
@@ -14,8 +14,8 @@ export interface InterfaceTypeProps {
  * Interfaces are marked with @Interface decorator in TypeSpec
  */
 export function InterfaceType(props: InterfaceTypeProps) {
-  const { program } = useTsp();
-  const doc = getDoc(program, props.type);
+  const { $ } = useTsp();
+  const doc = $.type.getDoc(props.type);
   const properties = Array.from(props.type.properties.values());
 
   return (

--- a/packages/graphql/src/components/types/object-type.tsx
+++ b/packages/graphql/src/components/types/object-type.tsx
@@ -1,0 +1,45 @@
+import { type Model, getDoc } from "@typespec/compiler";
+import * as gql from "@alloy-js/graphql";
+import { useTsp } from "@typespec/emitter-framework";
+import { Field, OperationField } from "../fields/index.js";
+import { getComposition } from "../../lib/interface.js";
+import { getOperationFields } from "../../lib/operation-fields.js";
+
+export interface ObjectTypeProps {
+  /** The object type to render */
+  type: Model;
+}
+
+/**
+ * Renders a GraphQL object type declaration
+ *
+ * Handles:
+ * - Regular fields from model properties
+ * - Interface implementations via @compose
+ * - Operation fields via @operationFields
+ */
+export function ObjectType(props: ObjectTypeProps) {
+  const { program } = useTsp();
+  const doc = getDoc(program, props.type);
+  const properties = Array.from(props.type.properties.values());
+  const implementations = getComposition(program, props.type);
+  const operationFields = getOperationFields(program, props.type);
+
+  // Convert interface implementations to string references
+  const implementsRefs = implementations?.map((iface) => iface.name) || [];
+
+  return (
+    <gql.ObjectType
+      name={props.type.name}
+      description={doc}
+      interfaces={implementsRefs}
+    >
+      {properties.map((prop) => (
+        <Field property={prop} isInput={false} />
+      ))}
+      {Array.from(operationFields).map((op) => (
+        <OperationField operation={op} />
+      ))}
+    </gql.ObjectType>
+  );
+}

--- a/packages/graphql/src/components/types/object-type.tsx
+++ b/packages/graphql/src/components/types/object-type.tsx
@@ -25,10 +25,6 @@ export function ObjectType(props: ObjectTypeProps) {
   const implementations = getComposition(program, props.type);
   const operationFields = getOperationFields(program, props.type);
 
-  // Convert interface implementations to string references.
-  // Note: getComposition returns original (pre-mutation) models from decorator state.
-  // This works because the mutation engine doesn't rename models, so iface.name
-  // matches the name used by InterfaceType for the same model.
   const implementsRefs = implementations?.map((iface) => iface.name) || [];
 
   return (

--- a/packages/graphql/src/components/types/object-type.tsx
+++ b/packages/graphql/src/components/types/object-type.tsx
@@ -1,4 +1,4 @@
-import { type Model, getDoc } from "@typespec/compiler";
+import type { Model } from "@typespec/compiler";
 import * as gql from "@alloy-js/graphql";
 import { useTsp } from "@typespec/emitter-framework";
 import { Field, OperationField } from "../fields/index.js";
@@ -19,13 +19,16 @@ export interface ObjectTypeProps {
  * - Operation fields via @operationFields
  */
 export function ObjectType(props: ObjectTypeProps) {
-  const { program } = useTsp();
-  const doc = getDoc(program, props.type);
+  const { $, program } = useTsp();
+  const doc = $.type.getDoc(props.type);
   const properties = Array.from(props.type.properties.values());
   const implementations = getComposition(program, props.type);
   const operationFields = getOperationFields(program, props.type);
 
-  // Convert interface implementations to string references
+  // Convert interface implementations to string references.
+  // Note: getComposition returns original (pre-mutation) models from decorator state.
+  // This works because the mutation engine doesn't rename models, so iface.name
+  // matches the name used by InterfaceType for the same model.
   const implementsRefs = implementations?.map((iface) => iface.name) || [];
 
   return (

--- a/packages/graphql/test/components/input-type.test.tsx
+++ b/packages/graphql/test/components/input-type.test.tsx
@@ -1,4 +1,3 @@
-import { type Model } from "@typespec/compiler";
 import { t } from "@typespec/compiler/testing";
 import { describe, expect, it, beforeEach } from "vitest";
 import { InputType } from "../../src/components/types/index.js";

--- a/packages/graphql/test/components/input-type.test.tsx
+++ b/packages/graphql/test/components/input-type.test.tsx
@@ -1,0 +1,88 @@
+import { type Model } from "@typespec/compiler";
+import { t } from "@typespec/compiler/testing";
+import { describe, expect, it, beforeEach } from "vitest";
+import { InputType } from "../../src/components/types/index.js";
+import { Tester } from "../test-host.js";
+import { renderComponentToSDL } from "./component-test-utils.js";
+
+describe("InputType component", () => {
+  let tester: Awaited<ReturnType<typeof Tester.createInstance>>;
+  beforeEach(async () => {
+    tester = await Tester.createInstance();
+  });
+
+  it("renders a basic input type with fields", async () => {
+    const { CreateUser } = await tester.compile(
+      t.code`model ${t.model("CreateUser")} { name: string; email: string; }`,
+    );
+
+    const sdl = renderComponentToSDL(tester.program, <InputType type={CreateUser} />);
+
+    expect(sdl).toContain("input CreateUser {");
+    expect(sdl).toContain("name: String!");
+    expect(sdl).toContain("email: String!");
+  });
+
+  it("renders with doc comment description", async () => {
+    const { LoginInput } = await tester.compile(
+      t.code`
+        /** Credentials for login */
+        model ${t.model("LoginInput")} { username: string; password: string; }
+      `,
+    );
+
+    const sdl = renderComponentToSDL(tester.program, <InputType type={LoginInput} />);
+
+    expect(sdl).toContain("Credentials for login");
+    expect(sdl).toContain("input LoginInput {");
+  });
+
+  it("renders optional fields as non-null (GraphQL input convention)", async () => {
+    // In GraphQL, input fields are always non-null; optionality is expressed
+    // via default values, not nullability. Only `| null` makes them nullable.
+    const { UpdateUser } = await tester.compile(
+      t.code`model ${t.model("UpdateUser")} { name?: string; bio?: string; }`,
+    );
+
+    const sdl = renderComponentToSDL(tester.program, <InputType type={UpdateUser} />);
+
+    expect(sdl).toContain("name: String!");
+    expect(sdl).toContain("bio: String!");
+  });
+
+  it("appends Input suffix when model has an output variant", async () => {
+    const { Pet } = await tester.compile(
+      t.code`model ${t.model("Pet")} { name: string; }`,
+    );
+
+    const sdl = renderComponentToSDL(tester.program, <InputType type={Pet} />, {
+      modelVariants: {
+        outputModels: new Map([["Pet", Pet]]),
+        inputModels: new Map([["Pet", Pet]]),
+      },
+    });
+
+    expect(sdl).toContain("input PetInput {");
+  });
+
+  it("uses original name when no output variant exists", async () => {
+    const { CreatePet } = await tester.compile(
+      t.code`model ${t.model("CreatePet")} { name: string; }`,
+    );
+
+    const sdl = renderComponentToSDL(tester.program, <InputType type={CreatePet} />);
+
+    expect(sdl).toContain("input CreatePet {");
+    expect(sdl).not.toContain("CreatePetInput");
+  });
+
+  it("renders array fields as list types", async () => {
+    const { TagInput } = await tester.compile(
+      t.code`model ${t.model("TagInput")} { values: string[]; }`,
+    );
+
+    const sdl = renderComponentToSDL(tester.program, <InputType type={TagInput} />);
+
+    expect(sdl).toContain("values: [String!]!");
+  });
+});

--- a/packages/graphql/test/components/input-type.test.tsx
+++ b/packages/graphql/test/components/input-type.test.tsx
@@ -49,31 +49,6 @@ describe("InputType component", () => {
     expect(sdl).toContain("bio: String!");
   });
 
-  it("renders mutated input model with Input suffix from mutation engine", async () => {
-    // The mutation engine adds the Input suffix when a model is used as input.
-    // This test simulates that by using a model already named with Input suffix.
-    const { PetInput } = await tester.compile(
-      t.code`model ${t.model("PetInput")} { name: string; }`,
-    );
-
-    const sdl = renderComponentToSDL(tester.program, <InputType type={PetInput} />);
-
-    expect(sdl).toContain("input PetInput {");
-  });
-
-  it("renders input-only model without suffix", async () => {
-    // Models used only as inputs (never as outputs) don't need the Input suffix.
-    // The mutation engine handles this - it only adds suffix when needed.
-    const { CreatePet } = await tester.compile(
-      t.code`model ${t.model("CreatePet")} { name: string; }`,
-    );
-
-    const sdl = renderComponentToSDL(tester.program, <InputType type={CreatePet} />);
-
-    expect(sdl).toContain("input CreatePet {");
-    expect(sdl).not.toContain("CreatePetInput");
-  });
-
   it("renders array fields as list types", async () => {
     const { TagInput } = await tester.compile(
       t.code`model ${t.model("TagInput")} { values: string[]; }`,

--- a/packages/graphql/test/components/input-type.test.tsx
+++ b/packages/graphql/test/components/input-type.test.tsx
@@ -84,4 +84,12 @@ describe("InputType component", () => {
 
     expect(sdl).toContain("values: [String!]!");
   });
+
+  it("throws error for empty model (GraphQL requires at least one field)", async () => {
+    const { Empty } = await tester.compile(t.code`model ${t.model("Empty")} {}`);
+
+    expect(() => {
+      renderComponentToSDL(tester.program, <InputType type={Empty} />);
+    }).toThrow(/must define fields/);
+  });
 });

--- a/packages/graphql/test/components/input-type.test.tsx
+++ b/packages/graphql/test/components/input-type.test.tsx
@@ -17,9 +17,16 @@ describe("InputType component", () => {
 
     const sdl = renderComponentToSDL(tester.program, <InputType type={CreateUser} />);
 
-    expect(sdl).toContain("input CreateUser {");
-    expect(sdl).toContain("name: String!");
-    expect(sdl).toContain("email: String!");
+    expect(sdl).toMatchInlineSnapshot(`
+      "input CreateUser {
+        name: String!
+        email: String!
+      }
+
+      type Query {
+        _placeholder: Boolean
+      }"
+    `);
   });
 
   it("renders with doc comment description", async () => {
@@ -32,8 +39,17 @@ describe("InputType component", () => {
 
     const sdl = renderComponentToSDL(tester.program, <InputType type={LoginInput} />);
 
-    expect(sdl).toContain("Credentials for login");
-    expect(sdl).toContain("input LoginInput {");
+    expect(sdl).toMatchInlineSnapshot(`
+      """"Credentials for login"""
+      input LoginInput {
+        username: String!
+        password: String!
+      }
+
+      type Query {
+        _placeholder: Boolean
+      }"
+    `);
   });
 
   it("renders optional fields as non-null (GraphQL input convention)", async () => {
@@ -45,8 +61,16 @@ describe("InputType component", () => {
 
     const sdl = renderComponentToSDL(tester.program, <InputType type={UpdateUser} />);
 
-    expect(sdl).toContain("name: String!");
-    expect(sdl).toContain("bio: String!");
+    expect(sdl).toMatchInlineSnapshot(`
+      "input UpdateUser {
+        name: String!
+        bio: String!
+      }
+
+      type Query {
+        _placeholder: Boolean
+      }"
+    `);
   });
 
   it("renders array fields as list types", async () => {
@@ -56,7 +80,15 @@ describe("InputType component", () => {
 
     const sdl = renderComponentToSDL(tester.program, <InputType type={TagInput} />);
 
-    expect(sdl).toContain("values: [String!]!");
+    expect(sdl).toMatchInlineSnapshot(`
+      "input TagInput {
+        values: [String!]!
+      }
+
+      type Query {
+        _placeholder: Boolean
+      }"
+    `);
   });
 
   it("throws error for empty model (GraphQL requires at least one field)", async () => {

--- a/packages/graphql/test/components/input-type.test.tsx
+++ b/packages/graphql/test/components/input-type.test.tsx
@@ -2,7 +2,7 @@ import { t } from "@typespec/compiler/testing";
 import { describe, expect, it, beforeEach } from "vitest";
 import { InputType } from "../../src/components/types/index.js";
 import { Tester } from "../test-host.js";
-import { renderComponentToSDL } from "./component-test-utils.js";
+import { renderToSDL } from "./test-utils.js";
 
 describe("InputType component", () => {
   let tester: Awaited<ReturnType<typeof Tester.createInstance>>;
@@ -15,7 +15,7 @@ describe("InputType component", () => {
       t.code`model ${t.model("CreateUser")} { name: string; email: string; }`,
     );
 
-    const sdl = renderComponentToSDL(tester.program, <InputType type={CreateUser} />);
+    const sdl = renderToSDL(tester.program, <InputType type={CreateUser} />);
 
     expect(sdl).toMatchInlineSnapshot(`
       "input CreateUser {
@@ -37,7 +37,7 @@ describe("InputType component", () => {
       `,
     );
 
-    const sdl = renderComponentToSDL(tester.program, <InputType type={LoginInput} />);
+    const sdl = renderToSDL(tester.program, <InputType type={LoginInput} />);
 
     expect(sdl).toMatchInlineSnapshot(`
       """"Credentials for login"""
@@ -60,7 +60,7 @@ describe("InputType component", () => {
       t.code`model ${t.model("UpdateUser")} { name?: string; bio?: string; }`,
     );
 
-    const sdl = renderComponentToSDL(tester.program, <InputType type={UpdateUser} />);
+    const sdl = renderToSDL(tester.program, <InputType type={UpdateUser} />);
 
     expect(sdl).toMatchInlineSnapshot(`
       "input UpdateUser {
@@ -79,7 +79,7 @@ describe("InputType component", () => {
       t.code`model ${t.model("TagInput")} { values: string[]; }`,
     );
 
-    const sdl = renderComponentToSDL(tester.program, <InputType type={TagInput} />);
+    const sdl = renderToSDL(tester.program, <InputType type={TagInput} />);
 
     expect(sdl).toMatchInlineSnapshot(`
       "input TagInput {
@@ -96,7 +96,7 @@ describe("InputType component", () => {
     const { Empty } = await tester.compile(t.code`model ${t.model("Empty")} {}`);
 
     expect(() => {
-      renderComponentToSDL(tester.program, <InputType type={Empty} />);
+      renderToSDL(tester.program, <InputType type={Empty} />);
     }).toThrow(/must define fields/);
   });
 });

--- a/packages/graphql/test/components/input-type.test.tsx
+++ b/packages/graphql/test/components/input-type.test.tsx
@@ -52,9 +52,10 @@ describe("InputType component", () => {
     `);
   });
 
-  it("renders optional fields as non-null (GraphQL input convention)", async () => {
-    // In GraphQL, input fields are always non-null; optionality is expressed
-    // via default values, not nullability. Only `| null` makes them nullable.
+  it("renders optional fields as nullable", async () => {
+    // In GraphQL, optional fields without defaults are nullable (per spec:
+    // "nullability directly determines whether a field is required").
+    // This also allows circular references in input types (e.g., Author.friend?: Author).
     const { UpdateUser } = await tester.compile(
       t.code`model ${t.model("UpdateUser")} { name?: string; bio?: string; }`,
     );
@@ -63,8 +64,8 @@ describe("InputType component", () => {
 
     expect(sdl).toMatchInlineSnapshot(`
       "input UpdateUser {
-        name: String!
-        bio: String!
+        name: String
+        bio: String
       }
 
       type Query {

--- a/packages/graphql/test/components/input-type.test.tsx
+++ b/packages/graphql/test/components/input-type.test.tsx
@@ -49,22 +49,21 @@ describe("InputType component", () => {
     expect(sdl).toContain("bio: String!");
   });
 
-  it("appends Input suffix when model has an output variant", async () => {
-    const { Pet } = await tester.compile(
-      t.code`model ${t.model("Pet")} { name: string; }`,
+  it("renders mutated input model with Input suffix from mutation engine", async () => {
+    // The mutation engine adds the Input suffix when a model is used as input.
+    // This test simulates that by using a model already named with Input suffix.
+    const { PetInput } = await tester.compile(
+      t.code`model ${t.model("PetInput")} { name: string; }`,
     );
 
-    const sdl = renderComponentToSDL(tester.program, <InputType type={Pet} />, {
-      modelVariants: {
-        outputModels: new Map([["Pet", Pet]]),
-        inputModels: new Map([["Pet", Pet]]),
-      },
-    });
+    const sdl = renderComponentToSDL(tester.program, <InputType type={PetInput} />);
 
     expect(sdl).toContain("input PetInput {");
   });
 
-  it("uses original name when no output variant exists", async () => {
+  it("renders input-only model without suffix", async () => {
+    // Models used only as inputs (never as outputs) don't need the Input suffix.
+    // The mutation engine handles this - it only adds suffix when needed.
     const { CreatePet } = await tester.compile(
       t.code`model ${t.model("CreatePet")} { name: string; }`,
     );

--- a/packages/graphql/test/components/interface-type.test.tsx
+++ b/packages/graphql/test/components/interface-type.test.tsx
@@ -1,4 +1,3 @@
-import { type Model } from "@typespec/compiler";
 import { t } from "@typespec/compiler/testing";
 import { describe, expect, it, beforeEach } from "vitest";
 import { InterfaceType } from "../../src/components/types/index.js";

--- a/packages/graphql/test/components/interface-type.test.tsx
+++ b/packages/graphql/test/components/interface-type.test.tsx
@@ -1,0 +1,76 @@
+import { type Model } from "@typespec/compiler";
+import { t } from "@typespec/compiler/testing";
+import { describe, expect, it, beforeEach } from "vitest";
+import { InterfaceType } from "../../src/components/types/index.js";
+import { Tester } from "../test-host.js";
+import { renderComponentToSDL } from "./component-test-utils.js";
+
+describe("InterfaceType component", () => {
+  let tester: Awaited<ReturnType<typeof Tester.createInstance>>;
+  beforeEach(async () => {
+    tester = await Tester.createInstance();
+  });
+
+  it("renders a basic interface with fields", async () => {
+    const { Node } = await tester.compile(
+      t.code`
+        @Interface
+        model ${t.model("Node")} { id: string; }
+      `,
+    );
+
+    const sdl = renderComponentToSDL(tester.program, <InterfaceType type={Node} />);
+
+    expect(sdl).toContain("interface Node {");
+    expect(sdl).toContain("id: String!");
+  });
+
+  it("renders with doc comment description", async () => {
+    const { Entity } = await tester.compile(
+      t.code`
+        /** A base entity */
+        @Interface
+        model ${t.model("Entity")} { id: string; }
+      `,
+    );
+
+    const sdl = renderComponentToSDL(tester.program, <InterfaceType type={Entity} />);
+
+    expect(sdl).toContain("A base entity");
+    expect(sdl).toContain("interface Entity {");
+  });
+
+  it("renders multiple fields with correct types", async () => {
+    const { Timestamped } = await tester.compile(
+      t.code`
+        @Interface
+        model ${t.model("Timestamped")} {
+          createdAt: string;
+          updatedAt: string;
+          version: int32;
+        }
+      `,
+    );
+
+    const sdl = renderComponentToSDL(tester.program, <InterfaceType type={Timestamped} />);
+
+    expect(sdl).toContain("interface Timestamped {");
+    expect(sdl).toContain("createdAt: String!");
+    expect(sdl).toContain("updatedAt: String!");
+    expect(sdl).toContain("version: Int!");
+  });
+
+  it("renders optional fields as nullable", async () => {
+    const { Described } = await tester.compile(
+      t.code`
+        @Interface
+        model ${t.model("Described")} { description?: string; }
+      `,
+    );
+
+    const sdl = renderComponentToSDL(tester.program, <InterfaceType type={Described} />);
+
+    expect(sdl).toContain("description: String");
+    expect(sdl).not.toContain("description: String!");
+  });
+});

--- a/packages/graphql/test/components/interface-type.test.tsx
+++ b/packages/graphql/test/components/interface-type.test.tsx
@@ -20,8 +20,15 @@ describe("InterfaceType component", () => {
 
     const sdl = renderComponentToSDL(tester.program, <InterfaceType type={Node} />);
 
-    expect(sdl).toContain("interface Node {");
-    expect(sdl).toContain("id: String!");
+    expect(sdl).toMatchInlineSnapshot(`
+      "interface Node {
+        id: String!
+      }
+
+      type Query {
+        _placeholder: Boolean
+      }"
+    `);
   });
 
   it("renders with doc comment description", async () => {
@@ -35,8 +42,16 @@ describe("InterfaceType component", () => {
 
     const sdl = renderComponentToSDL(tester.program, <InterfaceType type={Entity} />);
 
-    expect(sdl).toContain("A base entity");
-    expect(sdl).toContain("interface Entity {");
+    expect(sdl).toMatchInlineSnapshot(`
+      """"A base entity"""
+      interface Entity {
+        id: String!
+      }
+
+      type Query {
+        _placeholder: Boolean
+      }"
+    `);
   });
 
   it("renders multiple fields with correct types", async () => {
@@ -53,10 +68,17 @@ describe("InterfaceType component", () => {
 
     const sdl = renderComponentToSDL(tester.program, <InterfaceType type={Timestamped} />);
 
-    expect(sdl).toContain("interface Timestamped {");
-    expect(sdl).toContain("createdAt: String!");
-    expect(sdl).toContain("updatedAt: String!");
-    expect(sdl).toContain("version: Int!");
+    expect(sdl).toMatchInlineSnapshot(`
+      "interface Timestamped {
+        createdAt: String!
+        updatedAt: String!
+        version: Int!
+      }
+
+      type Query {
+        _placeholder: Boolean
+      }"
+    `);
   });
 
   it("renders optional fields as nullable", async () => {
@@ -69,8 +91,15 @@ describe("InterfaceType component", () => {
 
     const sdl = renderComponentToSDL(tester.program, <InterfaceType type={Described} />);
 
-    expect(sdl).toContain("description: String");
-    expect(sdl).not.toContain("description: String!");
+    expect(sdl).toMatchInlineSnapshot(`
+      "interface Described {
+        description: String
+      }
+
+      type Query {
+        _placeholder: Boolean
+      }"
+    `);
   });
 
   it("throws error for empty interface (GraphQL requires at least one field)", async () => {

--- a/packages/graphql/test/components/interface-type.test.tsx
+++ b/packages/graphql/test/components/interface-type.test.tsx
@@ -2,7 +2,7 @@ import { t } from "@typespec/compiler/testing";
 import { describe, expect, it, beforeEach } from "vitest";
 import { InterfaceType } from "../../src/components/types/index.js";
 import { Tester } from "../test-host.js";
-import { renderComponentToSDL } from "./component-test-utils.js";
+import { renderToSDL } from "./test-utils.js";
 
 describe("InterfaceType component", () => {
   let tester: Awaited<ReturnType<typeof Tester.createInstance>>;
@@ -18,7 +18,7 @@ describe("InterfaceType component", () => {
       `,
     );
 
-    const sdl = renderComponentToSDL(tester.program, <InterfaceType type={Node} />);
+    const sdl = renderToSDL(tester.program, <InterfaceType type={Node} />);
 
     expect(sdl).toMatchInlineSnapshot(`
       "interface Node {
@@ -40,7 +40,7 @@ describe("InterfaceType component", () => {
       `,
     );
 
-    const sdl = renderComponentToSDL(tester.program, <InterfaceType type={Entity} />);
+    const sdl = renderToSDL(tester.program, <InterfaceType type={Entity} />);
 
     expect(sdl).toMatchInlineSnapshot(`
       """"A base entity"""
@@ -66,7 +66,7 @@ describe("InterfaceType component", () => {
       `,
     );
 
-    const sdl = renderComponentToSDL(tester.program, <InterfaceType type={Timestamped} />);
+    const sdl = renderToSDL(tester.program, <InterfaceType type={Timestamped} />);
 
     expect(sdl).toMatchInlineSnapshot(`
       "interface Timestamped {
@@ -89,7 +89,7 @@ describe("InterfaceType component", () => {
       `,
     );
 
-    const sdl = renderComponentToSDL(tester.program, <InterfaceType type={Described} />);
+    const sdl = renderToSDL(tester.program, <InterfaceType type={Described} />);
 
     expect(sdl).toMatchInlineSnapshot(`
       "interface Described {
@@ -111,7 +111,7 @@ describe("InterfaceType component", () => {
     );
 
     expect(() => {
-      renderComponentToSDL(tester.program, <InterfaceType type={Empty} />);
+      renderToSDL(tester.program, <InterfaceType type={Empty} />);
     }).toThrow(/must define fields/);
   });
 });

--- a/packages/graphql/test/components/interface-type.test.tsx
+++ b/packages/graphql/test/components/interface-type.test.tsx
@@ -72,4 +72,17 @@ describe("InterfaceType component", () => {
     expect(sdl).toContain("description: String");
     expect(sdl).not.toContain("description: String!");
   });
+
+  it("throws error for empty interface (GraphQL requires at least one field)", async () => {
+    const { Empty } = await tester.compile(
+      t.code`
+        @Interface
+        model ${t.model("Empty")} {}
+      `,
+    );
+
+    expect(() => {
+      renderComponentToSDL(tester.program, <InterfaceType type={Empty} />);
+    }).toThrow(/must define fields/);
+  });
 });

--- a/packages/graphql/test/components/object-type.test.tsx
+++ b/packages/graphql/test/components/object-type.test.tsx
@@ -1,0 +1,123 @@
+import { type Model } from "@typespec/compiler";
+import { t } from "@typespec/compiler/testing";
+import * as gql from "@alloy-js/graphql";
+import { describe, expect, it, beforeEach } from "vitest";
+import { ObjectType } from "../../src/components/types/index.js";
+import { Tester } from "../test-host.js";
+import { renderComponentToSDL } from "./component-test-utils.js";
+
+describe("ObjectType component", () => {
+  let tester: Awaited<ReturnType<typeof Tester.createInstance>>;
+  beforeEach(async () => {
+    tester = await Tester.createInstance();
+  });
+
+  it("renders a basic object type with fields", async () => {
+    const { User } = await tester.compile(
+      t.code`model ${t.model("User")} { name: string; age: int32; }`,
+    );
+
+    const sdl = renderComponentToSDL(tester.program, <ObjectType type={User} />);
+
+    expect(sdl).toContain("type User {");
+    expect(sdl).toContain("name: String!");
+    expect(sdl).toContain("age: Int!");
+  });
+
+  it("renders with doc comment description", async () => {
+    const { Item } = await tester.compile(
+      t.code`
+        /** A store item */
+        model ${t.model("Item")} { title: string; }
+      `,
+    );
+
+    const sdl = renderComponentToSDL(tester.program, <ObjectType type={Item} />);
+
+    expect(sdl).toContain("A store item");
+    expect(sdl).toContain("type Item {");
+  });
+
+  it("renders optional fields as nullable", async () => {
+    const { Profile } = await tester.compile(
+      t.code`model ${t.model("Profile")} { bio?: string; }`,
+    );
+
+    const sdl = renderComponentToSDL(tester.program, <ObjectType type={Profile} />);
+
+    expect(sdl).toContain("bio: String");
+    expect(sdl).not.toContain("bio: String!");
+  });
+
+  it("renders array fields as list types", async () => {
+    const { Post } = await tester.compile(
+      t.code`model ${t.model("Post")} { tags: string[]; }`,
+    );
+
+    const sdl = renderComponentToSDL(tester.program, <ObjectType type={Post} />);
+
+    expect(sdl).toContain("tags: [String!]!");
+  });
+
+  it("renders field with doc comment description", async () => {
+    const { Thing } = await tester.compile(
+      t.code`
+        model ${t.model("Thing")} {
+          /** The display name */
+          name: string;
+        }
+      `,
+    );
+
+    const sdl = renderComponentToSDL(tester.program, <ObjectType type={Thing} />);
+
+    expect(sdl).toContain("The display name");
+    expect(sdl).toContain("name: String!");
+  });
+
+  it("renders deprecated fields", async () => {
+    const { Entry } = await tester.compile(
+      t.code`
+        model ${t.model("Entry")} {
+          current: string;
+          #deprecated "use current instead"
+          old: string;
+        }
+      `,
+    );
+
+    const sdl = renderComponentToSDL(tester.program, <ObjectType type={Entry} />);
+
+    expect(sdl).toContain("current: String!");
+    expect(sdl).toContain("old: String!");
+    expect(sdl).toContain("@deprecated");
+    expect(sdl).toContain("use current instead");
+  });
+
+  it("renders with interface implementation via @compose", async () => {
+    const { Pet } = await tester.compile(
+      t.code`
+        @Interface
+        model ${t.model("Node")} { id: string; }
+
+        @compose(Node)
+        model ${t.model("Pet")} { ...Node; name: string; }
+      `,
+    );
+
+    // Register the Node interface in the schema so buildSchema can resolve it
+    const sdl = renderComponentToSDL(
+      tester.program,
+      <>
+        <gql.InterfaceType name="Node">
+          <gql.Field name="id" type={gql.String} nonNull />
+        </gql.InterfaceType>
+        <ObjectType type={Pet} />
+      </>,
+    );
+
+    expect(sdl).toContain("type Pet implements Node {");
+    expect(sdl).toContain("id: String!");
+    expect(sdl).toContain("name: String!");
+  });
+});

--- a/packages/graphql/test/components/object-type.test.tsx
+++ b/packages/graphql/test/components/object-type.test.tsx
@@ -1,4 +1,3 @@
-import { type Model } from "@typespec/compiler";
 import { t } from "@typespec/compiler/testing";
 import * as gql from "@alloy-js/graphql";
 import { describe, expect, it, beforeEach } from "vitest";

--- a/packages/graphql/test/components/object-type.test.tsx
+++ b/packages/graphql/test/components/object-type.test.tsx
@@ -18,9 +18,16 @@ describe("ObjectType component", () => {
 
     const sdl = renderComponentToSDL(tester.program, <ObjectType type={User} />);
 
-    expect(sdl).toContain("type User {");
-    expect(sdl).toContain("name: String!");
-    expect(sdl).toContain("age: Int!");
+    expect(sdl).toMatchInlineSnapshot(`
+      "type User {
+        name: String!
+        age: Int!
+      }
+
+      type Query {
+        _placeholder: Boolean
+      }"
+    `);
   });
 
   it("renders with doc comment description", async () => {
@@ -33,8 +40,16 @@ describe("ObjectType component", () => {
 
     const sdl = renderComponentToSDL(tester.program, <ObjectType type={Item} />);
 
-    expect(sdl).toContain("A store item");
-    expect(sdl).toContain("type Item {");
+    expect(sdl).toMatchInlineSnapshot(`
+      """"A store item"""
+      type Item {
+        title: String!
+      }
+
+      type Query {
+        _placeholder: Boolean
+      }"
+    `);
   });
 
   it("renders optional fields as nullable", async () => {
@@ -44,8 +59,15 @@ describe("ObjectType component", () => {
 
     const sdl = renderComponentToSDL(tester.program, <ObjectType type={Profile} />);
 
-    expect(sdl).toContain("bio: String");
-    expect(sdl).not.toContain("bio: String!");
+    expect(sdl).toMatchInlineSnapshot(`
+      "type Profile {
+        bio: String
+      }
+
+      type Query {
+        _placeholder: Boolean
+      }"
+    `);
   });
 
   it("renders array fields as list types", async () => {
@@ -55,7 +77,15 @@ describe("ObjectType component", () => {
 
     const sdl = renderComponentToSDL(tester.program, <ObjectType type={Post} />);
 
-    expect(sdl).toContain("tags: [String!]!");
+    expect(sdl).toMatchInlineSnapshot(`
+      "type Post {
+        tags: [String!]!
+      }
+
+      type Query {
+        _placeholder: Boolean
+      }"
+    `);
   });
 
   it("renders field with doc comment description", async () => {
@@ -70,8 +100,16 @@ describe("ObjectType component", () => {
 
     const sdl = renderComponentToSDL(tester.program, <ObjectType type={Thing} />);
 
-    expect(sdl).toContain("The display name");
-    expect(sdl).toContain("name: String!");
+    expect(sdl).toMatchInlineSnapshot(`
+      "type Thing {
+        """The display name"""
+        name: String!
+      }
+
+      type Query {
+        _placeholder: Boolean
+      }"
+    `);
   });
 
   it("renders deprecated fields", async () => {
@@ -87,10 +125,16 @@ describe("ObjectType component", () => {
 
     const sdl = renderComponentToSDL(tester.program, <ObjectType type={Entry} />);
 
-    expect(sdl).toContain("current: String!");
-    expect(sdl).toContain("old: String!");
-    expect(sdl).toContain("@deprecated");
-    expect(sdl).toContain("use current instead");
+    expect(sdl).toMatchInlineSnapshot(`
+      "type Entry {
+        current: String!
+        old: String! @deprecated(reason: "use current instead")
+      }
+
+      type Query {
+        _placeholder: Boolean
+      }"
+    `);
   });
 
   it("renders with interface implementation via @compose", async () => {
@@ -115,9 +159,20 @@ describe("ObjectType component", () => {
       </>,
     );
 
-    expect(sdl).toContain("type Pet implements Node {");
-    expect(sdl).toContain("id: String!");
-    expect(sdl).toContain("name: String!");
+    expect(sdl).toMatchInlineSnapshot(`
+      "interface Node {
+        id: String!
+      }
+
+      type Pet implements Node {
+        id: String!
+        name: String!
+      }
+
+      type Query {
+        _placeholder: Boolean
+      }"
+    `);
   });
 
   it("renders operation fields via @operationFields", async () => {
@@ -132,9 +187,16 @@ describe("ObjectType component", () => {
 
     const sdl = renderComponentToSDL(tester.program, <ObjectType type={Book} />);
 
-    expect(sdl).toContain("type Book {");
-    expect(sdl).toContain("title: String!");
-    expect(sdl).toContain("getRelated(limit: Int!): [Book!]!");
+    expect(sdl).toMatchInlineSnapshot(`
+      "type Book {
+        title: String!
+        getRelated(limit: Int!): [Book!]!
+      }
+
+      type Query {
+        _placeholder: Boolean
+      }"
+    `);
   });
 
   it("renders fields that reference other models", async () => {
@@ -155,9 +217,20 @@ describe("ObjectType component", () => {
       </>,
     );
 
-    expect(sdl).toContain("type Author {");
-    expect(sdl).toContain("name: String!");
-    expect(sdl).toContain("favoriteBook: Book!");
+    expect(sdl).toMatchInlineSnapshot(`
+      "type Book {
+        title: String!
+      }
+
+      type Author {
+        name: String!
+        favoriteBook: Book!
+      }
+
+      type Query {
+        _placeholder: Boolean
+      }"
+    `);
   });
 
   it("throws error for empty model (GraphQL requires at least one field)", async () => {

--- a/packages/graphql/test/components/object-type.test.tsx
+++ b/packages/graphql/test/components/object-type.test.tsx
@@ -119,4 +119,52 @@ describe("ObjectType component", () => {
     expect(sdl).toContain("id: String!");
     expect(sdl).toContain("name: String!");
   });
+
+  it("renders operation fields via @operationFields", async () => {
+    const { Book } = await tester.compile(
+      t.code`
+        @operationFields(getRelated)
+        model ${t.model("Book")} { title: string; }
+
+        op getRelated(limit: int32): Book[];
+      `,
+    );
+
+    const sdl = renderComponentToSDL(tester.program, <ObjectType type={Book} />);
+
+    expect(sdl).toContain("type Book {");
+    expect(sdl).toContain("title: String!");
+    expect(sdl).toContain("getRelated(limit: Int!): [Book!]!");
+  });
+
+  it("renders fields that reference other models", async () => {
+    const { Author } = await tester.compile(
+      t.code`
+        model ${t.model("Book")} { title: string; }
+        model ${t.model("Author")} { name: string; favoriteBook: Book; }
+      `,
+    );
+
+    const sdl = renderComponentToSDL(
+      tester.program,
+      <>
+        <gql.ObjectType name="Book">
+          <gql.Field name="title" type={gql.String} nonNull />
+        </gql.ObjectType>
+        <ObjectType type={Author} />
+      </>,
+    );
+
+    expect(sdl).toContain("type Author {");
+    expect(sdl).toContain("name: String!");
+    expect(sdl).toContain("favoriteBook: Book!");
+  });
+
+  it("throws error for empty model (GraphQL requires at least one field)", async () => {
+    const { Empty } = await tester.compile(t.code`model ${t.model("Empty")} {}`);
+
+    expect(() => {
+      renderComponentToSDL(tester.program, <ObjectType type={Empty} />);
+    }).toThrow(/must define fields/);
+  });
 });

--- a/packages/graphql/test/components/object-type.test.tsx
+++ b/packages/graphql/test/components/object-type.test.tsx
@@ -3,7 +3,7 @@ import * as gql from "@alloy-js/graphql";
 import { describe, expect, it, beforeEach } from "vitest";
 import { ObjectType } from "../../src/components/types/index.js";
 import { Tester } from "../test-host.js";
-import { renderComponentToSDL } from "./component-test-utils.js";
+import { renderToSDL } from "./test-utils.js";
 
 describe("ObjectType component", () => {
   let tester: Awaited<ReturnType<typeof Tester.createInstance>>;
@@ -16,7 +16,7 @@ describe("ObjectType component", () => {
       t.code`model ${t.model("User")} { name: string; age: int32; }`,
     );
 
-    const sdl = renderComponentToSDL(tester.program, <ObjectType type={User} />);
+    const sdl = renderToSDL(tester.program, <ObjectType type={User} />);
 
     expect(sdl).toMatchInlineSnapshot(`
       "type User {
@@ -38,7 +38,7 @@ describe("ObjectType component", () => {
       `,
     );
 
-    const sdl = renderComponentToSDL(tester.program, <ObjectType type={Item} />);
+    const sdl = renderToSDL(tester.program, <ObjectType type={Item} />);
 
     expect(sdl).toMatchInlineSnapshot(`
       """"A store item"""
@@ -57,7 +57,7 @@ describe("ObjectType component", () => {
       t.code`model ${t.model("Profile")} { bio?: string; }`,
     );
 
-    const sdl = renderComponentToSDL(tester.program, <ObjectType type={Profile} />);
+    const sdl = renderToSDL(tester.program, <ObjectType type={Profile} />);
 
     expect(sdl).toMatchInlineSnapshot(`
       "type Profile {
@@ -75,7 +75,7 @@ describe("ObjectType component", () => {
       t.code`model ${t.model("Post")} { tags: string[]; }`,
     );
 
-    const sdl = renderComponentToSDL(tester.program, <ObjectType type={Post} />);
+    const sdl = renderToSDL(tester.program, <ObjectType type={Post} />);
 
     expect(sdl).toMatchInlineSnapshot(`
       "type Post {
@@ -98,7 +98,7 @@ describe("ObjectType component", () => {
       `,
     );
 
-    const sdl = renderComponentToSDL(tester.program, <ObjectType type={Thing} />);
+    const sdl = renderToSDL(tester.program, <ObjectType type={Thing} />);
 
     expect(sdl).toMatchInlineSnapshot(`
       "type Thing {
@@ -123,7 +123,7 @@ describe("ObjectType component", () => {
       `,
     );
 
-    const sdl = renderComponentToSDL(tester.program, <ObjectType type={Entry} />);
+    const sdl = renderToSDL(tester.program, <ObjectType type={Entry} />);
 
     expect(sdl).toMatchInlineSnapshot(`
       "type Entry {
@@ -149,7 +149,7 @@ describe("ObjectType component", () => {
     );
 
     // Register the Node interface in the schema so buildSchema can resolve it
-    const sdl = renderComponentToSDL(
+    const sdl = renderToSDL(
       tester.program,
       <>
         <gql.InterfaceType name="Node">
@@ -185,7 +185,7 @@ describe("ObjectType component", () => {
       `,
     );
 
-    const sdl = renderComponentToSDL(tester.program, <ObjectType type={Book} />);
+    const sdl = renderToSDL(tester.program, <ObjectType type={Book} />);
 
     expect(sdl).toMatchInlineSnapshot(`
       "type Book {
@@ -207,7 +207,7 @@ describe("ObjectType component", () => {
       `,
     );
 
-    const sdl = renderComponentToSDL(
+    const sdl = renderToSDL(
       tester.program,
       <>
         <gql.ObjectType name="Book">
@@ -237,7 +237,7 @@ describe("ObjectType component", () => {
     const { Empty } = await tester.compile(t.code`model ${t.model("Empty")} {}`);
 
     expect(() => {
-      renderComponentToSDL(tester.program, <ObjectType type={Empty} />);
+      renderToSDL(tester.program, <ObjectType type={Empty} />);
     }).toThrow(/must define fields/);
   });
 });


### PR DESCRIPTION
# Summary

  - `ObjectType` - Renders GraphQL object types with fields, interface implementations, and operation
  fields
  - `InterfaceType` - Renders GraphQL interface types (models marked with `@Interface`)
  - `InputType` - Renders GraphQL input object types

  The mutation engine handles all type naming during mutation, so components can simply use `type.name`
   directly.

  ## Changes

  ### New Components

  **ObjectType** (`src/components/types/object-type.tsx`)
  - Renders model properties as GraphQL fields
  - Supports interface implementations via `@compose` decorator
  - Supports operation fields via `@operationFields` decorator

  **InterfaceType** (`src/components/types/interface-type.tsx`)
  - Renders models marked with `@Interface` as GraphQL interface types
  - Includes all model properties as interface fields

  **InputType** (`src/components/types/input-type.tsx`)
  - Renders input object types for operation parameters
  - The mutation engine handles the "Input" suffix naming

  ### Simplification

  Removed the `modelVariants` lookup from `InputType` and `GraphQLTypeExpression` since the mutation
  engine now handles all input/output type naming. Components use `type.name` directly.

  ## Test plan

  - [x] ObjectType tests (10 tests) - fields, descriptions, interfaces, operation fields, empty type
  error
  - [x] InterfaceType tests (5 tests) - fields, descriptions, empty type error
  - [x] InputType tests (5 tests) - fields, descriptions, arrays, empty type error
  - [x] All 249 tests pass
