### PR TITLE
Add Object, Interface, and Input type components

### DIFF
--- a/packages/graphql/lib/interface.tsp
+++ b/packages/graphql/lib/interface.tsp
@@ -7,15 +7,25 @@ namespace TypeSpec.GraphQL;
 /**
  * Mark this model as a GraphQL Interface. Interfaces can be implemented by other models.
  *
+ * @param exclusive When true, the model will only be emitted as an interface (no
+ * "Interface" suffix is added to the name). Use this for models that will never be
+ * used directly as output/input types (e.g., Node, Connection). Defaults to false.
+ *
  * @example
  *
  * ```typespec
+ * @Interface(#{exclusive: true})
+ * model Node {
+ *   id: string;
+ * }
+ *
  * @Interface
  * model Person {
  *   name: string;
  * }
+ * ```
  */
-extern dec Interface(target: Model);
+extern dec Interface(target: Model, options?: valueof {exclusive?: boolean});
 
 /**
  * Specify the GraphQL interfaces that should be implemented by a model.

--- a/packages/graphql/src/components/types/index.ts
+++ b/packages/graphql/src/components/types/index.ts
@@ -1,3 +1,6 @@
 export { EnumType, type EnumTypeProps } from "./enum-type.js";
+export { InputType, type InputTypeProps } from "./input-type.js";
+export { InterfaceType, type InterfaceTypeProps } from "./interface-type.js";
+export { ObjectType, type ObjectTypeProps } from "./object-type.js";
 export { ScalarType, type ScalarTypeProps } from "./scalar-type.js";
 export { UnionType, type UnionTypeProps, type GraphQLUnion } from "./union-type.js";

--- a/packages/graphql/src/components/types/input-type.tsx
+++ b/packages/graphql/src/components/types/input-type.tsx
@@ -1,0 +1,23 @@
+import { type Model, getDoc } from "@typespec/compiler";
+import * as gql from "@alloy-js/graphql";
+import { useTsp } from "@typespec/emitter-framework";
+import { isOneOf } from "../../lib/one-of.js";
+import { Field } from "../fields/index.js";
+
+export interface InputTypeProps {
+  type: Model;
+}
+
+export function InputType(props: InputTypeProps) {
+  const { program } = useTsp();
+  const doc = getDoc(program, props.type);
+  const properties = [...props.type.properties.values()];
+
+  return (
+    <gql.InputObjectType name={props.type.name} description={doc} oneOf={isOneOf(props.type)}>
+      {properties.map((prop) => (
+        <Field property={prop} isInput={true} />
+      ))}
+    </gql.InputObjectType>
+  );
+}

--- a/packages/graphql/src/components/types/interface-type.tsx
+++ b/packages/graphql/src/components/types/interface-type.tsx
@@ -1,0 +1,25 @@
+import { type Model, getDoc } from "@typespec/compiler";
+import * as gql from "@alloy-js/graphql";
+import { useTsp } from "@typespec/emitter-framework";
+import { getComposition } from "../../lib/interface.js";
+import { Field } from "../fields/index.js";
+
+export interface InterfaceTypeProps {
+  type: Model;
+}
+
+export function InterfaceType(props: InterfaceTypeProps) {
+  const { program } = useTsp();
+  const doc = getDoc(program, props.type);
+  const properties = [...props.type.properties.values()];
+  const composition = getComposition(program, props.type);
+  const interfaces = composition?.map((iface) => iface.name);
+
+  return (
+    <gql.InterfaceType name={props.type.name} description={doc} interfaces={interfaces}>
+      {properties.map((prop) => (
+        <Field property={prop} isInput={false} />
+      ))}
+    </gql.InterfaceType>
+  );
+}

--- a/packages/graphql/src/components/types/object-type.tsx
+++ b/packages/graphql/src/components/types/object-type.tsx
@@ -1,0 +1,25 @@
+import { type Model, getDoc } from "@typespec/compiler";
+import * as gql from "@alloy-js/graphql";
+import { useTsp } from "@typespec/emitter-framework";
+import { getComposition } from "../../lib/interface.js";
+import { Field } from "../fields/index.js";
+
+export interface ObjectTypeProps {
+  type: Model;
+}
+
+export function ObjectType(props: ObjectTypeProps) {
+  const { program } = useTsp();
+  const doc = getDoc(program, props.type);
+  const properties = [...props.type.properties.values()];
+  const composition = getComposition(program, props.type);
+  const interfaces = composition?.map((iface) => iface.name);
+
+  return (
+    <gql.ObjectType name={props.type.name} description={doc} interfaces={interfaces}>
+      {properties.map((prop) => (
+        <Field property={prop} isInput={false} />
+      ))}
+    </gql.ObjectType>
+  );
+}

--- a/packages/graphql/src/lib.ts
+++ b/packages/graphql/src/lib.ts
@@ -187,6 +187,7 @@ export const libDef = {
     operationFields: { description: "State for the @operationFields decorator." },
     compose: { description: "State for the @compose decorator." },
     interface: { description: "State for the @Interface decorator." },
+    exclusiveInterface: { description: "State for @Interface(#{exclusive: true})." },
     schema: { description: "State for the @schema decorator." },
     specifiedBy: { description: "State for the @specifiedBy decorator." },
   },

--- a/packages/graphql/src/lib/input-type.ts
+++ b/packages/graphql/src/lib/input-type.ts
@@ -1,0 +1,18 @@
+import type { DecoratorContext, DecoratorFunction, Model, Type } from "@typespec/compiler";
+import { NAMESPACE } from "../lib.js";
+
+export const namespace = NAMESPACE;
+
+export const $inputType: DecoratorFunction = (
+  _context: DecoratorContext,
+  _target: Model,
+) => {};
+
+export function isInputType(model: Model): boolean {
+  return model.decorators.some((d) => d.decorator === $inputType);
+}
+
+export function setInputType(model: Model): void {
+  if (model.decorators.some((d) => d.decorator === $inputType)) return;
+  model.decorators.push({ decorator: $inputType, args: [] });
+}

--- a/packages/graphql/src/lib/interface.ts
+++ b/packages/graphql/src/lib/interface.ts
@@ -22,6 +22,9 @@ export const namespace = NAMESPACE;
 type Interface = Tagged<Model, "interface">;
 
 const [getInterface, setInterface] = useStateSet<Interface>(GraphQLKeys.interface);
+const [getExclusiveInterface, setExclusiveInterface] = useStateSet<Interface>(
+  GraphQLKeys.exclusiveInterface,
+);
 const [getComposition, setComposition, _getCompositionMap] = useStateMap<Model, Interface[]>(
   GraphQLKeys.compose,
 );
@@ -34,6 +37,7 @@ export {
    * @returns Composed interfaces or undefined if no interfaces are composed.
    */
   getComposition,
+  setComposition,
 };
 
 /**
@@ -44,6 +48,10 @@ export {
  */
 export function isInterface(program: Program, model: Model | Interface): model is Interface {
   return !!getInterface(program, model as Interface);
+}
+
+export function isExclusiveInterface(program: Program, model: Model): boolean {
+  return !!getExclusiveInterface(program, model as Interface);
 }
 
 function validateImplementedsAreInterfaces(context: DecoratorContext, interfaces: Model[]) {
@@ -123,9 +131,16 @@ function validateImplementsInterfacesProperties(
   return valid;
 }
 
-export const $Interface: DecoratorFunction = (context: DecoratorContext, target: Model) => {
+export const $Interface: DecoratorFunction = (
+  context: DecoratorContext,
+  target: Model,
+  options?: { exclusive?: boolean },
+) => {
   validateDecoratorUniqueOnNode(context, target, $Interface);
   setInterface(context.program, target as Interface);
+  if (options?.exclusive) {
+    setExclusiveInterface(context.program, target as Interface);
+  }
 };
 
 export const $compose: DecoratorFunction = (

--- a/packages/graphql/src/mutation-engine/mutations/model.ts
+++ b/packages/graphql/src/mutation-engine/mutations/model.ts
@@ -1,8 +1,11 @@
 import {
   isTemplateInstance,
+  isType,
   walkPropertiesInherited,
   type MemberType,
   type Model,
+  type Type,
+  type Value,
 } from "@typespec/compiler";
 import {
   SimpleModelMutation,
@@ -11,11 +14,25 @@ import {
   type SimpleMutationOptions,
   type SimpleMutations,
 } from "@typespec/mutator-framework";
-import { isInterface } from "../../lib/interface.js";
+import { isExclusiveInterface } from "../../lib/interface.js";
 import { applyTypeNamePipeline } from "../../lib/naming.js";
 import { composeTemplateName } from "../../lib/template-composition.js";
 import { isRecordType } from "../../lib/type-utils.js";
 import { GraphQLMutationOptions, GraphQLTypeContext } from "../options.js";
+
+/**
+ * Maps decorator function names to the mutation context their type args
+ * should be mutated with. When a model is cloned, decorator args that
+ * reference types need re-mutation — but the context may differ from the
+ * model's own context (e.g., @compose args are always interfaces regardless
+ * of whether the model is mutated as Input or Output).
+ *
+ * Keyed by function name (not reference) because vitest can load the same
+ * module from different paths, creating distinct function objects.
+ */
+const decoratorArgContext = new Map<string, GraphQLTypeContext>([
+  ["$compose", GraphQLTypeContext.Interface],
+]);
 
 /**
  * GraphQL-specific Model mutation.
@@ -43,6 +60,7 @@ export class GraphQLModelMutation extends SimpleModelMutation<SimpleMutationOpti
     const tk = this.engine.$;
     const program = tk.program;
     const isInputContext = this.typeContext === GraphQLTypeContext.Input;
+    const isInterfaceContext = this.typeContext === GraphQLTypeContext.Interface;
 
     if (isRecordType(this.sourceType) && walkPropertiesInherited(this.sourceType).next().done) {
       const rawName = isTemplateInstance(this.sourceType)
@@ -63,17 +81,42 @@ export class GraphQLModelMutation extends SimpleModelMutation<SimpleMutationOpti
       return;
     }
 
-    const isInterfaceModel = isInterface(program, this.sourceType);
     const rawName = isTemplateInstance(this.sourceType)
       ? composeTemplateName(this.sourceType)
       : this.sourceType.name;
 
+    const needsInterfaceSuffix =
+      isInterfaceContext && !isExclusiveInterface(program, this.sourceType);
+
     this.mutationNode.mutate((model) => {
       model.name = applyTypeNamePipeline(rawName, {
         isInput: isInputContext,
-        isInterface: isInterfaceModel,
+        isInterface: needsInterfaceSuffix,
       });
+      this.mutateDecoratorTypeArgs(model);
     });
     super.mutate();
+  }
+
+  private mutateDecoratorTypeArgs(model: Model) {
+    for (const dec of model.decorators) {
+      const argContext = decoratorArgContext.get(dec.decorator.name ?? "");
+      const options = argContext
+        ? new GraphQLMutationOptions(argContext)
+        : this.options;
+      for (const arg of dec.args) {
+        if (this.isMutatableType(arg.value)) {
+          const mutation = this.engine.mutate(arg.value, options) as { mutatedType: Type };
+          arg.value = mutation.mutatedType;
+          arg.jsValue = mutation.mutatedType;
+        }
+      }
+    }
+  }
+
+  private isMutatableType(value: Type | Value): value is Type {
+    if (!isType(value)) return false;
+    const kind = value.kind;
+    return kind === "Model" || kind === "Union" || kind === "Scalar" || kind === "Enum" || kind === "Interface" || kind === "Operation";
   }
 }

--- a/packages/graphql/src/mutation-engine/mutations/model.ts
+++ b/packages/graphql/src/mutation-engine/mutations/model.ts
@@ -99,17 +99,25 @@ export class GraphQLModelMutation extends SimpleModelMutation<SimpleMutationOpti
   }
 
   private mutateDecoratorTypeArgs(model: Model) {
-    for (const dec of model.decorators) {
-      const argContext = decoratorArgContext.get(dec.decorator.name ?? "");
+    for (let i = 0; i < model.decorators.length; i++) {
+      const dec = model.decorators[i];
+      const argContext = decoratorArgContext.get(dec.decorator.name);
       const options = argContext
         ? new GraphQLMutationOptions(argContext)
         : this.options;
-      for (const arg of dec.args) {
+
+      let argsChanged = false;
+      const newArgs = dec.args.map((arg) => {
         if (this.isMutatableType(arg.value)) {
           const mutation = this.engine.mutate(arg.value, options) as { mutatedType: Type };
-          arg.value = mutation.mutatedType;
-          arg.jsValue = mutation.mutatedType;
+          argsChanged = true;
+          return { ...arg, value: mutation.mutatedType, jsValue: mutation.mutatedType };
         }
+        return arg;
+      });
+
+      if (argsChanged) {
+        model.decorators[i] = { ...dec, args: newArgs };
       }
     }
   }

--- a/packages/graphql/src/mutation-engine/options.ts
+++ b/packages/graphql/src/mutation-engine/options.ts
@@ -9,6 +9,8 @@ export enum GraphQLTypeContext {
   Input = "input",
   /** Type reachable from operation return types */
   Output = "output",
+  /** Model marked with @Interface — emits as a GraphQL interface declaration */
+  Interface = "interface",
 }
 
 /**

--- a/packages/graphql/src/mutation-engine/schema-mutator.ts
+++ b/packages/graphql/src/mutation-engine/schema-mutator.ts
@@ -12,7 +12,7 @@ import {
 } from "@typespec/compiler";
 import { $ } from "@typespec/compiler/typekit";
 import { setInputType } from "../lib/input-type.js";
-import { isInterface } from "../lib/interface.js";
+import { isExclusiveInterface, isInterface } from "../lib/interface.js";
 import { reportDiagnostic } from "../lib.js";
 import { GraphQLTypeUsage, type TypeUsageResolver } from "../type-usage.js";
 import type { GraphQLMutationEngine } from "./engine.js";
@@ -47,12 +47,13 @@ export function mutateSchema(
       const usedAsOutput = usage?.has(GraphQLTypeUsage.Output) ?? false;
       const usedAsInput = usage?.has(GraphQLTypeUsage.Input) ?? false;
       const isInterfaceModel = isInterface(program, node);
+      const isExclusive = isInterfaceModel && isExclusiveInterface(program, node);
 
       if (isInterfaceModel) {
         const mutation = engine.mutateModel(node, GraphQLTypeContext.Interface);
         mutatedTypes.push(mutation.mutatedType);
       }
-      if (usedAsOutput || (!usage && !isInterfaceModel)) {
+      if (!isExclusive && (usedAsOutput || !usage)) {
         const mutation = engine.mutateModel(node, GraphQLTypeContext.Output);
         mutatedTypes.push(mutation.mutatedType);
       }

--- a/packages/graphql/src/mutation-engine/schema-mutator.ts
+++ b/packages/graphql/src/mutation-engine/schema-mutator.ts
@@ -11,6 +11,8 @@ import {
   type Union,
 } from "@typespec/compiler";
 import { $ } from "@typespec/compiler/typekit";
+import { setInputType } from "../lib/input-type.js";
+import { isInterface } from "../lib/interface.js";
 import { reportDiagnostic } from "../lib.js";
 import { GraphQLTypeUsage, type TypeUsageResolver } from "../type-usage.js";
 import type { GraphQLMutationEngine } from "./engine.js";
@@ -44,13 +46,19 @@ export function mutateSchema(
       const usage = typeUsage.getUsage(node);
       const usedAsOutput = usage?.has(GraphQLTypeUsage.Output) ?? false;
       const usedAsInput = usage?.has(GraphQLTypeUsage.Input) ?? false;
+      const isInterfaceModel = isInterface(program, node);
 
-      if (usedAsOutput || !usage) {
+      if (isInterfaceModel) {
+        const mutation = engine.mutateModel(node, GraphQLTypeContext.Interface);
+        mutatedTypes.push(mutation.mutatedType);
+      }
+      if (usedAsOutput || (!usage && !isInterfaceModel)) {
         const mutation = engine.mutateModel(node, GraphQLTypeContext.Output);
         mutatedTypes.push(mutation.mutatedType);
       }
       if (usedAsInput) {
         const mutation = engine.mutateModel(node, GraphQLTypeContext.Input);
+        setInputType(mutation.mutatedType);
         mutatedTypes.push(mutation.mutatedType);
       }
     },

--- a/packages/graphql/test/components/input-type.test.tsx
+++ b/packages/graphql/test/components/input-type.test.tsx
@@ -1,0 +1,78 @@
+import { type Model } from "@typespec/compiler";
+import { t } from "@typespec/compiler/testing";
+import { beforeEach, describe, expect, it } from "vitest";
+import { InputType } from "../../src/components/types/index.js";
+import { createGraphQLMutationEngine, GraphQLTypeContext } from "../../src/mutation-engine/index.js";
+import { Tester } from "../test-host.js";
+import { renderToSDL } from "./test-utils.js";
+
+describe("InputType component", () => {
+  let tester: Awaited<ReturnType<typeof Tester.createInstance>>;
+  beforeEach(async () => {
+    tester = await Tester.createInstance();
+  });
+
+  it("renders a basic input object type", async () => {
+    const { Book } = await tester.compile(
+      t.code`model ${t.model("Book")} { title: string; year: int32; }`,
+    );
+
+    const engine = createGraphQLMutationEngine(tester.program);
+    const mutated = engine.mutateModel(Book, GraphQLTypeContext.Input).mutatedType;
+
+    const sdl = renderToSDL(tester.program, <InputType type={mutated} />);
+
+    expect(sdl).toMatch(/input BookInput \{/);
+    expect(sdl).toContain("title: String!");
+    expect(sdl).toContain("year: Int!");
+  });
+
+  it("renders input type with doc comment", async () => {
+    const { Book } = await tester.compile(
+      t.code`
+        /** Data for creating a book */
+        model ${t.model("Book")} { title: string; }
+      `,
+    );
+
+    const engine = createGraphQLMutationEngine(tester.program);
+    const mutated = engine.mutateModel(Book, GraphQLTypeContext.Input).mutatedType;
+
+    const sdl = renderToSDL(tester.program, <InputType type={mutated} />);
+
+    expect(sdl).toContain('"Data for creating a book"');
+    expect(sdl).toMatch(/input BookInput \{/);
+  });
+
+  it("renders oneOf input type with @oneOf directive", async () => {
+    const { SearchBy } = await tester.compile(
+      t.code`
+        union ${t.union("SearchBy")} { byName: string; byId: int32; }
+      `,
+    );
+
+    const engine = createGraphQLMutationEngine(tester.program);
+    const mutation = engine.mutateUnion(SearchBy, GraphQLTypeContext.Input);
+    // In input context, union becomes a @oneOf Model
+    const mutated = mutation.mutatedType as Model;
+
+    const sdl = renderToSDL(tester.program, <InputType type={mutated} />);
+
+    expect(sdl).toMatch(/input SearchByInput @oneOf \{/);
+  });
+
+  it("renders input type with optional fields", async () => {
+    const { Filter } = await tester.compile(
+      t.code`model ${t.model("Filter")} { name?: string; limit?: int32; }`,
+    );
+
+    const engine = createGraphQLMutationEngine(tester.program);
+    const mutated = engine.mutateModel(Filter, GraphQLTypeContext.Input).mutatedType;
+
+    const sdl = renderToSDL(tester.program, <InputType type={mutated} />);
+
+    // Optional fields are nullable (no !)
+    expect(sdl).toContain("name: String");
+    expect(sdl).not.toContain("name: String!");
+  });
+});

--- a/packages/graphql/test/components/interface-type.test.tsx
+++ b/packages/graphql/test/components/interface-type.test.tsx
@@ -1,0 +1,57 @@
+import { t } from "@typespec/compiler/testing";
+import { beforeEach, describe, expect, it } from "vitest";
+import { InterfaceType } from "../../src/components/types/index.js";
+import { createGraphQLMutationEngine, GraphQLTypeContext } from "../../src/mutation-engine/index.js";
+import { Tester } from "../test-host.js";
+import { renderToSDL } from "./test-utils.js";
+
+describe("InterfaceType component", () => {
+  let tester: Awaited<ReturnType<typeof Tester.createInstance>>;
+  beforeEach(async () => {
+    tester = await Tester.createInstance();
+  });
+
+  it("renders a basic interface type", async () => {
+    const { Node } = await tester.compile(
+      t.code`@Interface model ${t.model("Node")} { id: string; }`,
+    );
+
+    const engine = createGraphQLMutationEngine(tester.program);
+    const mutated = engine.mutateModel(Node, GraphQLTypeContext.Interface).mutatedType;
+
+    const sdl = renderToSDL(tester.program, <InterfaceType type={mutated} />);
+
+    expect(sdl).toMatch(/interface NodeInterface \{/);
+    expect(sdl).toContain("id: String!");
+  });
+
+  it("renders exclusive interface without suffix", async () => {
+    const { Node } = await tester.compile(
+      t.code`@Interface(#{exclusive: true}) model ${t.model("Node")} { id: string; }`,
+    );
+
+    const engine = createGraphQLMutationEngine(tester.program);
+    const mutated = engine.mutateModel(Node, GraphQLTypeContext.Interface).mutatedType;
+
+    const sdl = renderToSDL(tester.program, <InterfaceType type={mutated} />);
+
+    expect(sdl).toMatch(/interface Node \{/);
+    expect(sdl).not.toContain("NodeInterface");
+  });
+
+  it("renders interface with doc comment", async () => {
+    const { Node } = await tester.compile(
+      t.code`
+        /** A uniquely identifiable entity */
+        @Interface model ${t.model("Node")} { id: string; }
+      `,
+    );
+
+    const engine = createGraphQLMutationEngine(tester.program);
+    const mutated = engine.mutateModel(Node, GraphQLTypeContext.Interface).mutatedType;
+
+    const sdl = renderToSDL(tester.program, <InterfaceType type={mutated} />);
+
+    expect(sdl).toContain('"A uniquely identifiable entity"');
+  });
+});

--- a/packages/graphql/test/components/object-type.test.tsx
+++ b/packages/graphql/test/components/object-type.test.tsx
@@ -1,0 +1,86 @@
+import { type Model } from "@typespec/compiler";
+import { t } from "@typespec/compiler/testing";
+import { beforeEach, describe, expect, it } from "vitest";
+import { InterfaceType, ObjectType } from "../../src/components/types/index.js";
+import { createGraphQLMutationEngine, GraphQLTypeContext } from "../../src/mutation-engine/index.js";
+import { Tester } from "../test-host.js";
+import { renderToSDL } from "./test-utils.js";
+
+describe("ObjectType component", () => {
+  let tester: Awaited<ReturnType<typeof Tester.createInstance>>;
+  beforeEach(async () => {
+    tester = await Tester.createInstance();
+  });
+
+  it("renders a basic object type with fields", async () => {
+    const { Book } = await tester.compile(
+      t.code`model ${t.model("Book")} { title: string; year: int32; }`,
+    );
+
+    const engine = createGraphQLMutationEngine(tester.program);
+    const mutated = engine.mutateModel(Book, GraphQLTypeContext.Output).mutatedType;
+
+    const sdl = renderToSDL(tester.program, <ObjectType type={mutated} />);
+
+    expect(sdl).toMatch(/type Book \{/);
+    expect(sdl).toContain("title: String!");
+    expect(sdl).toContain("year: Int!");
+  });
+
+  it("renders object type with doc comment", async () => {
+    const { Book } = await tester.compile(
+      t.code`
+        /** A published book */
+        model ${t.model("Book")} { title: string; }
+      `,
+    );
+
+    const engine = createGraphQLMutationEngine(tester.program);
+    const mutated = engine.mutateModel(Book, GraphQLTypeContext.Output).mutatedType;
+
+    const sdl = renderToSDL(tester.program, <ObjectType type={mutated} />);
+
+    expect(sdl).toContain('"A published book"');
+    expect(sdl).toMatch(/type Book \{/);
+  });
+
+  it("renders object type with optional fields as nullable", async () => {
+    const { User } = await tester.compile(
+      t.code`model ${t.model("User")} { name: string; nickname?: string; }`,
+    );
+
+    const engine = createGraphQLMutationEngine(tester.program);
+    const mutated = engine.mutateModel(User, GraphQLTypeContext.Output).mutatedType;
+
+    const sdl = renderToSDL(tester.program, <ObjectType type={mutated} />);
+
+    expect(sdl).toContain("name: String!");
+    expect(sdl).toContain("nickname: String");
+    // nickname should NOT have ! (it's optional/nullable)
+    expect(sdl).not.toContain("nickname: String!");
+  });
+
+  it("renders object type implementing interfaces", async () => {
+    const { Cat, Animal } = await tester.compile(
+      t.code`
+        @Interface model ${t.model("Animal")} { name: string; }
+        @compose(Animal)
+        model ${t.model("Cat")} { name: string; breed: string; }
+      `,
+    );
+
+    const engine = createGraphQLMutationEngine(tester.program);
+    const mutatedCat = engine.mutateModel(Cat, GraphQLTypeContext.Output).mutatedType;
+    const mutatedAnimal = engine.mutateModel(Animal, GraphQLTypeContext.Interface).mutatedType;
+
+    const sdl = renderToSDL(
+      tester.program,
+      <>
+        <InterfaceType type={mutatedAnimal} />
+        <ObjectType type={mutatedCat} />
+      </>,
+    );
+
+    expect(sdl).toMatch(/type Cat implements AnimalInterface \{/);
+  });
+});

--- a/packages/graphql/test/mutation-engine/schema-mutator.test.ts
+++ b/packages/graphql/test/mutation-engine/schema-mutator.test.ts
@@ -230,6 +230,53 @@ describe("mutateSchema", () => {
     expect(isInputType(bookInput)).toBe(true);
   });
 
+  it("mutateDecoratorTypeArgs does not corrupt source type decorator args", async () => {
+    await tester.compile(
+      t.code`
+        @Interface model ${t.model("Animal")} { name: string; }
+        @compose(Animal)
+        model ${t.model("Cat")} { name: string; breed: string; }
+        op ${t.op("getCat")}(): Cat;
+        op ${t.op("createCat")}(input: Cat): Cat;
+      `,
+    );
+
+    const ns = tester.program.getGlobalNamespaceType();
+    const sourceCat = ns.models.get("Cat")!;
+    const sourceComposeArg = sourceCat.decorators.find(
+      (d) => d.decorator.name === "$compose",
+    )?.args[0];
+
+    const typeUsage = resolveTypeUsage(ns, true);
+    const engine = createGraphQLMutationEngine(tester.program);
+    mutateSchema(tester.program, engine, ns, typeUsage);
+
+    // Source type's decorator args must not be modified by mutation
+    expect((sourceComposeArg!.value as any).name).toBe("Animal");
+  });
+
+  it("exclusive @Interface model used as output does not produce name collision", async () => {
+    await tester.compile(
+      t.code`
+        @Interface(#{exclusive: true}) model ${t.model("Node")} { id: string; }
+        op ${t.op("getNode")}(): Node;
+      `,
+    );
+
+    const ns = tester.program.getGlobalNamespaceType();
+    const typeUsage = resolveTypeUsage(ns, true);
+    const engine = createGraphQLMutationEngine(tester.program);
+    const typeGraph = mutateSchema(tester.program, engine, ns, typeUsage);
+
+    // Exclusive interface: only Interface variant emitted (no suffix → "Node")
+    // Should NOT also emit an Output variant (which would also be "Node" → collision)
+    expect(typeGraph.globalNamespace.models.has("Node")).toBe(true);
+    const collisions = tester.program.diagnostics.filter(
+      (d) => d.code === "@typespec/graphql/type-name-collision",
+    );
+    expect(collisions.length).toBe(0);
+  });
+
   it("reports diagnostic when two types produce the same GraphQL name", async () => {
     const [_, diagnostics] = await tester.compileAndDiagnose(
       t.code`

--- a/packages/graphql/test/mutation-engine/schema-mutator.test.ts
+++ b/packages/graphql/test/mutation-engine/schema-mutator.test.ts
@@ -1,5 +1,6 @@
 import { t } from "@typespec/compiler/testing";
 import { beforeEach, describe, expect, it } from "vitest";
+import { isInputType } from "../../src/lib/input-type.js";
 import { createGraphQLMutationEngine } from "../../src/mutation-engine/index.js";
 import { mutateSchema } from "../../src/mutation-engine/schema-mutator.js";
 import { resolveTypeUsage } from "../../src/type-usage.js";
@@ -206,6 +207,27 @@ describe("mutateSchema", () => {
     expect(typeGraph.globalNamespace.models.has("PayloadInput")).toBe(true);
     // Should NOT have an Output variant
     expect(typeGraph.globalNamespace.models.has("Payload")).toBe(false);
+  });
+
+  it("marks input models with isInputType decorator", async () => {
+    await tester.compile(
+      t.code`
+        model ${t.model("Book")} { title: string; }
+        op ${t.op("getBooks")}(): Book[];
+        op ${t.op("createBook")}(input: Book): Book;
+      `,
+    );
+
+    const ns = tester.program.getGlobalNamespaceType();
+    const typeUsage = resolveTypeUsage(ns, false);
+    const engine = createGraphQLMutationEngine(tester.program);
+    const typeGraph = mutateSchema(tester.program, engine, ns, typeUsage);
+
+    const bookOutput = typeGraph.globalNamespace.models.get("Book")!;
+    const bookInput = typeGraph.globalNamespace.models.get("BookInput")!;
+
+    expect(isInputType(bookOutput)).toBe(false);
+    expect(isInputType(bookInput)).toBe(true);
   });
 
   it("reports diagnostic when two types produce the same GraphQL name", async () => {


### PR DESCRIPTION
## Summary

- **ObjectType** component: renders `gql.ObjectType` with fields and `implements` clause from `@compose`
- **InterfaceType** component: renders `gql.InterfaceType` with fields
- **InputType** component: renders `gql.InputObjectType` with `@oneOf` support
- **`GraphQLTypeContext.Interface`**: third mutation context for interface declarations (separate cache slot)
- **`@Interface(#{exclusive: true})`**: skip Interface suffix for models that are only interfaces (e.g., Node)
- **`@inputType` synthetic decorator**: marks input-context models for renderer classification
- **`decoratorArgContext` registry**: maps decorator function names to their arg mutation context, so `@compose` args automatically resolve to Interface-suffixed names
- **Schema-mutator**: `@Interface` models always get an Interface mutation; Output/Input only if actually used

## Architecture decisions applied

- Components are thin wrappers around `@alloy-js/graphql`
- Classification at render time via `isInterface`/`isInputType`/`isOneOf`
- All mutation in Phase 1: decorator arg resolution happens in `mutateDecoratorTypeArgs` before `finishType`

## Test plan

- [x] ObjectType: 4 tests (basic, doc, optional fields, implements)
- [x] InterfaceType: 3 tests (exclusive, basic, doc)
- [x] InputType: 4 tests (basic, doc, oneOf, optional fields)
- [x] Schema-mutator: isInputType marker test
- [x] All 241 tests pass
- [x] `tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)