### PR TITLE
Add visibility filtering with operation-kind-aware input splitting

### DIFF
--- a/packages/graphql/src/emitter.tsx
+++ b/packages/graphql/src/emitter.tsx
@@ -49,7 +49,7 @@ function buildSchema(
   const program = context.program;
   const omitUnreachable = context.options["omit-unreachable-types"] ?? false;
 
-  const typeUsage = resolveTypeUsage(schema, omitUnreachable);
+  const typeUsage = resolveTypeUsage(program, schema, omitUnreachable);
   const engine = createGraphQLMutationEngine(program);
   const typeGraph = mutateSchema(program, engine, schema, typeUsage);
 

--- a/packages/graphql/src/lib/naming.ts
+++ b/packages/graphql/src/lib/naming.ts
@@ -3,6 +3,7 @@ import { camelCase, constantCase, pascalCase, split, splitSeparateNumbers } from
 export interface NamingContext {
   isInput: boolean;
   isInterface: boolean;
+  inputQualifier?: string;
 }
 
 type NameTransform = (name: string, context: NamingContext) => string;
@@ -64,7 +65,9 @@ function applyInterfaceSuffix(name: string, context: NamingContext): string {
 
 function applyInputSuffix(name: string, context: NamingContext): string {
   if (!context.isInput) return name;
-  return name.endsWith("Input") ? name : name + "Input";
+  const qualifier = context.inputQualifier ?? "";
+  const suffix = `${qualifier}Input`;
+  return name.endsWith(suffix) ? name : name + suffix;
 }
 
 const baseNamePipeline: NameTransform[] = [stripNamespace, sanitizeForGraphQL, toPascalCase];

--- a/packages/graphql/src/lib/visibility.ts
+++ b/packages/graphql/src/lib/visibility.ts
@@ -1,0 +1,35 @@
+import {
+  getLifecycleVisibilityEnum,
+  isVisible,
+  type ModelProperty,
+  type Program,
+  type VisibilityFilter,
+} from "@typespec/compiler";
+
+export interface GraphQLVisibilityFilters {
+  query: VisibilityFilter;
+  mutation: VisibilityFilter;
+  output: VisibilityFilter;
+}
+
+export function createVisibilityFilters(program: Program): GraphQLVisibilityFilters {
+  const lifecycleEnum = getLifecycleVisibilityEnum(program);
+  const createMember = lifecycleEnum.members.get("Create")!;
+  const readMember = lifecycleEnum.members.get("Read")!;
+  const updateMember = lifecycleEnum.members.get("Update")!;
+  const queryMember = lifecycleEnum.members.get("Query")!;
+
+  return {
+    query: { any: new Set([readMember, queryMember]) },
+    mutation: { any: new Set([createMember, updateMember]) },
+    output: { any: new Set([readMember]) },
+  };
+}
+
+export function isPropertyVisible(
+  program: Program,
+  property: ModelProperty,
+  filter: VisibilityFilter,
+): boolean {
+  return isVisible(program, property, filter);
+}

--- a/packages/graphql/src/mutation-engine/engine.ts
+++ b/packages/graphql/src/mutation-engine/engine.ts
@@ -5,7 +5,9 @@ import {
   type Program,
   type Scalar,
   type Union,
+  type VisibilityFilter,
 } from "@typespec/compiler";
+
 import { $ } from "@typespec/compiler/typekit";
 import {
   MutationEngine,
@@ -69,12 +71,21 @@ export class GraphQLMutationEngine {
   }
 
   /**
-   * Mutate a model with explicit input/output context.
+   * Mutate a model with explicit input/output context and optional visibility filter.
    * Models mutated with different contexts produce separate cached mutations,
    * allowing the same source model to have both an input and output variant.
    */
-  mutateModel(model: Model, context: GraphQLTypeContext): GraphQLModelMutation {
-    return this.engine.mutate(model, new GraphQLMutationOptions(context)) as GraphQLModelMutation;
+  mutateModel(
+    model: Model,
+    context: GraphQLTypeContext,
+    visibilityFilter?: VisibilityFilter,
+    operationKind?: string,
+    inputQualifier?: string,
+  ): GraphQLModelMutation {
+    return this.engine.mutate(
+      model,
+      new GraphQLMutationOptions(context, visibilityFilter, operationKind, inputQualifier),
+    ) as GraphQLModelMutation;
   }
 
   /**

--- a/packages/graphql/src/mutation-engine/mutations/model.ts
+++ b/packages/graphql/src/mutation-engine/mutations/model.ts
@@ -8,6 +8,7 @@ import {
   type Value,
 } from "@typespec/compiler";
 import {
+  type MutationOptions,
   SimpleModelMutation,
   type MutationInfo,
   type SimpleMutationEngine,
@@ -18,6 +19,7 @@ import { isInterfaceOnly } from "../../lib/interface.js";
 import { applyTypeNamePipeline } from "../../lib/naming.js";
 import { composeTemplateName } from "../../lib/template-composition.js";
 import { isRecordType } from "../../lib/type-utils.js";
+import { isPropertyVisible } from "../../lib/visibility.js";
 import { GraphQLMutationOptions, GraphQLTypeContext } from "../options.js";
 
 /**
@@ -88,14 +90,51 @@ export class GraphQLModelMutation extends SimpleModelMutation<SimpleMutationOpti
     const needsInterfaceSuffix =
       isInterfaceContext && !isInterfaceOnly(program, this.sourceType);
 
+    const inputQualifier =
+      this.options instanceof GraphQLMutationOptions ? this.options.inputQualifier : undefined;
+
     this.mutationNode.mutate((model) => {
       model.name = applyTypeNamePipeline(rawName, {
         isInput: isInputContext,
         isInterface: needsInterfaceSuffix,
+        inputQualifier,
       });
-      this.mutateDecoratorTypeArgs(model);
+      if (isInputContext) {
+        model.decorators = model.decorators.filter(
+          (d) => !decoratorArgContext.has(d.decorator.name),
+        );
+      } else {
+        this.mutateDecoratorTypeArgs(model);
+      }
     });
     super.mutate();
+  }
+
+  protected override mutateProperties(newOptions: MutationOptions = this.options) {
+    const visibilityFilter = this.options instanceof GraphQLMutationOptions
+      ? this.options.visibilityFilter
+      : undefined;
+
+    if (!visibilityFilter) {
+      super.mutateProperties(newOptions);
+      return;
+    }
+
+    const program = this.engine.$.program;
+
+    for (const prop of this.sourceType.properties.values()) {
+      if (!isPropertyVisible(program, prop, visibilityFilter)) {
+        this.mutationNode.mutatedType.properties.delete(prop.name);
+      }
+    }
+    for (const prop of this.sourceType.properties.values()) {
+      if (isPropertyVisible(program, prop, visibilityFilter)) {
+        this.properties.set(
+          prop.name,
+          this.engine.mutate(prop, newOptions, this.startPropertyEdge()),
+        );
+      }
+    }
   }
 
   private mutateDecoratorTypeArgs(model: Model) {

--- a/packages/graphql/src/mutation-engine/mutations/operation.ts
+++ b/packages/graphql/src/mutation-engine/mutations/operation.ts
@@ -9,6 +9,8 @@ import {
 import { applyFieldNamePipeline } from "../../lib/naming.js";
 import { setNullable, setNullableElements } from "../../lib/nullable.js";
 import { isNullableUnion, unwrapNullableUnion } from "../../lib/type-utils.js";
+import { getOperationKind } from "../../lib/operation-kind.js";
+import { createVisibilityFilters } from "../../lib/visibility.js";
 import { GraphQLMutationOptions, GraphQLTypeContext } from "../options.js";
 
 /** GraphQL-specific Operation mutation. */
@@ -23,9 +25,17 @@ export class GraphQLOperationMutation extends SimpleOperationMutation<SimpleMuta
     super(engine, sourceType, referenceTypes, options, info);
   }
 
-  /** Mutate parameters with input context. */
+  /** Mutate parameters with input context and operation-kind-aware visibility. */
   protected override mutateParameters() {
-    const inputOptions = new GraphQLMutationOptions(GraphQLTypeContext.Input);
+    const program = this.engine.$.program;
+    const kind = getOperationKind(program, this.sourceType);
+    const filters = createVisibilityFilters(program);
+    const isQuery = kind === "Query" || kind === "Subscription";
+    const visibilityFilter = isQuery ? filters.query : filters.mutation;
+    const opKind = isQuery ? "query" : "mutation";
+    const inputOptions = new GraphQLMutationOptions(
+      GraphQLTypeContext.Input, visibilityFilter, opKind,
+    );
     this.parameters = this.engine.mutate(
       this.sourceType.parameters,
       inputOptions,
@@ -35,7 +45,9 @@ export class GraphQLOperationMutation extends SimpleOperationMutation<SimpleMuta
 
   /** Mutate return type with output context. */
   protected override mutateReturnType() {
-    const outputOptions = new GraphQLMutationOptions(GraphQLTypeContext.Output);
+    const program = this.engine.$.program;
+    const filters = createVisibilityFilters(program);
+    const outputOptions = new GraphQLMutationOptions(GraphQLTypeContext.Output, filters.output);
     this.returnType = this.engine.mutate(
       this.sourceType.returnType,
       outputOptions,

--- a/packages/graphql/src/mutation-engine/options.ts
+++ b/packages/graphql/src/mutation-engine/options.ts
@@ -1,3 +1,4 @@
+import type { VisibilityFilter } from "@typespec/compiler";
 import { SimpleMutationOptions } from "@typespec/mutator-framework";
 
 /**
@@ -14,19 +15,39 @@ export enum GraphQLTypeContext {
 }
 
 /**
- * Mutation options that carry input/output context through the type graph.
- * The mutationKey ensures the framework caches input and output variants
- * separately for the same source type.
+ * Mutation options that carry input/output context and visibility through the type graph.
+ * The mutationKey ensures the framework caches variants separately.
+ *
+ * @param typeContext - structural context (Input/Output/Interface)
+ * @param visibilityFilter - which properties to include (from compiler's VisibilityFilter)
+ * @param inputQualifier - when set, distinguishes cache entries and feeds the naming pipeline
+ *   (e.g., "Query" → UserQueryInput, "Mutation" → UserMutationInput)
  */
 export class GraphQLMutationOptions extends SimpleMutationOptions {
   readonly typeContext: GraphQLTypeContext;
+  readonly visibilityFilter?: VisibilityFilter;
+  /** Cache key discriminator — always set for input variants ("query" or "mutation"). */
+  readonly operationKind?: string;
+  /** Naming qualifier — only set when operation variance requires distinct type names. */
+  readonly inputQualifier?: string;
 
-  constructor(typeContext: GraphQLTypeContext) {
+  constructor(
+    typeContext: GraphQLTypeContext,
+    visibilityFilter?: VisibilityFilter,
+    operationKind?: string,
+    inputQualifier?: string,
+  ) {
     super();
     this.typeContext = typeContext;
+    this.visibilityFilter = visibilityFilter;
+    this.operationKind = operationKind;
+    this.inputQualifier = inputQualifier;
   }
 
   override get mutationKey(): string {
+    if (this.operationKind) {
+      return `${this.typeContext}-${this.operationKind}`;
+    }
     return this.typeContext;
   }
 }

--- a/packages/graphql/src/mutation-engine/schema-mutator.ts
+++ b/packages/graphql/src/mutation-engine/schema-mutator.ts
@@ -15,6 +15,7 @@ import { setInputType } from "../lib/input-type.js";
 import { isInterface } from "../lib/interface.js";
 import { getOperationFields } from "../lib/operation-fields.js";
 import { reportDiagnostic } from "../lib.js";
+import { createVisibilityFilters } from "../lib/visibility.js";
 import { GraphQLTypeUsage, type TypeUsageResolver } from "../type-usage.js";
 import type { GraphQLMutationEngine } from "./engine.js";
 import { GraphQLTypeContext } from "./options.js";
@@ -38,6 +39,7 @@ export function mutateSchema(
 ): TypeGraph {
   const tk = $(program);
   const mutatedTypes: Type[] = [];
+  const filters = createVisibilityFilters(program);
 
   navigateTypesInNamespace(schema, {
     model: (node: Model) => {
@@ -54,7 +56,7 @@ export function mutateSchema(
         mutatedTypes.push(mutation.mutatedType);
       }
       if (!isInterfaceModel && (usedAsOutput || !usage)) {
-        const mutation = engine.mutateModel(node, GraphQLTypeContext.Output);
+        const mutation = engine.mutateModel(node, GraphQLTypeContext.Output, filters.output);
         mutatedTypes.push(mutation.mutatedType);
       }
       if (usedAsInput) {
@@ -65,9 +67,33 @@ export function mutateSchema(
             target: node,
           });
         }
-        const mutation = engine.mutateModel(node, GraphQLTypeContext.Input);
-        setInputType(mutation.mutatedType);
-        mutatedTypes.push(mutation.mutatedType);
+        const hasVariance = typeUsage.hasInputOperationVariance(node);
+        const usedByQuery = usage?.has(GraphQLTypeUsage.InputQuery) ?? false;
+        const usedByMutation = usage?.has(GraphQLTypeUsage.InputMutation) ?? false;
+
+        if (hasVariance) {
+          // Different property sets per operation kind — emit both with qualified names.
+          const qm = engine.mutateModel(node, GraphQLTypeContext.Input, filters.query, "query", "Query");
+          const mm = engine.mutateModel(node, GraphQLTypeContext.Input, filters.mutation, "mutation", "Mutation");
+          setInputType(qm.mutatedType);
+          setInputType(mm.mutatedType);
+          mutatedTypes.push(qm.mutatedType);
+          mutatedTypes.push(mm.mutatedType);
+        } else {
+          // Same property sets — one input type, but create cache entries for each
+          // operation kind so operations can resolve their references.
+          const emitted = usedByMutation
+            ? engine.mutateModel(node, GraphQLTypeContext.Input, filters.mutation, "mutation")
+            : engine.mutateModel(node, GraphQLTypeContext.Input, filters.query, "query");
+          setInputType(emitted.mutatedType);
+          mutatedTypes.push(emitted.mutatedType);
+
+          if (usedByQuery && usedByMutation) {
+            setInputType(
+              engine.mutateModel(node, GraphQLTypeContext.Input, filters.query, "query").mutatedType,
+            );
+          }
+        }
       }
     },
     enum: (node: Enum) => {

--- a/packages/graphql/src/type-usage.ts
+++ b/packages/graphql/src/type-usage.ts
@@ -1,10 +1,14 @@
 import {
   isArrayModelType,
   navigateTypesInNamespace,
+  type Model,
   type Namespace,
   type Operation,
+  type Program,
   type Type,
 } from "@typespec/compiler";
+import { getOperationKind, type GraphQLOperationKind } from "./lib/operation-kind.js";
+import { createVisibilityFilters, isPropertyVisible } from "./lib/visibility.js";
 
 /**
  * GraphQL-specific flags for type usage tracking (input vs output).
@@ -12,41 +16,56 @@ import {
 export enum GraphQLTypeUsage {
   /** Type is used as an input (operation parameter or nested within one) */
   Input = "Input",
+  /** Type is used as an input to a @query or @subscription operation */
+  InputQuery = "InputQuery",
+  /** Type is used as an input to a @mutation operation */
+  InputMutation = "InputMutation",
   /** Type is used as an output (operation return type or nested within one) */
   Output = "Output",
 }
 
 export interface TypeUsageResolver {
-  /** Get the set of usage flags for a type, or undefined if never referenced by an operation */
   getUsage(type: Type): Set<GraphQLTypeUsage> | undefined;
-  /** Returns true if the type should not be included in the schema */
   isUnreachable(type: Type): boolean;
+  /**
+   * Returns true if the model is used by both @query and @mutation operations
+   * AND the visibility filters produce different property sets for each context.
+   * When true, two separate input types are needed (e.g., UserQueryInput + UserMutationInput).
+   */
+  hasInputOperationVariance(type: Type): boolean;
 }
 
-/**
- * Walk all operations in a namespace tree to determine type reachability and
- * input/output classification.
- *
- * Produces two independent results:
- * - **Reachability**: whether a type should be included in the emitted schema.
- * - **Usage**: whether a type is used as Input, Output, or both.
- *
- * When `omitUnreachableTypes` is false, all types declared in the namespace
- * are considered reachable regardless of whether an operation references them.
- */
 export function resolveTypeUsage(
+  program: Program,
   root: Namespace,
   omitUnreachableTypes: boolean,
 ): TypeUsageResolver {
-  // Two independent concerns tracked in a single walk:
-  //   reachableTypes — should this type appear in the schema?
-  //   usages         — is this type used as Input, Output, or both?
   const reachableTypes = new Set<Type>();
   const usages = new Map<Type, Set<GraphQLTypeUsage>>();
+  const inputOperationVariance = new Set<Type>();
 
-  addUsagesInNamespace(root, reachableTypes, usages);
+  addUsagesInNamespace(program, root, reachableTypes, usages);
 
-  // When all declared types should be emitted, mark them reachable.
+  // Pre-compute which models need split input types
+  const filters = createVisibilityFilters(program);
+  for (const [type, usage] of usages) {
+    if (
+      type.kind === "Model" &&
+      usage.has(GraphQLTypeUsage.InputQuery) &&
+      usage.has(GraphQLTypeUsage.InputMutation)
+    ) {
+      const queryVisible = new Set<string>();
+      const mutationVisible = new Set<string>();
+      for (const prop of type.properties.values()) {
+        if (isPropertyVisible(program, prop, filters.query)) queryVisible.add(prop.name);
+        if (isPropertyVisible(program, prop, filters.mutation)) mutationVisible.add(prop.name);
+      }
+      if (queryVisible.size !== mutationVisible.size || ![...queryVisible].every(k => mutationVisible.has(k))) {
+        inputOperationVariance.add(type);
+      }
+    }
+  }
+
   if (!omitUnreachableTypes) {
     const markReachable = (type: Type) => {
       reachableTypes.add(type);
@@ -62,6 +81,7 @@ export function resolveTypeUsage(
   return {
     getUsage: (type: Type) => usages.get(type),
     isUnreachable: (type: Type) => !reachableTypes.has(type),
+    hasInputOperationVariance: (type: Type) => inputOperationVariance.has(type),
   };
 }
 
@@ -77,46 +97,45 @@ function trackUsage(
   usages.set(type, existing);
 }
 
-/**
- * Recursively walk a namespace and all sub-namespaces, tracking type usage
- * from operations.
- */
 function addUsagesInNamespace(
+  program: Program,
   namespace: Namespace,
   reachableTypes: Set<Type>,
   usages: Map<Type, Set<GraphQLTypeUsage>>,
 ): void {
   for (const subNamespace of namespace.namespaces.values()) {
-    addUsagesInNamespace(subNamespace, reachableTypes, usages);
+    addUsagesInNamespace(program, subNamespace, reachableTypes, usages);
   }
   for (const iface of namespace.interfaces.values()) {
     for (const operation of iface.operations.values()) {
-      addUsagesFromOperation(operation, reachableTypes, usages);
+      addUsagesFromOperation(program, operation, reachableTypes, usages);
     }
   }
   for (const operation of namespace.operations.values()) {
-    addUsagesFromOperation(operation, reachableTypes, usages);
+    addUsagesFromOperation(program, operation, reachableTypes, usages);
   }
 }
 
-/**
- * For a single operation, mark parameter types as Input and return type as Output.
- */
+function inputUsageForKind(kind: GraphQLOperationKind | undefined): GraphQLTypeUsage {
+  if (kind === "Query" || kind === "Subscription") return GraphQLTypeUsage.InputQuery;
+  return GraphQLTypeUsage.InputMutation;
+}
+
 function addUsagesFromOperation(
+  program: Program,
   operation: Operation,
   reachableTypes: Set<Type>,
   usages: Map<Type, Set<GraphQLTypeUsage>>,
 ): void {
+  const kind = getOperationKind(program, operation);
+  const inputUsage = inputUsageForKind(kind);
   for (const param of operation.parameters.properties.values()) {
     navigateReferencedTypes(param.type, GraphQLTypeUsage.Input, reachableTypes, usages);
+    navigateReferencedTypes(param.type, inputUsage, reachableTypes, usages);
   }
   navigateReferencedTypes(operation.returnType, GraphQLTypeUsage.Output, reachableTypes, usages);
 }
 
-/**
- * Recursively walk a type graph, tracking reachability and usage classification.
- * Handles circular references via a visited set.
- */
 function navigateReferencedTypes(
   type: Type,
   usage: GraphQLTypeUsage,
@@ -134,9 +153,6 @@ function navigateReferencedTypes(
           navigateReferencedTypes(type.indexer.value, usage, reachableTypes, usages, visited);
         }
       } else {
-        // Note: Record<K, V> models land here but their indexer value type
-        // is not navigated. That's intentional — we don't support Record
-        // types in GraphQL.
         trackUsage(reachableTypes, usages, type, usage);
         for (const prop of type.properties.values()) {
           navigateReferencedTypes(prop.type, usage, reachableTypes, usages, visited);

--- a/packages/graphql/test/e2e.test.ts
+++ b/packages/graphql/test/e2e.test.ts
@@ -788,3 +788,188 @@ describe("e2e: TypeSpec interface keyword prefixes operations", () => {
     `);
   });
 });
+
+describe("e2e: visibility filtering", () => {
+  it("excludes read-only properties from input type", async () => {
+    const result = await emitSingleSchemaWithDiagnostics(`
+      @schema namespace Test {
+        model Board {
+          @visibility(Lifecycle.Read)
+          id: string;
+
+          @visibility(Lifecycle.Read)
+          createdAt: string;
+
+          name: string;
+          description: string;
+        }
+        @query op getBoard(id: string): Board;
+        @mutation op createBoard(input: Board): Board;
+      }
+    `);
+    expect(result.graphQLOutput).toMatchInlineSnapshot(`
+      "type Board {
+        id: String!
+        createdAt: String!
+        name: String!
+        description: String!
+      }
+
+      input BoardInput {
+        name: String!
+        description: String!
+      }
+
+      type Query {
+        getBoard(id: String!): Board!
+      }
+
+      type Mutation {
+        createBoard(input: BoardInput!): Board!
+      }"
+    `);
+  });
+
+  it("excludes create-only properties from output type", async () => {
+    const result = await emitSingleSchemaWithDiagnostics(`
+      @schema namespace Test {
+        model User {
+          @visibility(Lifecycle.Read)
+          id: string;
+
+          @visibility(Lifecycle.Create)
+          password: string;
+
+          name: string;
+        }
+        @query op getUser(id: string): User;
+        @mutation op createUser(input: User): User;
+      }
+    `);
+    expect(result.graphQLOutput).toMatchInlineSnapshot(`
+      "type User {
+        id: String!
+        name: String!
+      }
+
+      input UserInput {
+        password: String!
+        name: String!
+      }
+
+      type Query {
+        getUser(id: String!): User!
+      }
+
+      type Mutation {
+        createUser(input: UserInput!): User!
+      }"
+    `);
+  });
+
+  it("includes all properties when no visibility decorator is set", async () => {
+    const result = await emitSingleSchemaWithDiagnostics(`
+      @schema namespace Test {
+        model Item {
+          name: string;
+          count: int32;
+        }
+        @query op getItem(): Item;
+        @mutation op createItem(input: Item): Item;
+      }
+    `);
+    expect(result.graphQLOutput).toMatchInlineSnapshot(`
+      "type Item {
+        name: String!
+        count: Int!
+      }
+
+      input ItemInput {
+        name: String!
+        count: Int!
+      }
+
+      type Query {
+        getItem: Item!
+      }
+
+      type Mutation {
+        createItem(input: ItemInput!): Item!
+      }"
+    `);
+  });
+
+  it("splits input types when query and mutation have different visible properties", async () => {
+    const result = await emitSingleSchemaWithDiagnostics(`
+      @schema namespace Test {
+        model User {
+          @visibility(Lifecycle.Read, Lifecycle.Query)
+          id: string;
+
+          @visibility(Lifecycle.Create, Lifecycle.Update)
+          password: string;
+
+          name: string;
+        }
+        @query op getUser(filter: User): User;
+        @mutation op createUser(input: User): User;
+      }
+    `);
+    expect(result.graphQLOutput).toMatchInlineSnapshot(`
+      "type User {
+        id: String!
+        name: String!
+      }
+
+      input UserQueryInput {
+        id: String!
+        name: String!
+      }
+
+      input UserMutationInput {
+        password: String!
+        name: String!
+      }
+
+      type Query {
+        getUser(filter: UserQueryInput!): User!
+      }
+
+      type Mutation {
+        createUser(input: UserMutationInput!): User!
+      }"
+    `);
+  });
+
+  it("does not split input types when visibility produces same properties", async () => {
+    const result = await emitSingleSchemaWithDiagnostics(`
+      @schema namespace Test {
+        model Item {
+          name: string;
+          count: int32;
+        }
+        @query op searchItems(filter: Item): Item[];
+        @mutation op createItem(input: Item): Item;
+      }
+    `);
+    expect(result.graphQLOutput).toMatchInlineSnapshot(`
+      "type Item {
+        name: String!
+        count: Int!
+      }
+
+      input ItemInput {
+        name: String!
+        count: Int!
+      }
+
+      type Query {
+        searchItems(filter: ItemInput!): [Item!]!
+      }
+
+      type Mutation {
+        createItem(input: ItemInput!): Item!
+      }"
+    `);
+  });
+});

--- a/packages/graphql/test/mutation-engine/schema-mutator.test.ts
+++ b/packages/graphql/test/mutation-engine/schema-mutator.test.ts
@@ -21,7 +21,7 @@ describe("mutateSchema", () => {
     );
 
     const ns = tester.program.getGlobalNamespaceType();
-    const typeUsage = resolveTypeUsage(ns, false);
+    const typeUsage = resolveTypeUsage(tester.program, ns, false);
     const engine = createGraphQLMutationEngine(tester.program);
     const typeGraph = mutateSchema(tester.program, engine, ns, typeUsage);
 
@@ -36,7 +36,7 @@ describe("mutateSchema", () => {
     );
 
     const ns = tester.program.getGlobalNamespaceType();
-    const typeUsage = resolveTypeUsage(ns, false);
+    const typeUsage = resolveTypeUsage(tester.program, ns, false);
     const engine = createGraphQLMutationEngine(tester.program);
     const typeGraph = mutateSchema(tester.program, engine, ns, typeUsage);
 
@@ -53,7 +53,7 @@ describe("mutateSchema", () => {
     );
 
     const ns = tester.program.getGlobalNamespaceType();
-    const typeUsage = resolveTypeUsage(ns, false);
+    const typeUsage = resolveTypeUsage(tester.program, ns, false);
     const engine = createGraphQLMutationEngine(tester.program);
     const typeGraph = mutateSchema(tester.program, engine, ns, typeUsage);
 
@@ -71,7 +71,7 @@ describe("mutateSchema", () => {
     );
 
     const ns = tester.program.getGlobalNamespaceType();
-    const typeUsage = resolveTypeUsage(ns, false);
+    const typeUsage = resolveTypeUsage(tester.program, ns, false);
     const engine = createGraphQLMutationEngine(tester.program);
     const typeGraph = mutateSchema(tester.program, engine, ns, typeUsage);
 
@@ -88,7 +88,7 @@ describe("mutateSchema", () => {
     );
 
     const ns = tester.program.getGlobalNamespaceType();
-    const typeUsage = resolveTypeUsage(ns, true);
+    const typeUsage = resolveTypeUsage(tester.program, ns, true);
     const engine = createGraphQLMutationEngine(tester.program);
     const typeGraph = mutateSchema(tester.program, engine, ns, typeUsage);
 
@@ -106,7 +106,7 @@ describe("mutateSchema", () => {
     );
 
     const ns = tester.program.getGlobalNamespaceType();
-    const typeUsage = resolveTypeUsage(ns, false);
+    const typeUsage = resolveTypeUsage(tester.program, ns, false);
     const engine = createGraphQLMutationEngine(tester.program);
     const typeGraph = mutateSchema(tester.program, engine, ns, typeUsage);
 
@@ -124,7 +124,7 @@ describe("mutateSchema", () => {
     );
 
     const ns = tester.program.getGlobalNamespaceType();
-    const typeUsage = resolveTypeUsage(ns, false);
+    const typeUsage = resolveTypeUsage(tester.program, ns, false);
     const engine = createGraphQLMutationEngine(tester.program);
     const typeGraph = mutateSchema(tester.program, engine, ns, typeUsage);
 
@@ -142,7 +142,7 @@ describe("mutateSchema", () => {
     );
 
     const ns = tester.program.getGlobalNamespaceType();
-    const typeUsage = resolveTypeUsage(ns, false);
+    const typeUsage = resolveTypeUsage(tester.program, ns, false);
     const engine = createGraphQLMutationEngine(tester.program);
     const typeGraph = mutateSchema(tester.program, engine, ns, typeUsage);
 
@@ -161,7 +161,7 @@ describe("mutateSchema", () => {
     );
 
     const ns = tester.program.getGlobalNamespaceType();
-    const typeUsage = resolveTypeUsage(ns, false);
+    const typeUsage = resolveTypeUsage(tester.program, ns, false);
     const engine = createGraphQLMutationEngine(tester.program);
     const typeGraph = mutateSchema(tester.program, engine, ns, typeUsage);
 
@@ -180,7 +180,7 @@ describe("mutateSchema", () => {
     );
 
     const ns = tester.program.getGlobalNamespaceType();
-    const typeUsage = resolveTypeUsage(ns, false);
+    const typeUsage = resolveTypeUsage(tester.program, ns, false);
     const engine = createGraphQLMutationEngine(tester.program);
     const typeGraph = mutateSchema(tester.program, engine, ns, typeUsage);
 
@@ -199,7 +199,7 @@ describe("mutateSchema", () => {
     );
 
     const ns = tester.program.getGlobalNamespaceType();
-    const typeUsage = resolveTypeUsage(ns, true);
+    const typeUsage = resolveTypeUsage(tester.program, ns, true);
     const engine = createGraphQLMutationEngine(tester.program);
     const typeGraph = mutateSchema(tester.program, engine, ns, typeUsage);
 
@@ -219,7 +219,7 @@ describe("mutateSchema", () => {
     );
 
     const ns = tester.program.getGlobalNamespaceType();
-    const typeUsage = resolveTypeUsage(ns, false);
+    const typeUsage = resolveTypeUsage(tester.program, ns, false);
     const engine = createGraphQLMutationEngine(tester.program);
     const typeGraph = mutateSchema(tester.program, engine, ns, typeUsage);
 
@@ -247,7 +247,7 @@ describe("mutateSchema", () => {
       (d) => d.decorator.name === "$compose",
     )?.args[0];
 
-    const typeUsage = resolveTypeUsage(ns, true);
+    const typeUsage = resolveTypeUsage(tester.program, ns, true);
     const engine = createGraphQLMutationEngine(tester.program);
     mutateSchema(tester.program, engine, ns, typeUsage);
 
@@ -264,7 +264,7 @@ describe("mutateSchema", () => {
     );
 
     const ns = tester.program.getGlobalNamespaceType();
-    const typeUsage = resolveTypeUsage(ns, true);
+    const typeUsage = resolveTypeUsage(tester.program, ns, true);
     const engine = createGraphQLMutationEngine(tester.program);
     const typeGraph = mutateSchema(tester.program, engine, ns, typeUsage);
 
@@ -291,7 +291,7 @@ describe("mutateSchema", () => {
     // BookInput declared explicitly → Output mutation → "BookInput"
     // This should produce a collision diagnostic
     const ns = tester.program.getGlobalNamespaceType();
-    const typeUsage = resolveTypeUsage(ns, false);
+    const typeUsage = resolveTypeUsage(tester.program, ns, false);
     const engine = createGraphQLMutationEngine(tester.program);
     mutateSchema(tester.program, engine, ns, typeUsage);
 
@@ -310,7 +310,7 @@ describe("mutateSchema", () => {
     );
 
     const ns = tester.program.getGlobalNamespaceType();
-    const typeUsage = resolveTypeUsage(ns, false);
+    const typeUsage = resolveTypeUsage(tester.program, ns, false);
     const engine = createGraphQLMutationEngine(tester.program);
     const typeGraph = mutateSchema(tester.program, engine, ns, typeUsage);
 

--- a/packages/graphql/test/mutation-engine/visibility.test.ts
+++ b/packages/graphql/test/mutation-engine/visibility.test.ts
@@ -1,0 +1,265 @@
+import type { Model } from "@typespec/compiler";
+import { t } from "@typespec/compiler/testing";
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  createGraphQLMutationEngine,
+  GraphQLTypeContext,
+} from "../../src/mutation-engine/index.js";
+import { createVisibilityFilters } from "../../src/lib/visibility.js";
+import { Tester } from "../test-host.js";
+
+function createTestEngine(program: Parameters<typeof createGraphQLMutationEngine>[0]) {
+  return createGraphQLMutationEngine(program);
+}
+
+describe("GraphQL Mutation Engine - Visibility Filtering", () => {
+  let tester: Awaited<ReturnType<typeof Tester.createInstance>>;
+  let filters: ReturnType<typeof createVisibilityFilters>;
+  beforeEach(async () => {
+    tester = await Tester.createInstance();
+  });
+
+  function mutateAsInput(engine: ReturnType<typeof createTestEngine>, model: Model) {
+    filters = createVisibilityFilters(tester.program);
+    return engine.mutateModel(model, GraphQLTypeContext.Input, filters.mutation);
+  }
+
+  function mutateAsOutput(engine: ReturnType<typeof createTestEngine>, model: Model) {
+    filters = createVisibilityFilters(tester.program);
+    return engine.mutateModel(model, GraphQLTypeContext.Output, filters.output);
+  }
+
+  describe("Input context", () => {
+    it("excludes read-only properties from input mutation", async () => {
+      const { Board } = await tester.compile(t.code`
+        model ${t.model("Board")} {
+          @visibility(Lifecycle.Read)
+          id: string;
+
+          @visibility(Lifecycle.Read)
+          created_at: string;
+
+          name: string;
+        }
+      `);
+
+      const engine = createTestEngine(tester.program);
+      const mutation = mutateAsInput(engine, Board);
+
+      expect(mutation.mutatedType.properties.has("name")).toBe(true);
+      expect(mutation.mutatedType.properties.has("id")).toBe(false);
+      expect(mutation.mutatedType.properties.has("created_at")).toBe(false);
+    });
+
+    it("includes create-visible properties in input mutation", async () => {
+      const { User } = await tester.compile(t.code`
+        model ${t.model("User")} {
+          @visibility(Lifecycle.Read)
+          id: string;
+
+          @visibility(Lifecycle.Create, Lifecycle.Read)
+          email: string;
+
+          name: string;
+        }
+      `);
+
+      const engine = createTestEngine(tester.program);
+      const mutation = mutateAsInput(engine, User);
+
+      expect(mutation.mutatedType.properties.has("name")).toBe(true);
+      expect(mutation.mutatedType.properties.has("email")).toBe(true);
+      expect(mutation.mutatedType.properties.has("id")).toBe(false);
+    });
+
+    it("includes properties with no visibility decorator in input mutation", async () => {
+      const { Item } = await tester.compile(t.code`
+        model ${t.model("Item")} {
+          name: string;
+          description: string;
+        }
+      `);
+
+      const engine = createTestEngine(tester.program);
+      const mutation = mutateAsInput(engine, Item);
+
+      expect(mutation.mutatedType.properties.has("name")).toBe(true);
+      expect(mutation.mutatedType.properties.has("description")).toBe(true);
+    });
+  });
+
+  describe("Output context", () => {
+    it("includes read-only properties in output mutation", async () => {
+      const { Board } = await tester.compile(t.code`
+        model ${t.model("Board")} {
+          @visibility(Lifecycle.Read)
+          id: string;
+
+          @visibility(Lifecycle.Read)
+          createdAt: string;
+
+          name: string;
+        }
+      `);
+
+      const engine = createTestEngine(tester.program);
+      const mutation = mutateAsOutput(engine, Board);
+
+      expect(mutation.mutatedType.properties.has("id")).toBe(true);
+      expect(mutation.mutatedType.properties.has("createdAt")).toBe(true);
+      expect(mutation.mutatedType.properties.has("name")).toBe(true);
+    });
+
+    it("excludes create-only properties from output mutation", async () => {
+      const { User } = await tester.compile(t.code`
+        model ${t.model("User")} {
+          @visibility(Lifecycle.Read)
+          id: string;
+
+          @visibility(Lifecycle.Create)
+          password: string;
+
+          name: string;
+        }
+      `);
+
+      const engine = createTestEngine(tester.program);
+      const mutation = mutateAsOutput(engine, User);
+
+      expect(mutation.mutatedType.properties.has("id")).toBe(true);
+      expect(mutation.mutatedType.properties.has("name")).toBe(true);
+      expect(mutation.mutatedType.properties.has("password")).toBe(false);
+    });
+
+    it("includes properties with no visibility decorator in output mutation", async () => {
+      const { Item } = await tester.compile(t.code`
+        model ${t.model("Item")} {
+          name: string;
+          description: string;
+        }
+      `);
+
+      const engine = createTestEngine(tester.program);
+      const mutation = mutateAsOutput(engine, Item);
+
+      expect(mutation.mutatedType.properties.has("name")).toBe(true);
+      expect(mutation.mutatedType.properties.has("description")).toBe(true);
+    });
+  });
+
+  describe("Edge cases", () => {
+    it("does not filter properties when no type context is provided", async () => {
+      const { Board } = await tester.compile(t.code`
+        model ${t.model("Board")} {
+          @visibility(Lifecycle.Read)
+          id: string;
+
+          name: string;
+        }
+      `);
+
+      const engine = createTestEngine(tester.program);
+      // Mutate without context (e.g., type not reachable from an operation)
+      const mutation = mutateAsOutput(engine, Board);
+
+      // Both should be present since Output includes Read-visible properties
+      expect(mutation.mutatedType.properties.has("id")).toBe(true);
+      expect(mutation.mutatedType.properties.has("name")).toBe(true);
+    });
+
+    it("produces empty model when all properties are read-only in input context", async () => {
+      const { ReadOnlyModel } = await tester.compile(t.code`
+        model ${t.model("ReadOnlyModel")} {
+          @visibility(Lifecycle.Read)
+          id: string;
+
+          @visibility(Lifecycle.Read)
+          status: string;
+        }
+      `);
+
+      const engine = createTestEngine(tester.program);
+      const mutation = mutateAsInput(engine, ReadOnlyModel);
+
+      expect(mutation.mutatedType.properties.size).toBe(0);
+    });
+
+    it("strips @compose from input variants to avoid spurious validation", async () => {
+      const { User } = await tester.compile(t.code`
+        @Interface(#{interfaceOnly: true})
+        model Node {
+          @visibility(Lifecycle.Read)
+          id: string;
+        }
+
+        @compose(Node)
+        model ${t.model("User")} {
+          @visibility(Lifecycle.Read)
+          id: string;
+
+          name: string;
+        }
+      `);
+
+      const engine = createTestEngine(tester.program);
+      const mutation = mutateAsInput(engine, User);
+
+      expect(mutation.mutatedType.properties.has("id")).toBe(false);
+      expect(mutation.mutatedType.properties.has("name")).toBe(true);
+      const hasCompose = mutation.mutatedType.decorators.some(
+        (d) => d.decorator.name === "$compose",
+      );
+      expect(hasCompose).toBe(false);
+    });
+
+    it("excludes @invisible properties from both input and output", async () => {
+      const { Secret } = await tester.compile(t.code`
+        model ${t.model("Secret")} {
+          @invisible(Lifecycle)
+          internal: string;
+
+          name: string;
+        }
+      `);
+
+      const engine = createTestEngine(tester.program);
+      const inputMutation = mutateAsInput(engine, Secret);
+      const outputMutation = mutateAsOutput(engine, Secret);
+
+      expect(inputMutation.mutatedType.properties.has("internal")).toBe(false);
+      expect(inputMutation.mutatedType.properties.has("name")).toBe(true);
+      expect(outputMutation.mutatedType.properties.has("internal")).toBe(false);
+      expect(outputMutation.mutatedType.properties.has("name")).toBe(true);
+    });
+
+    it("properties are finalized with mutated names after mutateModel returns", async () => {
+      const { User } = await tester.compile(t.code`
+        model ${t.model("User")} {
+          @visibility(Lifecycle.Read, Lifecycle.Query)
+          user_id: string;
+
+          @visibility(Lifecycle.Create, Lifecycle.Update)
+          pass_word: string;
+
+          display_name: string;
+        }
+      `);
+
+      filters = createVisibilityFilters(tester.program);
+      const engine = createTestEngine(tester.program);
+      const queryMutation = engine.mutateModel(
+        User, GraphQLTypeContext.Input, filters.query, "Query",
+      );
+      const mutMutation = engine.mutateModel(
+        User, GraphQLTypeContext.Input, filters.mutation, "Mutation",
+      );
+
+      const queryKeys = [...queryMutation.mutatedType.properties.keys()].sort();
+      const mutKeys = [...mutMutation.mutatedType.properties.keys()].sort();
+
+      expect(queryKeys).toEqual(["displayName", "userId"]);
+      expect(mutKeys).toEqual(["displayName", "passWord"]);
+      expect(queryKeys.join(",")).not.toBe(mutKeys.join(","));
+    });
+  });
+});

--- a/packages/graphql/test/type-usage.test.ts
+++ b/packages/graphql/test/type-usage.test.ts
@@ -10,8 +10,9 @@ describe("type-usage", () => {
   });
 
   function resolve(omitUnreachableTypes = true) {
-    return resolveTypeUsage(tester.program.getGlobalNamespaceType(), omitUnreachableTypes);
+    return resolveTypeUsage(tester.program, tester.program.getGlobalNamespaceType(), omitUnreachableTypes);
   }
+
 
   describe("basic output reachability", () => {
     it("marks return type model as Output", async () => {
@@ -246,4 +247,5 @@ describe("type-usage", () => {
       expect(resolver.isUnreachable(User)).toBe(false);
     });
   });
+
 });


### PR DESCRIPTION
## Summary

- Implements TypeSpec lifecycle visibility for the GraphQL emitter
- Query params accept Read/Query-visible fields, mutation params accept Create/Update-visible fields
- When a model is used by both `@query` and `@mutation` and visibility produces different property sets, emits `UserQueryInput` + `UserMutationInput`; otherwise a single `UserInput`
- Uses the compiler's `isVisible()` + `VisibilityFilter` API
- Pre-computes `inputOperationVariance` in type-usage to drive naming cleanly through the pipeline
- Strips `@compose` from input variants to prevent spurious interface validation
- Handles `@invisible` properties (excluded from all contexts)

## Test plan

- [x] 11 unit tests in `test/mutation-engine/visibility.test.ts` (filtering, @invisible, @compose stripping, property finalization)
- [x] 5 e2e tests covering visibility scenarios (read-only exclusion, create-only exclusion, split, no-split, no-visibility)
- [x] All 290 existing tests pass with no regressions
- [x] Type check clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)