### PR TITLE
Fix @Interface models emitting spurious Output type

### DIFF
--- a/packages/graphql/src/mutation-engine/schema-mutator.ts
+++ b/packages/graphql/src/mutation-engine/schema-mutator.ts
@@ -12,7 +12,7 @@ import {
 } from "@typespec/compiler";
 import { $ } from "@typespec/compiler/typekit";
 import { setInputType } from "../lib/input-type.js";
-import { isInterfaceOnly, isInterface } from "../lib/interface.js";
+import { isInterface } from "../lib/interface.js";
 import { reportDiagnostic } from "../lib.js";
 import { GraphQLTypeUsage, type TypeUsageResolver } from "../type-usage.js";
 import type { GraphQLMutationEngine } from "./engine.js";
@@ -47,13 +47,12 @@ export function mutateSchema(
       const usedAsOutput = usage?.has(GraphQLTypeUsage.Output) ?? false;
       const usedAsInput = usage?.has(GraphQLTypeUsage.Input) ?? false;
       const isInterfaceModel = isInterface(program, node);
-      const isExclusive = isInterfaceModel && isInterfaceOnly(program, node);
 
       if (isInterfaceModel) {
         const mutation = engine.mutateModel(node, GraphQLTypeContext.Interface);
         mutatedTypes.push(mutation.mutatedType);
       }
-      if (!isExclusive && (usedAsOutput || !usage)) {
+      if (!isInterfaceModel && (usedAsOutput || !usage)) {
         const mutation = engine.mutateModel(node, GraphQLTypeContext.Output);
         mutatedTypes.push(mutation.mutatedType);
       }

--- a/packages/graphql/test/e2e.test.ts
+++ b/packages/graphql/test/e2e.test.ts
@@ -399,10 +399,6 @@ describe("e2e: interfaces", () => {
         name: String!
       }
 
-      interface Animal {
-        name: String!
-      }
-
       type Cat implements AnimalInterface {
         name: String!
         breed: String!


### PR DESCRIPTION
## Summary
- `@Interface` models were being emitted in both `Interface` and `Output` context, producing a duplicate declaration in the SDL
- The `isExclusive` guard only prevented this for `interfaceOnly: true` — regular `@Interface` models (interfaceOnly: false) still fell through to Output emission
- Fix: skip Output emission for all `@Interface` models since `GraphQLTypeContext.Interface` is their sole emission path

## Before
```graphql
interface AnimalInterface {
  name: String!
}

interface Animal {    <-- spurious duplicate
  name: String!
}
```

## After
```graphql
interface AnimalInterface {
  name: String!
}
```

## Test plan
- [x] 277 existing tests pass
- [x] Snapshot updated for the one test that captured the spurious behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)