### PR TITLE
Fix built-in scalars emitted as declarations from nullable unions

### DIFF
--- a/packages/graphql/src/mutation-engine/schema-mutator.ts
+++ b/packages/graphql/src/mutation-engine/schema-mutator.ts
@@ -80,6 +80,9 @@ export function mutateSchema(
       if (mutation.mutatedType.kind === "Model" && isArrayModelType(mutation.mutatedType)) {
         return;
       }
+      if ((mutation.mutatedType as Type).kind === "Scalar") {
+        return;
+      }
       mutatedTypes.push(mutation.mutatedType);
       for (const wrapper of mutation.wrapperModels) {
         mutatedTypes.push(wrapper);

--- a/packages/graphql/test/e2e.test.ts
+++ b/packages/graphql/test/e2e.test.ts
@@ -525,6 +525,52 @@ describe("e2e: nullability combinations", () => {
   });
 });
 
+describe("e2e: nullable scalar does not emit built-in scalar declaration", () => {
+  it("does not emit scalar string for nullable string field", async () => {
+    const result = await emitSingleSchemaWithDiagnostics(`
+      @schema namespace Test {
+        model Foo {
+          id: GraphQL.ID;
+          value: string | null;
+        }
+        @query op getFoo(id: GraphQL.ID): Foo;
+      }
+    `);
+    expect(result.graphQLOutput).not.toContain("scalar string");
+    expect(result.graphQLOutput).toMatchInlineSnapshot(`
+      "type Foo {
+        id: ID!
+        value: String
+      }
+
+      type Query {
+        getFoo(id: ID!): Foo!
+      }"
+    `);
+  });
+
+  it("does not emit scalar int32 for nullable int field", async () => {
+    const result = await emitSingleSchemaWithDiagnostics(`
+      @schema namespace Test {
+        model Bar {
+          count: int32 | null;
+        }
+        @query op getBar(): Bar;
+      }
+    `);
+    expect(result.graphQLOutput).not.toContain("scalar int32");
+    expect(result.graphQLOutput).toMatchInlineSnapshot(`
+      "type Bar {
+        count: Int
+      }
+
+      type Query {
+        getBar: Bar!
+      }"
+    `);
+  });
+});
+
 describe("e2e: @operationFields", () => {
   it("renders operation as field with arguments on object type", async () => {
     const result = await emitSingleSchemaWithDiagnostics(`


### PR DESCRIPTION
## Summary
- `string | null`, `int32 | null`, `boolean | null`, etc. caused the TypeSpec built-in scalar to be emitted as a `scalar string` declaration in the GraphQL SDL
- Root cause: anonymous unions have `.namespace === undefined`, bypassing the compiler's namespace scope filter in `navigateTypesInNamespace`. The union mutation then unwraps `T | null` to the inner scalar, which gets pushed into the type graph
- Fix: skip adding the mutation result to `mutatedTypes` when a nullable union unwraps to a Scalar type

## Before
```graphql
"""A sequence of textual characters."""
scalar string

type Foo {
  value: String
}
```

## After
```graphql
type Foo {
  value: String
}
```

## Test plan
- [x] Added 2 tests: `string | null` and `int32 | null` both verify no `scalar` declaration appears
- [x] All 279 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)