### PR TITLE
Flatten base model fields into child during GraphQL mutation

### DIFF
--- a/packages/graphql/src/mutation-engine/mutations/model.ts
+++ b/packages/graphql/src/mutation-engine/mutations/model.ts
@@ -108,6 +108,7 @@ export class GraphQLModelMutation extends SimpleModelMutation<SimpleMutationOpti
       }
     });
     super.mutate();
+    this.flattenBaseModel();
   }
 
   protected override mutateProperties(newOptions: MutationOptions = this.options) {
@@ -135,6 +136,21 @@ export class GraphQLModelMutation extends SimpleModelMutation<SimpleMutationOpti
         );
       }
     }
+  }
+
+  private flattenBaseModel() {
+    if (!this.baseModel) return;
+    const mutated = this.mutationNode.mutatedType;
+    const baseProps = this.baseModel.mutatedType.properties;
+    const ownEntries = [...mutated.properties.entries()];
+    mutated.properties.clear();
+    for (const [name, prop] of baseProps) {
+      mutated.properties.set(name, prop);
+    }
+    for (const [name, prop] of ownEntries) {
+      mutated.properties.set(name, prop);
+    }
+    mutated.baseModel = undefined;
   }
 
   private mutateDecoratorTypeArgs(model: Model) {

--- a/packages/graphql/test/e2e-manual/TEST_COVERAGE.md
+++ b/packages/graphql/test/e2e-manual/TEST_COVERAGE.md
@@ -37,7 +37,7 @@ Patterns: operations, models, scalars, enums, interfaces, unions, nullability, s
 | 12 | Scalar variant in union (`NotificationContentMessageUnionVariant`) | Correct |
 | 14 | Anonymous union return → auto-named (`GetContentUnion`) | Correct |
 | 15 | Anonymous union property → auto-named (`FeedItemContentUnion`) | Correct |
-| 19 | `extends` (field flattening) | **BUG: fields not flattened (API-5279)** |
+| 19 | `extends` (field flattening) | Correct (fixed in PR #101) |
 | 20 | `...spread` (Timestamps/Auditable fields on User) | Correct |
 | 21 | `Record<string>` → `scalar RecordOfString` | Correct |
 | 22 | `Record<Model>` → `scalar RecordOfMetric` | Correct |
@@ -59,7 +59,7 @@ Patterns: operations, models, scalars, enums, interfaces, unions, nullability, s
 | 54 | Deprecated field (`body @deprecated`) | Correct |
 | 55 | Deprecated operation (`publishDraft @deprecated`) | Correct |
 | 56 | Interface inheritance chain (`PagedConnection implements Connection`) | Correct |
-| 59 | extends + spread combined | **BUG: extends portion missing (API-5279)** |
+| 59 | extends + spread combined | Correct (fixed in PR #101) |
 | 60 | Circular input model (`CreateCommentInput.replies`) | Correct |
 | 69 | Single-variant union → unwrapped (`getWrapped: Article!`) | Correct |
 
@@ -154,8 +154,8 @@ Edge case: model with property whose type is fully visibility-filtered.
 
 ## Known Bugs
 
-| Ticket | Summary |
-|--------|---------|
-| API-5278 | Record<T> scalars duplicated for input/output context (`RecordOfString` + `RecordOfStringInput`) |
-| API-5279 | Model `extends` does not flatten base model fields into child type |
-| API-5280 | Emitter crashes when nested model property type is fully visibility-filtered to empty |
+| Ticket | Summary | Status |
+|--------|---------|--------|
+| API-5278 | Record<T> scalars duplicated for input/output context (`RecordOfString` + `RecordOfStringInput`) | Open |
+| API-5279 | Model `extends` does not flatten base model fields into child type | Fixed (PR #101) |
+| API-5280 | Emitter crashes when nested model property type is fully visibility-filtered to empty | Open |

--- a/packages/graphql/test/e2e.test.ts
+++ b/packages/graphql/test/e2e.test.ts
@@ -973,3 +973,66 @@ describe("e2e: visibility filtering", () => {
     `);
   });
 });
+
+describe("e2e: extends flattening", () => {
+  it("flattens base model fields into child type", async () => {
+    const result = await emitSingleSchemaWithDiagnostics(`
+      @schema namespace Test {
+        scalar DateTime extends utcDateTime;
+        model Timestamps { createdAt: DateTime; updatedAt: DateTime; }
+        model AuditedComment extends Timestamps {
+          commentId: string;
+          action: string;
+        }
+        @query op getAudit(): AuditedComment;
+      }
+    `);
+    expect(result.graphQLOutput).toMatchInlineSnapshot(`
+      "scalar DateTime
+
+      type Timestamps {
+        createdAt: DateTime!
+        updatedAt: DateTime!
+      }
+
+      type AuditedComment {
+        createdAt: DateTime!
+        updatedAt: DateTime!
+        commentId: String!
+        action: String!
+      }
+
+      type Query {
+        getAudit: AuditedComment!
+      }"
+    `);
+  });
+
+  it("flattens multi-level inheritance", async () => {
+    const result = await emitSingleSchemaWithDiagnostics(`
+      @schema namespace Test {
+        model Base { id: string; }
+        model Middle extends Base { name: string; }
+        model Child extends Middle { age: int32; }
+        @query op getChild(): Child;
+      }
+    `);
+    // All inherited fields should be on Child, not separate types
+    expect(result.graphQLOutput).toMatch(/type Child \{[^}]*id: String!/s);
+    expect(result.graphQLOutput).toMatch(/type Child \{[^}]*name: String!/s);
+    expect(result.graphQLOutput).toMatch(/type Child \{[^}]*age: Int!/s);
+  });
+
+  it("flattens base model fields into input type", async () => {
+    const result = await emitSingleSchemaWithDiagnostics(`
+      @schema namespace Test {
+        model Base { id: string; }
+        model Child extends Base { name: string; }
+        @query op getChild(): Child;
+        @mutation op createChild(input: Child): Child;
+      }
+    `);
+    expect(result.graphQLOutput).toMatch(/input ChildInput[^}]*id: String!/s);
+    expect(result.graphQLOutput).toMatch(/input ChildInput[^}]*name: String!/s);
+  });
+});


### PR DESCRIPTION
## Summary
Models using `extends` now have all inherited fields flattened into the child type during mutation. GraphQL has no type inheritance for object/input types, so the child must contain all fields directly.

**Before:**
```graphql
type AuditedComment {
  commentId: String!
  action: String!
}
```

**After:**
```graphql
type AuditedComment {
  createdAt: DateTime!
  updatedAt: DateTime!
  commentId: String!
  action: String!
}
```

## Implementation
After `super.mutate()` (which traverses baseModel via the framework), `flattenBaseModel()` copies the mutated base model's properties into the child and clears `baseModel`. Own properties take precedence over inherited ones. Works for multi-level inheritance (base → middle → child) since each level flattens its parent.

Fixes [API-5279](https://pinterest.atlassian.net/browse/API-5279).

## Test plan
- [x] 313 tests pass (3 new tests)
- [x] Single-level extends: inherited fields appear on child
- [x] Multi-level extends: all ancestor fields appear on child
- [x] Input type: inherited fields appear on input variant

🤖 Generated with [Claude Code](https://claude.com/claude-code)