### PR TITLE
Fix Record<T> scalars duplicated for input/output context

### DIFF
--- a/packages/graphql/src/mutation-engine/mutations/model.ts
+++ b/packages/graphql/src/mutation-engine/mutations/model.ts
@@ -76,7 +76,16 @@ export class GraphQLModelMutation extends SimpleModelMutation<SimpleMutationOpti
       this.options instanceof GraphQLMutationOptions ? this.options.inputQualifier : undefined;
 
     if (this.shouldReplaceWithScalar(program, visibilityFilter)) {
-      const scalarName = applyTypeNamePipeline(rawName, { isInput: isInputContext, isInterface: false, inputQualifier });
+      // Record<T> scalars should NOT get Input suffix - they're opaque map types with
+      // no structural difference between input/output. Visibility-filtered scalars
+      // (where all properties were removed) keep the Input suffix to distinguish variants.
+      const isPureRecord = isRecordType(this.sourceType) &&
+        (walkPropertiesInherited(this.sourceType).next().done ?? false);
+      const scalarName = applyTypeNamePipeline(rawName, {
+        isInput: isInputContext && !isPureRecord,
+        isInterface: false,
+        inputQualifier: isPureRecord ? undefined : inputQualifier,
+      });
       this.mutationNode.replace(program.checker.createType({
         kind: "Scalar",
         name: scalarName,
@@ -157,7 +166,7 @@ export class GraphQLModelMutation extends SimpleModelMutation<SimpleMutationOpti
 
   private willHaveNoFields(program: Program, visibilityFilter: VisibilityFilter | undefined): boolean {
     // Record<T> with no own/inherited properties → opaque map scalar
-    if (isRecordType(this.sourceType)) return walkPropertiesInherited(this.sourceType).next().done;
+    if (isRecordType(this.sourceType)) return walkPropertiesInherited(this.sourceType).next().done ?? false;
     // Model declared with no properties at all
     if (this.sourceType.properties.size === 0) return true;
     // All properties removed by visibility filtering (e.g., all @visibility(Lifecycle.Read) in input context)

--- a/packages/graphql/test/e2e-manual/emit.test.ts
+++ b/packages/graphql/test/e2e-manual/emit.test.ts
@@ -316,6 +316,35 @@ describe("schema: record types", () => {
     expect(sdl).toContain("scalar RecordOfMetric");
     expect(errors).toHaveLength(0);
   });
+
+  it("emits a single scalar for Record<T> used in both input and output contexts", async () => {
+    const { sdl, errors } = await emitSchema("04b-records-dedup", `
+      @schema(#{ name: "records-dedup" })
+      namespace RecordsDedup {
+        model User {
+          name: string;
+          metadata: Record<string>;
+        }
+
+        @query op getUser(): User;
+        @mutation op createUser(input: User): User;
+      }
+    `);
+
+    expect(sdl).toBeTruthy();
+    expect(errors).toHaveLength(0);
+
+    // Should have exactly ONE RecordOfString scalar, not two
+    const matches = sdl!.match(/scalar RecordOfString/g);
+    expect(matches).toHaveLength(1);
+
+    // Should NOT have RecordOfStringInput
+    expect(sdl).not.toContain("RecordOfStringInput");
+
+    // Both type and input should reference the same scalar
+    expect(sdl).toMatch(/type User \{[\s\S]*?metadata: RecordOfString/);
+    expect(sdl).toMatch(/input UserInput \{[\s\S]*?metadata: RecordOfString/);
+  });
 });
 
 // =============================================================================

--- a/packages/graphql/test/mutation-engine/models.test.ts
+++ b/packages/graphql/test/mutation-engine/models.test.ts
@@ -69,6 +69,23 @@ describe("GraphQL Mutation Engine - Record-to-Scalar", () => {
     expect(resolved).toHaveProperty("name", "Metadata");
   });
 
+  it("produces same scalar name for Record in both input and output contexts", async () => {
+    const { Metadata } = await tester.compile(
+      t.code`model ${t.model("Metadata")} is Record<string>;`,
+    );
+
+    const engine = createTestEngine(tester.program);
+    const outputMutation = engine.mutateModel(Metadata, GraphQLTypeContext.Output);
+    const inputMutation = engine.mutateModel(Metadata, GraphQLTypeContext.Input);
+
+    const outputScalar = outputMutation.mutationNode.replacementNode!.mutatedType;
+    const inputScalar = inputMutation.mutationNode.replacementNode!.mutatedType;
+
+    // Both should produce the same scalar name - no Input suffix for Records
+    expect(outputScalar).toHaveProperty("name", "Metadata");
+    expect(inputScalar).toHaveProperty("name", "Metadata");
+  });
+
   it("replaces Record model with scalar even through T | null unwrap", async () => {
     const { Foo } = await tester.compile(
       t.code`


### PR DESCRIPTION
 ### Problem

`Record<T>` types were incorrectly producing separate scalar names in input vs output contexts (e.g., `RecordOfString` and `RecordOfStringInput`). Since Records are opaque map types with no structural difference between input/output usage, they should share a single scalar name.

  ### Solution

When a Record is replaced with a scalar during mutation, skip the Input suffix. The fix is in `model.ts` at the mutation level, which ensures it catches Records regardless of how they're encountered:
  - Named Record models (`model Metadata is Record<string>`)
  - Inline Record property types (`metadata: Record<string>`)
  - Records nested in unions or other structures

  ### Before
  ```graphql
  scalar RecordOfString
  scalar RecordOfStringInput  # duplicate

  type User {
    metadata: RecordOfString!
  }

  input UserInput {
    metadata: RecordOfStringInput!
  }
```

  ### After
```graphql
  scalar RecordOfString

  type User {
    metadata: RecordOfString!
  }

  input UserInput {
    metadata: RecordOfString!
  }
```

  ### Testing

  - Added e2e test verifying single scalar emission when Record is used in both contexts
  - Added unit test verifying named Records produce same scalar name in input/output contexts

  ### Notes

  Includes a TypeScript 6.0 compatibility fix: Iterator.next().done now returns boolean | undefined, fixed with ?? false coercion.
